### PR TITLE
vPC Pair with switch deploy config support

### DIFF
--- a/generator/defs/vpc-pair.yaml
+++ b/generator/defs/vpc-pair.yaml
@@ -18,7 +18,7 @@ resource:
       type: List:String
       payload_hide: true
       ndfc_type: set
-      example: '["FGE20360RRZ", "FGE20360RRK"]'
+      example: "[\"FGE20360RRZ\", \"FGE20360RRY\"]"
       mandatory: true
       validator: SizeBetween(2, 2)
       tf_requires_replace: true
@@ -44,211 +44,20 @@ resource:
       description: Set to true to use virtual peer link
       example: true
       mandatory: true
-    - &template_name
-      model_name: templateName
-      tf_name: template_name
-      type: String
-      description: Template to be applied to this VPC switch pair
-      example: "vpc_template"
-      mandatory: false
-    - &domain_id
-      model_name: DOMAIN_ID
-      ndfc_nested: [nvPairs]
-      tf_name: domain_id
-      type: Int64
-      description: vPC Domain ID
-      example: 101
-      min_int: 1
-      max_int: 1000
-      handle_empty: true
-    - &peer1_keep_alive_local_ip
-      model_name: PEER1_KEEP_ALIVE_LOCAL_IP
-      ndfc_nested: [nvPairs]
-      tf_name: peer1_keep_alive_local_ip
-      type: String
-      description: IP address of a L3 interface in non-default VRF on Peer 1
-      example: 10.10.10.1
-    - &peer2_keep_alive_local_ip
-      model_name: PEER2_KEEP_ALIVE_LOCAL_IP
-      ndfc_nested: [nvPairs]
-      tf_name: peer2_keep_alive_local_ip
-      type: String
-      description: IP address of a L3 interface in non-default VRF on Peer 2
-      example: 10.10.10.2
-    - &keep_alive_vrf
-      model_name: KEEP_ALIVE_VRF
-      ndfc_nested: [nvPairs]
-      tf_name: keep_alive_vrf
-      type: String
-      description: Name of VRF used for keep-alive, enter 'default' for default VRF
-      example: management
-    - &keep_alive_hold_timeout
-      model_name: KEEP_ALIVE_HOLD_TIMEOUT
-      ndfc_nested: [nvPairs]
-      tf_name: keep_alive_hold_timeout
-      type: Int64
-      description: Hold timeout to ignore stale peer alive messages, default is 3 if not specified, Mandatory
-      example: 3
-    - &is_vpc_plus
-      model_name: isVpcPlus
-      ndfc_nested: [nvPairs]
-      tf_name: is_vpc_plus
-      type: Bool
-      description: Set to true to enable VPC plus
-      example: true
-    - &fabricpath_switch_id
-      model_name: fabricPath_switch_id
-      ndfc_nested: [nvPairs]
-      tf_name: fabricpath_switch_id
-      type: String
-      description: Fabric path switch ID
-      example: FGE20360RRQ
-    - &peer1_source_loopback
-      model_name: PEER1_SOURCE_LOOPBACK
-      ndfc_nested: [nvPairs]
-      tf_name: peer1_source_loopback
-      type: String
-      description: Source loopback IP address for Peer 1
-      example: 11.10.10.1
-    - &peer2_source_loopback
-      model_name: PEER2_SOURCE_LOOPBACK
-      ndfc_nested: [nvPairs]
-      tf_name: peer2_source_loopback
-      type: String
-      description: Source loopback IP address for Peer 2
-      example: 11.10.10.2
-    - &peer1_primary_ip
-      model_name: PEER1_PRIMARY_IP
-      ndfc_nested: [nvPairs]
-      tf_name: peer1_primary_ip
-      type: String
-      description: Primary IP address for Peer 1
-      example: 12.10.10.1
-    - &peer2_primary_ip
-      model_name: PEER2_PRIMARY_IP
-      ndfc_nested: [nvPairs]
-      tf_name: peer2_primary_ip
-      type: String
-      description: Primary IP address for Peer 2
-      example: 12.10.10.2
-    - &loopback_secondary_ip
-      model_name: LOOPBACK_SECONDARY_IP
-      ndfc_nested: [nvPairs]
-      tf_name: loopback_secondary_ip
-      type: String
-      description: Secondary loopback IP address
-      example: 13.10.10.1
-    - &peer1_domain_conf
-      model_name: PEER1_DOMAIN_CONF
-      ndfc_nested: [nvPairs]
-      tf_name: peer1_domain_conf
-      type: String
-      description: Additional CLI for Peer-1 vPC Domain
-      example: 1
-    - &clear_policy
-      model_name: clear_policy
-      ndfc_nested: [nvPairs]
-      tf_name: clear_policy
-      type: Bool
-      description: Set to true to clear policy
-      example: true
     - &fabric_name
       model_name: FABRIC_NAME
       ndfc_nested: [nvPairs]
       tf_name: fabric_name
       type: String
+      mandatory: true
       tf_requires_replace: true
       description: Fabric name to which the vPC pair belongs
       example: VXLAN_FABRIC
-    - &peer1_pcid
-      model_name: PEER1_PCID
-      ndfc_nested: [nvPairs]
-      tf_name: peer1_pcid
-      type: String
-      description: Peer 1 PCID
-      example: 1
-    - &peer2_pcid
-      model_name: PEER2_PCID
-      ndfc_nested: [nvPairs]
-      tf_name: peer2_pcid
-      type: String
-      description: Peer 2 PCID
-      example: 2
-    - &peer1_member_interfaces
-      model_name: PEER1_MEMBER_INTERFACES
-      ndfc_nested: [nvPairs]
-      tf_name: peer1_member_interfaces
-      type: String
-      description: List of member interfaces for Peer 1
-      example: "[Ethernet1/1, Ethernet1/2]"
-    - &peer2_member_interfaces
-      model_name: PEER2_MEMBER_INTERFACES
-      ndfc_nested: [nvPairs]
-      tf_name: peer2_member_interfaces
-      type: String
-      description: List of member interfaces for Peer 2
-      example: "[Ethernet1/1, Ethernet1/2]"
-    - &pc_mode
-      model_name: PC_MODE
-      ndfc_nested: [nvPairs]
-      tf_name: pc_mode
-      type: String
-      description: Port-channel mode
-      example: active
-    - &peer1_po_desc
-      model_name: PEER1_PO_DESC
-      ndfc_nested: [nvPairs]
-      tf_name: peer1_po_desc
-      type: String
-      description: Port-channel description for Peer 1
-      example: "vPC Peer 1"
-    - &peer2_po_desc
-      model_name: PEER2_PO_DESC
-      ndfc_nested: [nvPairs]
-      tf_name: peer2_po_desc
-      type: String
-      description: Port-channel description for Peer 2
-      example: "vPC Peer 2"
-    - &admin_state
-      model_name: ADMIN_STATE
-      ndfc_nested: [nvPairs]
-      tf_name: admin_state
+    - &deploy
+      model_name: deploy
+      tf_name: deploy
       type: Bool
