### PR TITLE
Policy delete will do a switch deploy

### DIFF
--- a/generator/defs/policy.yaml
+++ b/generator/defs/policy.yaml
@@ -16,6 +16,13 @@ resource:
       description: "Policy ID"
       computed: true
       use_state: true
+    - model_name: fabricName
+      tf_name: fabric_name
+      type: String
+      description: "Name of the fabric"
+      mandatory: true
+      payload_hide: true
+      tf_requires_replace: true
     - model_name: policyGroup
       tf_name: is_policy_group
       type: Bool

--- a/internal/provider/ndfc/api/config_deploy_api.go
+++ b/internal/provider/ndfc/api/config_deploy_api.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"terraform-provider-ndfc/tfutils/go-nd"
+)
+
+type ConfigDeploymentAPI struct {
+	NDFCAPICommon
+	mutex         *sync.Mutex
+	SerialNumbers []string
+	Deploy        bool
+	FabricName    string
+}
+
+// For additional functions
+
+const UrlGlobalConfigDeploy = "/lan-fabric/rest/control/fabrics/%s/config-deploy"
+const UrlSwitchConfigDeploy = "/lan-fabric/rest/control/fabrics/%s/config-deploy/%s"
+const UrlSaveConfig = "/lan-fabric/rest/control/fabrics/%s/config-save"
+const UrlGetFabricErrors = "/lan-fabric/rest/control/fabrics/%s/errors"
+
+func (c *ConfigDeploymentAPI) GetLock() *sync.Mutex {
+	return c.mutex
+}
+
+func (c *ConfigDeploymentAPI) GetUrl() string {
+	return fmt.Sprintf(UrlGetFabricErrors, c.FabricName)
+}
+
+func (c *ConfigDeploymentAPI) PostUrl() string {
+	if c.Deploy {
+		if len(c.SerialNumbers) > 0 {
+			return fmt.Sprintf(UrlSwitchConfigDeploy, c.FabricName, strings.Join(c.SerialNumbers, ","))
+		} else {
+			return fmt.Sprintf(UrlGlobalConfigDeploy, c.FabricName)
+		}
+	} else {
+		return fmt.Sprintf(UrlSaveConfig, c.FabricName)
+	}
+}
+
+func (c *ConfigDeploymentAPI) PutUrl() string {
+	panic("PUT Not supported")
+}
+
+func (c *ConfigDeploymentAPI) DeleteUrl() string {
+	panic("DELETE Not supported")
+}
+
+func (c ConfigDeploymentAPI) GetDeleteQP() []string {
+	panic("Not supported")
+}
+
+func (c *ConfigDeploymentAPI) SetDeleteList(qp []string) {
+	panic("Not supported")
+}
+
+func NewConfigDeploymentAPI(lock *sync.Mutex, client *nd.Client) *ConfigDeploymentAPI {
+	api := new(ConfigDeploymentAPI)
+	api.mutex = lock
+	api.NDFCAPI = api
+	api.client = client
+	return api
+}