-      description: Admin state of the vPC pair
-      example: true
-    - &allowed_vlans
-      model_name: ALLOWED_VLANS
-      ndfc_nested: [nvPairs]
-      tf_name: allowed_vlans
-      Default: "all"
-      type: String
-      description: Allowed VLANs for the vPC pair
-      example: "1-4094"
-    - &peer1_po_conf
-      model_name: PEER1_PO_CONF
-      ndfc_nested: [nvPairs]
-      tf_name: peer1_po_conf
-      type: String
-      description: Additional CLI for Peer-1 Port-channel
-      example: ""
-    - &peer2_po_conf
-      model_name: PEER2_PO_CONF
-      ndfc_nested: [nvPairs]
-      tf_name: peer2_po_conf
-      type: String
-      description: Additional CLI for Peer-2 Port-channel
-      example: ""
-    - &is_vteps
-      model_name: isVTEPS
-      ndfc_nested: [nvPairs]
-      tf_name: is_vteps
-      type: Bool
-      description: Set to true to enable VTEPs
-      example: true
-    - &nve_interface
-      model_name: NVE_INTERFACE
-      ndfc_nested: [nvPairs]
-      tf_name: nve_interface
-      type: String
-      description: NVE interface
-      example: "nve1"
+      description: "Deploy vPC pair"
+      mandatory: true
+      ndfc_type: bool
+      payload_hide: true

--- a/internal/provider/ndfc/api/config_deploy_api.go
+++ b/internal/provider/ndfc/api/config_deploy_api.go
@@ -12,22 +12,32 @@ type ConfigDeploymentAPI struct {
 	mutex         *sync.Mutex
 	SerialNumbers []string
 	Deploy        bool
+	Preview       bool
 	FabricName    string
 }
 
 // For additional functions
 
-const UrlGlobalConfigDeploy = "/lan-fabric/rest/control/fabrics/%s/config-deploy"
-const UrlSwitchConfigDeploy = "/lan-fabric/rest/control/fabrics/%s/config-deploy/%s"
+const UrlGlobalConfigDeploy = "/lan-fabric/rest/control/fabrics/%s/config-deploy?forceShowRun=false"
+const UrlSwitchConfigDeploy = "/lan-fabric/rest/control/fabrics/%s/config-deploy/%s?forceShowRun=false"
 const UrlSaveConfig = "/lan-fabric/rest/control/fabrics/%s/config-save"
 const UrlGetFabricErrors = "/lan-fabric/rest/control/fabrics/%s/errors"
+const UrlGetGlobalConfigPreview = "/lan-fabric/rest/control/fabrics/%s/config-preview/%s"
+const UrlGetConfigPreview = "/lan-fabric/rest/control/fabrics/%s/config-preview"
 
 func (c *ConfigDeploymentAPI) GetLock() *sync.Mutex {
 	return c.mutex
 }
 
 func (c *ConfigDeploymentAPI) GetUrl() string {
-	return fmt.Sprintf(UrlGetFabricErrors, c.FabricName)
+	if c.Preview {
+		if len(c.SerialNumbers) > 0 {
+			return fmt.Sprintf(UrlGetGlobalConfigPreview, c.FabricName, strings.Join(c.SerialNumbers, ","))
+		}
+		return fmt.Sprintf(UrlGetConfigPreview, c.FabricName)
+	} else {
+		return fmt.Sprintf(UrlGetFabricErrors, c.FabricName)
+	}
 }
 
 func (c *ConfigDeploymentAPI) PostUrl() string {

--- a/internal/provider/ndfc/ndfc_global_deploy.go
+++ b/internal/provider/ndfc/ndfc_global_deploy.go
@@ -2,13 +2,20 @@ package ndfc
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"terraform-provider-ndfc/internal/provider/ndfc/api"
+	"terraform-provider-ndfc/internal/provider/resources/resource_configuration_deploy"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const ResourceConfigDeploy = "config_deploy"
+const inSync = "In-Sync"
+const outOfSync = "Out-of-Sync"
+const failed = "Failed"
 
 func (c NDFC) SaveConfiguration(ctx context.Context, diags *diag.Diagnostics, fabricName string) {
 	saveApi := api.NewConfigDeploymentAPI(c.GetLock(ResourceConfigDeploy), &c.apiClient)
@@ -16,11 +23,12 @@ func (c NDFC) SaveConfiguration(ctx context.Context, diags *diag.Diagnostics, fa
 	saveApi.Deploy = false
 	_, err := saveApi.Post([]byte{})
 	if err != nil {
-		diags.AddError("Deploy failed", err.Error())
+		diags.AddError("Config Save failed", err.Error())
+		saveApi.Preview = false
 		time.Sleep(3 * time.Second)
-		_, err := saveApi.Get()
+		res, _ := saveApi.Get()
 		// TODO determine which error should be returned
-		diags.AddError("Deploy Errors:", err.Error())
+		diags.AddError("Deploy Errors:", string(res))
 	}
 }
 
@@ -29,15 +37,69 @@ func (c NDFC) DeployConfiguration(ctx context.Context, diags *diag.Diagnostics, 
 	deployApi := api.NewConfigDeploymentAPI(c.GetLock(ResourceConfigDeploy), &c.apiClient)
 	deployApi.FabricName = fabricName
 	deployApi.Deploy = true
-	if len(serialNumbers) > 0 {
-		deployApi.SerialNumbers = serialNumbers
+
+	for retry := 0; retry < 3; retry++ {
+		serialNumbers = c.CheckDeployStatus(ctx, diags, fabricName, serialNumbers)
+		if diags.HasError() {
+			return
+		}
+		if len(serialNumbers) == 0 {
+			return
+		} else {
+			deployApi.SerialNumbers = serialNumbers
+		}
+		_, err = deployApi.Post([]byte{})
+		if err != nil {
+			diags.AddError("Deploy failed", err.Error())
+			time.Sleep(3 * time.Second)
+			deployApi.Preview = false
+			res, _ := deployApi.Get()
+			// TODO determine which error should be returned
+			diags.AddError("Deploy Errors:", string(res))
+			return
+		}
 	}
-	_, err = deployApi.Post([]byte{})
+	diags.AddError("Deploy failed", "Switches are still out of sync")
+}
+
+func (c NDFC) CheckDeployStatus(ctx context.Context, diags *diag.Diagnostics, fabricName string, serialNumbers []string) []string {
+	previewApi := api.NewConfigDeploymentAPI(c.GetLock(ResourceConfigDeploy), &c.apiClient)
+	previewApi.FabricName = fabricName
+	previewApi.Preview = true
+	var response resource_configuration_deploy.SwitchStatusDB
+
+	payload, err := previewApi.Get()
+	if err != nil || len(payload) == 0 {
+		diags.AddError("Deploy failed", "Configuration preview failed")
+		return nil
+	}
+	err = json.Unmarshal(payload, &response)
 	if err != nil {
 		diags.AddError("Deploy failed", err.Error())
-		time.Sleep(3 * time.Second)
-		_, err := deployApi.Get()
-		// TODO determine which error should be returned
-		diags.AddError("Deploy Errors:", err.Error())
 	}
+	tempList := serialNumbers
+	if len(serialNumbers) > 0 {
+		tflog.Debug(ctx, fmt.Sprintf("Switches out of sync: %v", serialNumbers))
+		tflog.Debug(ctx, fmt.Sprintf("Switches in sync: %v", response.SerialNumMap))
+		for index, serialNumber := range serialNumbers {
+			if response.SerialNumMap[serialNumber].Status == inSync {
+				// Delete serial number from outOfSync
+				tempList = append(serialNumbers[:index], serialNumbers[index+1:]...)
+			} else if response.SerialNumMap[serialNumber].Status == failed {
+				diags.AddError("Deploy failed", fmt.Sprintf("Deploy failed for serial number %s", serialNumber))
+			}
+		}
+	} else {
+		for serialNumber, entry := range response.SerialNumMap {
+			if entry.Status == outOfSync {
+				// Add serial number from outOfSync
+				tempList = append(tempList, serialNumber)
+			} else if entry.Status == failed {
+				diags.AddError("Deploy failed", fmt.Sprintf("Deploy failed for serial number %s", serialNumber))
+				return nil
+			}
+		}
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Switches out of sync: %v", tempList))
+	return tempList
 }

--- a/internal/provider/resources/resource_configuration_deploy/resource_custom_codec.go
+++ b/internal/provider/resources/resource_configuration_deploy/resource_custom_codec.go
@@ -1,0 +1,29 @@
+// This file is used to define the custom codec for the resource_configuration_deploy resource
+
+package resource_configuration_deploy
+
+import (
+	"encoding/json"
+)
+
+type SwitchStatusDB struct {
+	SerialNumMap map[string]SwitchStatus
+}
+
+type SwitchStatus struct {
+	SwitchId string `json:"switchId"`
+	Status   string `json:"status"`
+}
+type CustomSwitchStatus SwitchStatus
+
+func (m *SwitchStatusDB) UnmarshalJSON(data []byte) error {
+	customModel := make([]SwitchStatus, 0)
+	m.SerialNumMap = make(map[string]SwitchStatus)
+	if err := json.Unmarshal(data, &customModel); err != nil {
+		return err
+	}
+	for _, entry := range customModel {
+		m.SerialNumMap[entry.SwitchId] = entry
+	}
+	return nil
+}

--- a/internal/provider/resources/resource_vpc_pair/resource_codec_gen.go
+++ b/internal/provider/resources/resource_vpc_pair/resource_codec_gen.go
@@ -5,8 +5,6 @@ package resource_vpc_pair
 import (
 	"context"
 	"log"
-	"strconv"
-	. "terraform-provider-ndfc/internal/provider/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -18,39 +16,12 @@ type NDFCVpcPairModel struct {
 	PeerOneId          string           `json:"peerOneId,omitempty"`
 	PeerTwoId          string           `json:"peerTwoId,omitempty"`
 	UseVirtualPeerlink *bool            `json:"useVirtualPeerlink,omitempty"`
-	TemplateName       string           `json:"templateName,omitempty"`
+	Deploy             bool             `json:"-"`
 	NvPairs            NDFCNvPairsValue `json:"nvPairs,omitempty"`
 }
 
 type NDFCNvPairsValue struct {
-	DomainId              *Int64Custom `json:"DOMAIN_ID,omitempty"`
-	Peer1KeepAliveLocalIp string       `json:"PEER1_KEEP_ALIVE_LOCAL_IP,omitempty"`
-	Peer2KeepAliveLocalIp string       `json:"PEER2_KEEP_ALIVE_LOCAL_IP,omitempty"`
-	KeepAliveVrf          string       `json:"KEEP_ALIVE_VRF,omitempty"`
-	KeepAliveHoldTimeout  *int64       `json:"KEEP_ALIVE_HOLD_TIMEOUT,omitempty"`
-	IsVpcPlus             string       `json:"isVpcPlus,omitempty"`
-	FabricpathSwitchId    string       `json:"fabricPath_switch_id,omitempty"`
-	Peer1SourceLoopback   string       `json:"PEER1_SOURCE_LOOPBACK,omitempty"`
-	Peer2SourceLoopback   string       `json:"PEER2_SOURCE_LOOPBACK,omitempty"`
-	Peer1PrimaryIp        string       `json:"PEER1_PRIMARY_IP,omitempty"`
-	Peer2PrimaryIp        string       `json:"PEER2_PRIMARY_IP,omitempty"`
-	LoopbackSecondaryIp   string       `json:"LOOPBACK_SECONDARY_IP,omitempty"`
-	Peer1DomainConf       string       `json:"PEER1_DOMAIN_CONF,omitempty"`
-	ClearPolicy           string       `json:"clear_policy,omitempty"`
-	FabricName            string       `json:"FABRIC_NAME,omitempty"`
-	Peer1Pcid             string       `json:"PEER1_PCID,omitempty"`
-	Peer2Pcid             string       `json:"PEER2_PCID,omitempty"`
-	Peer1MemberInterfaces string       `json:"PEER1_MEMBER_INTERFACES,omitempty"`
-	Peer2MemberInterfaces string       `json:"PEER2_MEMBER_INTERFACES,omitempty"`
-	PcMode                string       `json:"PC_MODE,omitempty"`
-	Peer1PoDesc           string       `json:"PEER1_PO_DESC,omitempty"`
-	Peer2PoDesc           string       `json:"PEER2_PO_DESC,omitempty"`
-	AdminState            string       `json:"ADMIN_STATE,omitempty"`
-	AllowedVlans          string       `json:"ALLOWED_VLANS,omitempty"`
-	Peer1PoConf           string       `json:"PEER1_PO_CONF,omitempty"`
-	Peer2PoConf           string       `json:"PEER2_PO_CONF,omitempty"`
-	IsVteps               string       `json:"isVTEPS,omitempty"`
-	NveInterface          string       `json:"NVE_INTERFACE,omitempty"`
+	FabricName string `json:"FABRIC_NAME,omitempty"`
 }
 
 func (v *VpcPairModel) SetModelData(jsonData *NDFCVpcPairModel) diag.Diagnostics {
@@ -83,189 +54,13 @@ func (v *VpcPairModel) SetModelData(jsonData *NDFCVpcPairModel) diag.Diagnostics
 		v.UseVirtualPeerlink = types.BoolNull()
 	}
 
-	if jsonData.TemplateName != "" {
-		v.TemplateName = types.StringValue(jsonData.TemplateName)
-	} else {
-		v.TemplateName = types.StringNull()
-	}
-
-	if jsonData.NvPairs.DomainId != nil {
-		if jsonData.NvPairs.DomainId.IsEmpty() {
-			v.DomainId = types.Int64Null()
-		} else {
-			v.DomainId = types.Int64Value(int64(*jsonData.NvPairs.DomainId))
-		}
-
-	} else {
-		v.DomainId = types.Int64Null()
-	}
-
-	if jsonData.NvPairs.Peer1KeepAliveLocalIp != "" {
-		v.Peer1KeepAliveLocalIp = types.StringValue(jsonData.NvPairs.Peer1KeepAliveLocalIp)
-	} else {
-		v.Peer1KeepAliveLocalIp = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer2KeepAliveLocalIp != "" {
-		v.Peer2KeepAliveLocalIp = types.StringValue(jsonData.NvPairs.Peer2KeepAliveLocalIp)
-	} else {
-		v.Peer2KeepAliveLocalIp = types.StringNull()
-	}
-
-	if jsonData.NvPairs.KeepAliveVrf != "" {
-		v.KeepAliveVrf = types.StringValue(jsonData.NvPairs.KeepAliveVrf)
-	} else {
-		v.KeepAliveVrf = types.StringNull()
-	}
-
-	if jsonData.NvPairs.KeepAliveHoldTimeout != nil {
-		v.KeepAliveHoldTimeout = types.Int64Value(*jsonData.NvPairs.KeepAliveHoldTimeout)
-
-	} else {
-		v.KeepAliveHoldTimeout = types.Int64Null()
-	}
-
-	if jsonData.NvPairs.IsVpcPlus != "" {
-		x, _ := strconv.ParseBool(jsonData.NvPairs.IsVpcPlus)
-		v.IsVpcPlus = types.BoolValue(x)
-	} else {
-		v.IsVpcPlus = types.BoolNull()
-	}
-
-	if jsonData.NvPairs.FabricpathSwitchId != "" {
-		v.FabricpathSwitchId = types.StringValue(jsonData.NvPairs.FabricpathSwitchId)
-	} else {
-		v.FabricpathSwitchId = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer1SourceLoopback != "" {
-		v.Peer1SourceLoopback = types.StringValue(jsonData.NvPairs.Peer1SourceLoopback)
-	} else {
-		v.Peer1SourceLoopback = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer2SourceLoopback != "" {
-		v.Peer2SourceLoopback = types.StringValue(jsonData.NvPairs.Peer2SourceLoopback)
-	} else {
-		v.Peer2SourceLoopback = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer1PrimaryIp != "" {
-		v.Peer1PrimaryIp = types.StringValue(jsonData.NvPairs.Peer1PrimaryIp)
-	} else {
-		v.Peer1PrimaryIp = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer2PrimaryIp != "" {
-		v.Peer2PrimaryIp = types.StringValue(jsonData.NvPairs.Peer2PrimaryIp)
-	} else {
-		v.Peer2PrimaryIp = types.StringNull()
-	}
-
-	if jsonData.NvPairs.LoopbackSecondaryIp != "" {
-		v.LoopbackSecondaryIp = types.StringValue(jsonData.NvPairs.LoopbackSecondaryIp)
-	} else {
-		v.LoopbackSecondaryIp = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer1DomainConf != "" {
-		v.Peer1DomainConf = types.StringValue(jsonData.NvPairs.Peer1DomainConf)
-	} else {
-		v.Peer1DomainConf = types.StringNull()
-	}
-
-	if jsonData.NvPairs.ClearPolicy != "" {
-		x, _ := strconv.ParseBool(jsonData.NvPairs.ClearPolicy)
-		v.ClearPolicy = types.BoolValue(x)
-	} else {
-		v.ClearPolicy = types.BoolNull()
-	}
-
 	if jsonData.NvPairs.FabricName != "" {
 		v.FabricName = types.StringValue(jsonData.NvPairs.FabricName)
 	} else {
 		v.FabricName = types.StringNull()
 	}
 
-	if jsonData.NvPairs.Peer1Pcid != "" {
-		v.Peer1Pcid = types.StringValue(jsonData.NvPairs.Peer1Pcid)
-	} else {
-		v.Peer1Pcid = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer2Pcid != "" {
-		v.Peer2Pcid = types.StringValue(jsonData.NvPairs.Peer2Pcid)
-	} else {
-		v.Peer2Pcid = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer1MemberInterfaces != "" {
-		v.Peer1MemberInterfaces = types.StringValue(jsonData.NvPairs.Peer1MemberInterfaces)
-	} else {
-		v.Peer1MemberInterfaces = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer2MemberInterfaces != "" {
-		v.Peer2MemberInterfaces = types.StringValue(jsonData.NvPairs.Peer2MemberInterfaces)
-	} else {
-		v.Peer2MemberInterfaces = types.StringNull()
-	}
-
-	if jsonData.NvPairs.PcMode != "" {
-		v.PcMode = types.StringValue(jsonData.NvPairs.PcMode)
-	} else {
-		v.PcMode = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer1PoDesc != "" {
-		v.Peer1PoDesc = types.StringValue(jsonData.NvPairs.Peer1PoDesc)
-	} else {
-		v.Peer1PoDesc = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer2PoDesc != "" {
-		v.Peer2PoDesc = types.StringValue(jsonData.NvPairs.Peer2PoDesc)
-	} else {
-		v.Peer2PoDesc = types.StringNull()
-	}
-
-	if jsonData.NvPairs.AdminState != "" {
-		x, _ := strconv.ParseBool(jsonData.NvPairs.AdminState)
-		v.AdminState = types.BoolValue(x)
-	} else {
-		v.AdminState = types.BoolNull()
-	}
-
-	if jsonData.NvPairs.AllowedVlans != "" {
-		v.AllowedVlans = types.StringValue(jsonData.NvPairs.AllowedVlans)
-	} else {
-		v.AllowedVlans = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer1PoConf != "" {
-		v.Peer1PoConf = types.StringValue(jsonData.NvPairs.Peer1PoConf)
-	} else {
-		v.Peer1PoConf = types.StringNull()
-	}
-
-	if jsonData.NvPairs.Peer2PoConf != "" {
-		v.Peer2PoConf = types.StringValue(jsonData.NvPairs.Peer2PoConf)
-	} else {
-		v.Peer2PoConf = types.StringNull()
-	}
-
-	if jsonData.NvPairs.IsVteps != "" {
-		x, _ := strconv.ParseBool(jsonData.NvPairs.IsVteps)
-		v.IsVteps = types.BoolValue(x)
-	} else {
-		v.IsVteps = types.BoolNull()
-	}
-
-	if jsonData.NvPairs.NveInterface != "" {
-		v.NveInterface = types.StringValue(jsonData.NvPairs.NveInterface)
-	} else {
-		v.NveInterface = types.StringNull()
-	}
+	v.Deploy = types.BoolValue(jsonData.Deploy)
 
 	return err
 }
@@ -292,181 +87,14 @@ func (v VpcPairModel) GetModelData() *NDFCVpcPairModel {
 		data.UseVirtualPeerlink = nil
 	}
 
-	if !v.TemplateName.IsNull() && !v.TemplateName.IsUnknown() {
-		data.TemplateName = v.TemplateName.ValueString()
-	} else {
-		data.TemplateName = ""
-	}
-
-	if !v.DomainId.IsNull() && !v.DomainId.IsUnknown() {
-		data.NvPairs.DomainId = new(Int64Custom)
-		*data.NvPairs.DomainId = Int64Custom(v.DomainId.ValueInt64())
-	} else {
-		data.NvPairs.DomainId = nil
-	}
-
-	if !v.Peer1KeepAliveLocalIp.IsNull() && !v.Peer1KeepAliveLocalIp.IsUnknown() {
-		data.NvPairs.Peer1KeepAliveLocalIp = v.Peer1KeepAliveLocalIp.ValueString()
-	} else {
-		data.NvPairs.Peer1KeepAliveLocalIp = ""
-	}
-
-	if !v.Peer2KeepAliveLocalIp.IsNull() && !v.Peer2KeepAliveLocalIp.IsUnknown() {
-		data.NvPairs.Peer2KeepAliveLocalIp = v.Peer2KeepAliveLocalIp.ValueString()
-	} else {
-		data.NvPairs.Peer2KeepAliveLocalIp = ""
-	}
-
-	if !v.KeepAliveVrf.IsNull() && !v.KeepAliveVrf.IsUnknown() {
-		data.NvPairs.KeepAliveVrf = v.KeepAliveVrf.ValueString()
-	} else {
-		data.NvPairs.KeepAliveVrf = ""
-	}
-
-	if !v.KeepAliveHoldTimeout.IsNull() && !v.KeepAliveHoldTimeout.IsUnknown() {
-		data.NvPairs.KeepAliveHoldTimeout = new(int64)
-		*data.NvPairs.KeepAliveHoldTimeout = v.KeepAliveHoldTimeout.ValueInt64()
-
-	} else {
-		data.NvPairs.KeepAliveHoldTimeout = nil
-	}
-
-	if !v.IsVpcPlus.IsNull() && !v.IsVpcPlus.IsUnknown() {
-		data.NvPairs.IsVpcPlus = strconv.FormatBool(v.IsVpcPlus.ValueBool())
-	} else {
-		data.NvPairs.IsVpcPlus = ""
-	}
-
-	if !v.FabricpathSwitchId.IsNull() && !v.FabricpathSwitchId.IsUnknown() {
-		data.NvPairs.FabricpathSwitchId = v.FabricpathSwitchId.ValueString()
-	} else {
-		data.NvPairs.FabricpathSwitchId = ""
-	}
-
-	if !v.Peer1SourceLoopback.IsNull() && !v.Peer1SourceLoopback.IsUnknown() {
-		data.NvPairs.Peer1SourceLoopback = v.Peer1SourceLoopback.ValueString()
-	} else {
-		data.NvPairs.Peer1SourceLoopback = ""
-	}
-
-	if !v.Peer2SourceLoopback.IsNull() && !v.Peer2SourceLoopback.IsUnknown() {
-		data.NvPairs.Peer2SourceLoopback = v.Peer2SourceLoopback.ValueString()
-	} else {
-		data.NvPairs.Peer2SourceLoopback = ""
-	}
-
-	if !v.Peer1PrimaryIp.IsNull() && !v.Peer1PrimaryIp.IsUnknown() {
-		data.NvPairs.Peer1PrimaryIp = v.Peer1PrimaryIp.ValueString()
-	} else {
-		data.NvPairs.Peer1PrimaryIp = ""
-	}
-
-	if !v.Peer2PrimaryIp.IsNull() && !v.Peer2PrimaryIp.IsUnknown() {
-		data.NvPairs.Peer2PrimaryIp = v.Peer2PrimaryIp.ValueString()
-	} else {
-		data.NvPairs.Peer2PrimaryIp = ""
-	}
-
-	if !v.LoopbackSecondaryIp.IsNull() && !v.LoopbackSecondaryIp.IsUnknown() {
-		data.NvPairs.LoopbackSecondaryIp = v.LoopbackSecondaryIp.ValueString()
-	} else {
-		data.NvPairs.LoopbackSecondaryIp = ""
-	}
-
-	if !v.Peer1DomainConf.IsNull() && !v.Peer1DomainConf.IsUnknown() {
-		data.NvPairs.Peer1DomainConf = v.Peer1DomainConf.ValueString()
-	} else {
-		data.NvPairs.Peer1DomainConf = ""
-	}
-
-	if !v.ClearPolicy.IsNull() && !v.ClearPolicy.IsUnknown() {
-		data.NvPairs.ClearPolicy = strconv.FormatBool(v.ClearPolicy.ValueBool())
-	} else {
-		data.NvPairs.ClearPolicy = ""
-	}
-
 	if !v.FabricName.IsNull() && !v.FabricName.IsUnknown() {
 		data.NvPairs.FabricName = v.FabricName.ValueString()
 	} else {
 		data.NvPairs.FabricName = ""
 	}
 
-	if !v.Peer1Pcid.IsNull() && !v.Peer1Pcid.IsUnknown() {
-		data.NvPairs.Peer1Pcid = v.Peer1Pcid.ValueString()
-	} else {
-		data.NvPairs.Peer1Pcid = ""
-	}
-
-	if !v.Peer2Pcid.IsNull() && !v.Peer2Pcid.IsUnknown() {
-		data.NvPairs.Peer2Pcid = v.Peer2Pcid.ValueString()
-	} else {
-		data.NvPairs.Peer2Pcid = ""
-	}
-
-	if !v.Peer1MemberInterfaces.IsNull() && !v.Peer1MemberInterfaces.IsUnknown() {
-		data.NvPairs.Peer1MemberInterfaces = v.Peer1MemberInterfaces.ValueString()
-	} else {
-		data.NvPairs.Peer1MemberInterfaces = ""
-	}
-
-	if !v.Peer2MemberInterfaces.IsNull() && !v.Peer2MemberInterfaces.IsUnknown() {
-		data.NvPairs.Peer2MemberInterfaces = v.Peer2MemberInterfaces.ValueString()
-	} else {
-		data.NvPairs.Peer2MemberInterfaces = ""
-	}
-
-	if !v.PcMode.IsNull() && !v.PcMode.IsUnknown() {
-		data.NvPairs.PcMode = v.PcMode.ValueString()
-	} else {
-		data.NvPairs.PcMode = ""
-	}
-
-	if !v.Peer1PoDesc.IsNull() && !v.Peer1PoDesc.IsUnknown() {
-		data.NvPairs.Peer1PoDesc = v.Peer1PoDesc.ValueString()
-	} else {
-		data.NvPairs.Peer1PoDesc = ""
-	}
-
-	if !v.Peer2PoDesc.IsNull() && !v.Peer2PoDesc.IsUnknown() {
-		data.NvPairs.Peer2PoDesc = v.Peer2PoDesc.ValueString()
-	} else {
-		data.NvPairs.Peer2PoDesc = ""
-	}
-
-	if !v.AdminState.IsNull() && !v.AdminState.IsUnknown() {
-		data.NvPairs.AdminState = strconv.FormatBool(v.AdminState.ValueBool())
-	} else {
-		data.NvPairs.AdminState = ""
-	}
-
-	if !v.AllowedVlans.IsNull() && !v.AllowedVlans.IsUnknown() {
-		data.NvPairs.AllowedVlans = v.AllowedVlans.ValueString()
-	} else {
-		data.NvPairs.AllowedVlans = ""
-	}
-
-	if !v.Peer1PoConf.IsNull() && !v.Peer1PoConf.IsUnknown() {
-		data.NvPairs.Peer1PoConf = v.Peer1PoConf.ValueString()
-	} else {
-		data.NvPairs.Peer1PoConf = ""
-	}
-
-	if !v.Peer2PoConf.IsNull() && !v.Peer2PoConf.IsUnknown() {
-		data.NvPairs.Peer2PoConf = v.Peer2PoConf.ValueString()
-	} else {
-		data.NvPairs.Peer2PoConf = ""
-	}
-
-	if !v.IsVteps.IsNull() && !v.IsVteps.IsUnknown() {
-		data.NvPairs.IsVteps = strconv.FormatBool(v.IsVteps.ValueBool())
-	} else {
-		data.NvPairs.IsVteps = ""
-	}
-
-	if !v.NveInterface.IsNull() && !v.NveInterface.IsUnknown() {
-		data.NvPairs.NveInterface = v.NveInterface.ValueString()
-	} else {
-		data.NvPairs.NveInterface = ""
+	if !v.Deploy.IsNull() && !v.Deploy.IsUnknown() {
+		data.Deploy = v.Deploy.ValueBool()
 	}
 
 	return data

--- a/internal/provider/resources/resource_vpc_pair/resource_custom_codec.go
+++ b/internal/provider/resources/resource_vpc_pair/resource_custom_codec.go
@@ -5,21 +5,10 @@ import (
 )
 
 type NDFCVpcPairRecommendations struct {
-	LanId                int     `json:"lanId"`
-	EthSwitchId          int     `json:"ethSwitchId"`
-	LogicalName          string  `json:"logicalName"`
-	IpAddress            string  `json:"ipAddress"`
-	VdcName              *string `json:"vdcName"` // Use a pointer to handle null values
-	VdcId                int     `json:"vdcId"`
 	SerialNumber         string  `json:"serialNumber"`
-	NxosVersion          string  `json:"nxosVersion"`
-	FabricName           *string `json:"fabricName"` // Use a pointer to handle null values
 	RecommendationReason string  `json:"recommendationReason"`
-	BlockSelection       bool    `json:"blockSelection"`
-	Uuid                 *string `json:"uuid"`         // Use a pointer to handle null values
-	PlatformType         *string `json:"platformType"` // Use a pointer to handle null values
+    LogicalName 		 string  `json:"logicalName"`
 	UseVirtualPeerlink   bool    `json:"useVirtualPeerlink"`
-	CurrentPeer          bool    `json:"currentPeer"`
 	Recommended          bool    `json:"recommended"`
 }
 

--- a/internal/provider/resources/resource_vpc_pair/vpc_pair_resource_gen.go
+++ b/internal/provider/resources/resource_vpc_pair/vpc_pair_resource_gen.go
@@ -16,153 +16,23 @@ import (
 func VpcPairResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"admin_state": schema.BoolAttribute{
-				Optional:            true,
-				Description:         "Admin state of the vPC pair",
-				MarkdownDescription: "Admin state of the vPC pair",
-			},
-			"allowed_vlans": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Allowed VLANs for the vPC pair",
-				MarkdownDescription: "Allowed VLANs for the vPC pair",
-			},
-			"clear_policy": schema.BoolAttribute{
-				Optional:            true,
-				Description:         "Set to true to clear policy",
-				MarkdownDescription: "Set to true to clear policy",
-			},
-			"domain_id": schema.Int64Attribute{
-				Optional:            true,
-				Description:         "vPC Domain ID",
-				MarkdownDescription: "vPC Domain ID",
+			"deploy": schema.BoolAttribute{
+				Required:            true,
+				Description:         "Deploy vPC pair",
+				MarkdownDescription: "Deploy vPC pair",
 			},
 			"fabric_name": schema.StringAttribute{
-				Optional:            true,
+				Required:            true,
 				Description:         "Fabric name to which the vPC pair belongs",
 				MarkdownDescription: "Fabric name to which the vPC pair belongs",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"fabricpath_switch_id": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Fabric path switch ID",
-				MarkdownDescription: "Fabric path switch ID",
-			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				Description:         "The Terraform Unique Identifier for the vPC pair resource",
 				MarkdownDescription: "The Terraform Unique Identifier for the vPC pair resource",
-			},
-			"is_vpc_plus": schema.BoolAttribute{
-				Optional:            true,
-				Description:         "Set to true to enable VPC plus",
-				MarkdownDescription: "Set to true to enable VPC plus",
-			},
-			"is_vteps": schema.BoolAttribute{
-				Optional:            true,
-				Description:         "Set to true to enable VTEPs",
-				MarkdownDescription: "Set to true to enable VTEPs",
-			},
-			"keep_alive_hold_timeout": schema.Int64Attribute{
-				Optional:            true,
-				Description:         "Hold timeout to ignore stale peer alive messages, default is 3 if not specified, Mandatory",
-				MarkdownDescription: "Hold timeout to ignore stale peer alive messages, default is 3 if not specified, Mandatory",
-			},
-			"keep_alive_vrf": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Name of VRF used for keep-alive, enter 'default' for default VRF",
-				MarkdownDescription: "Name of VRF used for keep-alive, enter 'default' for default VRF",
-			},
-			"loopback_secondary_ip": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Secondary loopback IP address",
-				MarkdownDescription: "Secondary loopback IP address",
-			},
-			"nve_interface": schema.StringAttribute{
-				Optional:            true,
-				Description:         "NVE interface",
-				MarkdownDescription: "NVE interface",
-			},
-			"pc_mode": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Port-channel mode",
-				MarkdownDescription: "Port-channel mode",
-			},
-			"peer1_domain_conf": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Additional CLI for Peer-1 vPC Domain",
-				MarkdownDescription: "Additional CLI for Peer-1 vPC Domain",
-			},
-			"peer1_keep_alive_local_ip": schema.StringAttribute{
-				Optional:            true,
-				Description:         "IP address of a L3 interface in non-default VRF on Peer 1",
-				MarkdownDescription: "IP address of a L3 interface in non-default VRF on Peer 1",
-			},
-			"peer1_member_interfaces": schema.StringAttribute{
-				Optional:            true,
-				Description:         "List of member interfaces for Peer 1",
-				MarkdownDescription: "List of member interfaces for Peer 1",
-			},
-			"peer1_pcid": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Peer 1 PCID",
-				MarkdownDescription: "Peer 1 PCID",
-			},
-			"peer1_po_conf": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Additional CLI for Peer-1 Port-channel",
-				MarkdownDescription: "Additional CLI for Peer-1 Port-channel",
-			},
-			"peer1_po_desc": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Port-channel description for Peer 1",
-				MarkdownDescription: "Port-channel description for Peer 1",
-			},
-			"peer1_primary_ip": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Primary IP address for Peer 1",
-				MarkdownDescription: "Primary IP address for Peer 1",
-			},
-			"peer1_source_loopback": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Source loopback IP address for Peer 1",
-				MarkdownDescription: "Source loopback IP address for Peer 1",
-			},
-			"peer2_keep_alive_local_ip": schema.StringAttribute{
-				Optional:            true,
-				Description:         "IP address of a L3 interface in non-default VRF on Peer 2",
-				MarkdownDescription: "IP address of a L3 interface in non-default VRF on Peer 2",
-			},
-			"peer2_member_interfaces": schema.StringAttribute{
-				Optional:            true,
-				Description:         "List of member interfaces for Peer 2",
-				MarkdownDescription: "List of member interfaces for Peer 2",
-			},
-			"peer2_pcid": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Peer 2 PCID",
-				MarkdownDescription: "Peer 2 PCID",
-			},
-			"peer2_po_conf": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Additional CLI for Peer-2 Port-channel",
-				MarkdownDescription: "Additional CLI for Peer-2 Port-channel",
-			},
-			"peer2_po_desc": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Port-channel description for Peer 2",
-				MarkdownDescription: "Port-channel description for Peer 2",
-			},
-			"peer2_primary_ip": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Primary IP address for Peer 2",
-				MarkdownDescription: "Primary IP address for Peer 2",
-			},
-			"peer2_source_loopback": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Source loopback IP address for Peer 2",
-				MarkdownDescription: "Source loopback IP address for Peer 2",
 			},
 			"serial_numbers": schema.SetAttribute{
 				ElementType:         types.StringType,
@@ -172,11 +42,6 @@ func VpcPairResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.Set{
 					setvalidator.SizeBetween(2, 2),
 				},
-			},
-			"template_name": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Template to be applied to this VPC switch pair",
-				MarkdownDescription: "Template to be applied to this VPC switch pair",
 			},
 			"use_virtual_peerlink": schema.BoolAttribute{
 				Required:            true,
@@ -188,36 +53,9 @@ func VpcPairResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type VpcPairModel struct {
-	AdminState            types.Bool   `tfsdk:"admin_state"`
-	AllowedVlans          types.String `tfsdk:"allowed_vlans"`
-	ClearPolicy           types.Bool   `tfsdk:"clear_policy"`
-	DomainId              types.Int64  `tfsdk:"domain_id"`
-	FabricName            types.String `tfsdk:"fabric_name"`
-	FabricpathSwitchId    types.String `tfsdk:"fabricpath_switch_id"`
-	Id                    types.String `tfsdk:"id"`
-	IsVpcPlus             types.Bool   `tfsdk:"is_vpc_plus"`
-	IsVteps               types.Bool   `tfsdk:"is_vteps"`
-	KeepAliveHoldTimeout  types.Int64  `tfsdk:"keep_alive_hold_timeout"`
-	KeepAliveVrf          types.String `tfsdk:"keep_alive_vrf"`
-	LoopbackSecondaryIp   types.String `tfsdk:"loopback_secondary_ip"`
-	NveInterface          types.String `tfsdk:"nve_interface"`
-	PcMode                types.String `tfsdk:"pc_mode"`
-	Peer1DomainConf       types.String `tfsdk:"peer1_domain_conf"`
-	Peer1KeepAliveLocalIp types.String `tfsdk:"peer1_keep_alive_local_ip"`
-	Peer1MemberInterfaces types.String `tfsdk:"peer1_member_interfaces"`
-	Peer1Pcid             types.String `tfsdk:"peer1_pcid"`
-	Peer1PoConf           types.String `tfsdk:"peer1_po_conf"`
-	Peer1PoDesc           types.String `tfsdk:"peer1_po_desc"`
-	Peer1PrimaryIp        types.String `tfsdk:"peer1_primary_ip"`
-	Peer1SourceLoopback   types.String `tfsdk:"peer1_source_loopback"`
-	Peer2KeepAliveLocalIp types.String `tfsdk:"peer2_keep_alive_local_ip"`
-	Peer2MemberInterfaces types.String `tfsdk:"peer2_member_interfaces"`
-	Peer2Pcid             types.String `tfsdk:"peer2_pcid"`
-	Peer2PoConf           types.String `tfsdk:"peer2_po_conf"`
-	Peer2PoDesc           types.String `tfsdk:"peer2_po_desc"`
-	Peer2PrimaryIp        types.String `tfsdk:"peer2_primary_ip"`
-	Peer2SourceLoopback   types.String `tfsdk:"peer2_source_loopback"`
-	SerialNumbers         types.Set    `tfsdk:"serial_numbers"`
-	TemplateName          types.String `tfsdk:"template_name"`
-	UseVirtualPeerlink    types.Bool   `tfsdk:"use_virtual_peerlink"`
+	Deploy             types.Bool   `tfsdk:"deploy"`
+	FabricName         types.String `tfsdk:"fabric_name"`
+	Id                 types.String `tfsdk:"id"`
+	SerialNumbers      types.Set    `tfsdk:"serial_numbers"`
+	UseVirtualPeerlink types.Bool   `tfsdk:"use_virtual_peerlink"`
 }

--- a/internal/provider/test_utils_vpc_pair_test.go
+++ b/internal/provider/test_utils_vpc_pair_test.go
@@ -16,92 +16,13 @@ func VpcPairModelHelperStateCheck(RscName string, c resource_vpc_pair.NDFCVpcPai
 	if c.UseVirtualPeerlink != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("use_virtual_peerlink").String(), strconv.FormatBool(*c.UseVirtualPeerlink)))
 	}
-	if c.TemplateName != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("template_name").String(), c.TemplateName))
-	}
-	if c.NvPairs.DomainId != nil {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("domain_id").String(), strconv.Itoa(int(*c.NvPairs.DomainId))))
-	}
-	if c.NvPairs.Peer1KeepAliveLocalIp != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer1_keep_alive_local_ip").String(), c.NvPairs.Peer1KeepAliveLocalIp))
-	}
-	if c.NvPairs.Peer2KeepAliveLocalIp != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer2_keep_alive_local_ip").String(), c.NvPairs.Peer2KeepAliveLocalIp))
-	}
-	if c.NvPairs.KeepAliveVrf != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("keep_alive_vrf").String(), c.NvPairs.KeepAliveVrf))
-	}
-	if c.NvPairs.KeepAliveHoldTimeout != nil {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("keep_alive_hold_timeout").String(), strconv.Itoa(int(*c.NvPairs.KeepAliveHoldTimeout))))
-	}
-	if c.NvPairs.IsVpcPlus != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_vpc_plus").String(), c.NvPairs.IsVpcPlus))
-	}
-	if c.NvPairs.FabricpathSwitchId != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabricpath_switch_id").String(), c.NvPairs.FabricpathSwitchId))
-	}
-	if c.NvPairs.Peer1SourceLoopback != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer1_source_loopback").String(), c.NvPairs.Peer1SourceLoopback))
-	}
-	if c.NvPairs.Peer2SourceLoopback != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer2_source_loopback").String(), c.NvPairs.Peer2SourceLoopback))
-	}
-	if c.NvPairs.Peer1PrimaryIp != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer1_primary_ip").String(), c.NvPairs.Peer1PrimaryIp))
-	}
-	if c.NvPairs.Peer2PrimaryIp != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer2_primary_ip").String(), c.NvPairs.Peer2PrimaryIp))
-	}
-	if c.NvPairs.LoopbackSecondaryIp != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback_secondary_ip").String(), c.NvPairs.LoopbackSecondaryIp))
-	}
-	if c.NvPairs.Peer1DomainConf != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer1_domain_conf").String(), c.NvPairs.Peer1DomainConf))
-	}
-	if c.NvPairs.ClearPolicy != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("clear_policy").String(), c.NvPairs.ClearPolicy))
-	}
 	if c.NvPairs.FabricName != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_name").String(), c.NvPairs.FabricName))
 	}