--- a/internal/provider/ndfc/ndfc_global_deploy.go
+++ b/internal/provider/ndfc/ndfc_global_deploy.go
@@ -2,25 +2,42 @@ package ndfc
 
 import (
 	"context"
-	"fmt"
-	"strings"
+	"terraform-provider-ndfc/internal/provider/ndfc/api"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
+const ResourceConfigDeploy = "config_deploy"
+
 func (c NDFC) SaveConfiguration(ctx context.Context, diags *diag.Diagnostics, fabricName string) {
-	_, err := c.apiClient.Post(fmt.Sprintf("/lan-fabric/rest/control/fabrics/%s/config-save", fabricName), "")
+	saveApi := api.NewConfigDeploymentAPI(c.GetLock(ResourceConfigDeploy), &c.apiClient)
+	saveApi.FabricName = fabricName
+	saveApi.Deploy = false
+	_, err := saveApi.Post([]byte{})
 	if err != nil {
-		diags.AddError("Save failed", err.Error())
-		res, _ := c.apiClient.Get(fmt.Sprintf("/lan-fabric/rest/control/fabrics/%s/errors", fabricName))
+		diags.AddError("Deploy failed", err.Error())
+		time.Sleep(3 * time.Second)
+		_, err := saveApi.Get()
 		// TODO determine which error should be returned
-		diags.AddError("Fabric Errors", res.String())
+		diags.AddError("Deploy Errors:", err.Error())
 	}
 }
 
 func (c NDFC) DeployConfiguration(ctx context.Context, diags *diag.Diagnostics, fabricName string, serialNumbers []string) {
-	_, err := c.apiClient.Post(fmt.Sprintf("/lan-fabric/rest/control/fabrics/%s/config-deploy/%s", fabricName, strings.Join(serialNumbers, ",")), "")
+	var err error
+	deployApi := api.NewConfigDeploymentAPI(c.GetLock(ResourceConfigDeploy), &c.apiClient)
+	deployApi.FabricName = fabricName
+	deployApi.Deploy = true
+	if len(serialNumbers) > 0 {
+		deployApi.SerialNumbers = serialNumbers
+	}
+	_, err = deployApi.Post([]byte{})
 	if err != nil {
 		diags.AddError("Deploy failed", err.Error())
+		time.Sleep(3 * time.Second)
+		_, err := deployApi.Get()
+		// TODO determine which error should be returned
+		diags.AddError("Deploy Errors:", err.Error())
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -114,6 +114,7 @@ func (p *ndfcProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	ndfc.NewResource(ndfc.ResourceTemplate)
 	ndfc.NewResource(ndfc.ResourcePolicy)
 	ndfc.NewResource(ndfc.ResourceVpcPair)
+	ndfc.NewResource(ndfc.ResourceConfigDeploy)
 
 	// Make the HashiCups client available during DataSource and Resource
 	// type Configure methods.

--- a/internal/provider/resources/resource_policy/policy_resource_gen.go
+++ b/internal/provider/resources/resource_policy/policy_resource_gen.go
@@ -58,6 +58,14 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Type of the entity",
 				MarkdownDescription: "Type of the entity",
 			},
+			"fabric_name": schema.StringAttribute{
+				Required:            true,
+				Description:         "Name of the fabric",
+				MarkdownDescription: "Name of the fabric",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"id": schema.Int64Attribute{
 				Computed:            true,
 				Description:         "ID of the policy",
@@ -127,6 +135,7 @@ type PolicyModel struct {
 	DeviceSerialNumber types.String `tfsdk:"device_serial_number"`
 	EntityName         types.String `tfsdk:"entity_name"`
 	EntityType         types.String `tfsdk:"entity_type"`
+	FabricName         types.String `tfsdk:"fabric_name"`
 	Id                 types.Int64  `tfsdk:"id"`
 	IsPolicyGroup      types.Bool   `tfsdk:"is_policy_group"`
 	PolicyId           types.String `tfsdk:"policy_id"`

--- a/internal/provider/resources/resource_policy/resource_codec_gen.go
+++ b/internal/provider/resources/resource_policy/resource_codec_gen.go
@@ -14,6 +14,7 @@ import (
 type NDFCPolicyModel struct {
 	Id                 *int64            `json:"id,omitempty"`
 	PolicyId           string            `json:"policyId,omitempty"`
+	FabricName         string            `json:"-"`
 	IsPolicyGroup      bool              `json:"-"`
 	Deploy             bool              `json:"-"`
 	Status             string            `json:"status,omitempty"`
@@ -44,6 +45,12 @@ func (v *PolicyModel) SetModelData(jsonData *NDFCPolicyModel) diag.Diagnostics {
 		v.PolicyId = types.StringValue(jsonData.PolicyId)
 	} else {
 		v.PolicyId = types.StringNull()
+	}
+
+	if jsonData.FabricName != "" {
+		v.FabricName = types.StringValue(jsonData.FabricName)
+	} else {
+		v.FabricName = types.StringNull()
 	}
 
 	v.IsPolicyGroup = types.BoolValue(jsonData.IsPolicyGroup)
@@ -134,6 +141,12 @@ func (v PolicyModel) GetModelData() *NDFCPolicyModel {
 	var data = new(NDFCPolicyModel)
 
 	//MARSHAL_BODY
+
+	if !v.FabricName.IsNull() && !v.FabricName.IsUnknown() {
+		data.FabricName = v.FabricName.ValueString()
+	} else {
+		data.FabricName = ""
+	}
 
 	if !v.IsPolicyGroup.IsNull() && !v.IsPolicyGroup.IsUnknown() {
 		data.IsPolicyGroup = v.IsPolicyGroup.ValueBool()

--- a/internal/provider/test_utils_policy_test.go
+++ b/internal/provider/test_utils_policy_test.go
@@ -19,6 +19,9 @@ func PolicyModelHelperStateCheck(RscName string, c resource_policy.NDFCPolicyMod
 	if c.PolicyId != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("policy_id").String(), c.PolicyId))
 	}
+	if c.FabricName != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_name").String(), c.FabricName))
+	}
 	if c.IsPolicyGroup {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_policy_group").String(), "true"))
 	} else {


### PR DESCRIPTION
In NDFC, in order to delete a policy we need to do a switch deploy for it to take effect. Changes are done for the same.

Fix issues : https://github.com/CiscoDevNet/terraform-provider-ndfc/issues/86

Config used : 
```
resource "ndfc_policy" "test_policy" {
  entity_name          = "Switch"
  entity_type          = "SWITCH"
  description          = "Test Policy from TF"
  template_name        = "TelemetryDst_EF"
  device_serial_number = "9D0ZV7JBFNM"
  fabric_name = "Vxlan_vPC_Pair_Ak"
  deploy = true
  priority = 500
  policy_parameters = {
    DSTGRP = "501"
    IPADDR = "5.5.5.6"
    PORT   = "57900"
    VRF    = "management"
  }
}