-	if c.NvPairs.Peer1Pcid != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer1_pcid").String(), c.NvPairs.Peer1Pcid))
-	}
-	if c.NvPairs.Peer2Pcid != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer2_pcid").String(), c.NvPairs.Peer2Pcid))
-	}
-	if c.NvPairs.Peer1MemberInterfaces != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer1_member_interfaces").String(), c.NvPairs.Peer1MemberInterfaces))
-	}
-	if c.NvPairs.Peer2MemberInterfaces != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer2_member_interfaces").String(), c.NvPairs.Peer2MemberInterfaces))
-	}
-	if c.NvPairs.PcMode != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pc_mode").String(), c.NvPairs.PcMode))
-	}
-	if c.NvPairs.Peer1PoDesc != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer1_po_desc").String(), c.NvPairs.Peer1PoDesc))
-	}
-	if c.NvPairs.Peer2PoDesc != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer2_po_desc").String(), c.NvPairs.Peer2PoDesc))
-	}
-	if c.NvPairs.AdminState != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("admin_state").String(), c.NvPairs.AdminState))
-	}
-	if c.NvPairs.AllowedVlans != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("allowed_vlans").String(), c.NvPairs.AllowedVlans))
-	}
-	if c.NvPairs.Peer1PoConf != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer1_po_conf").String(), c.NvPairs.Peer1PoConf))
-	}
-	if c.NvPairs.Peer2PoConf != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("peer2_po_conf").String(), c.NvPairs.Peer2PoConf))
-	}
-	if c.NvPairs.IsVteps != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_vteps").String(), c.NvPairs.IsVteps))
-	}
-	if c.NvPairs.NveInterface != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nve_interface").String(), c.NvPairs.NveInterface))
+	if c.Deploy {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), "true"))
+	} else {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), "false"))
 	}
 	return ret
 }

--- a/internal/provider/vpc_pair_resource.go
+++ b/internal/provider/vpc_pair_resource.go
@@ -105,7 +105,6 @@ func (r *vpcPairResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-
 	// Create API call logic
 	r.client.RscUpdateVpcPair(ctx, &resp.Diagnostics, &planData)
 	if resp.Diagnostics.HasError() {
@@ -154,4 +153,12 @@ func (r *vpcPairResource) ImportState(ctx context.Context, req resource.ImportSt
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 
+}
+func (r vpcPairResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data resource_vpc_pair.VpcPairModel
+	tflog.Debug(ctx, "ValidateConfig called")
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }


### PR DESCRIPTION
Root cause:
vPC pair needs config-save and switch deploy to be done explicitly for configs to be propagated. This support was not there in the resource and was expecting to be done by using configuration_deploy resource

Fix:

Added support to do switch deploy in vPC pair module.

Issue fixed : https://github.com/CiscoDevNet/terraform-provider-ndfc/issues/84