### PR TITLE
Support to make vrf_name optional when layer2_only was made true

### DIFF
--- a/generator/defs/networks.yaml
+++ b/generator/defs/networks.yaml
@@ -99,7 +99,7 @@ resource:
         model_name: vrf
         tf_name: vrf_name
         type: String
-        mandatory: true
+        default_value: NA
         description: The name of the vrf
         example: VRF1
       - &primaryNetworkId

--- a/internal/provider/datasources/datasource_networks/networks_data_source_gen.go
+++ b/internal/provider/datasources/datasource_networks/networks_data_source_gen.go
@@ -283,7 +283,7 @@ func NetworksDataSourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "Vlan Netflow Monitor. Provide monitor name defined in fabric setting for Layer 3 Record. For NX-OS only",
 						},
 						"vrf_name": schema.StringAttribute{
-							Required:            true,
+							Optional:            true,
 							Description:         "The name of the vrf",
 							MarkdownDescription: "The name of the vrf",
 						},

--- a/internal/provider/networks_resource.go
+++ b/internal/provider/networks_resource.go
@@ -217,6 +217,19 @@ func (r networkBulkResource) ValidateConfig(ctx context.Context, req resource.Va
 
 		for network, v := range elements1 {
 			networkDeploy := false
+			if v.Layer2Only.ValueBool() {
+				if !v.VrfName.IsNull() {
+					tflog.Error(ctx, fmt.Sprintf("VRF Name is not required for network %s", network))
+					resp.Diagnostics.AddError("VRF Name is not required", fmt.Sprintf("In network %s, vrf_name is not mandatory since layer2_only is true", network))
+					return
+				}
+			} else {
+				if v.VrfName.IsNull() {
+					tflog.Error(ctx, fmt.Sprintf("VRF Name is required for network %s", network))
+					resp.Diagnostics.AddError("VRF Name is required", fmt.Sprintf("In network %s, vrf_name is mandatory since layer2_only is false", network))
+					return
+				}
+			}
 			if !v.DeployAttachments.IsNull() && !v.DeployAttachments.IsUnknown() {
 				tflog.Debug(ctx, fmt.Sprintf("DeployAttachments is set for network %s", network))
 				networkDeploy = v.DeployAttachments.ValueBool()

--- a/internal/provider/resources/resource_networks/networks_resource_gen.go
+++ b/internal/provider/resources/resource_networks/networks_resource_gen.go
@@ -340,9 +340,11 @@ func NetworksResourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "Vlan Netflow Monitor. Provide monitor name defined in fabric setting for Layer 3 Record. For NX-OS only",
 						},
 						"vrf_name": schema.StringAttribute{
-							Required:            true,
+							Optional:            true,
+							Computed:            true,
 							Description:         "The name of the vrf",
 							MarkdownDescription: "The name of the vrf",
+							Default:             stringdefault.StaticString("NA"),
 						},
 					},
 					CustomType: NetworksType{

--- a/internal/provider/test_utils_networks_test.go
+++ b/internal/provider/test_utils_networks_test.go
@@ -61,6 +61,8 @@ func NetworksValueHelperStateCheck(RscName string, c resource_networks.NDFCNetwo
 	}
 	if c.VrfName != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_name").String(), c.VrfName))
+	} else {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_name").String(), "NA"))
 	}
 	if c.PrimaryNetworkId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("primary_network_id").String(), strconv.Itoa(int(*c.PrimaryNetworkId))))


### PR DESCRIPTION
Requirement:
When layer2_only is made true, vrf_name need not be provided. 

Issue:
vrf_name was a mandatory parameter in network resource.
This fixes Issue: https://github.com/CiscoDevNet/terraform-provider-ndfc/issues/71

Fix:
vrf_name is made optional and error is thrown based on value set in layer2_only flag.

configs_used:
```
locals {
  vrfs = ndfc_vrf_bulk.test_evpn_vxlan_deployment_vrf1.vrfs
  network_vrfs = flatten([
    for key, value in local.vrfs :
    [key]
  ])
}

resource "ndfc_vrf_bulk" "test_evpn_vxlan_deployment_vrf1" {
  fabric_name = "Vxlan_vPC_Pair_Ak"
  vrfs = {
    "Murali_vrf_01" : {
      attach_list : {
        "9D0ZV7JBFNM" : {
          deploy_this_attachment = true
        },
        "9N14Y8PVD2Y" : {
          deploy_this_attachment = true
        },
        "9AF57UDHKDI" : {
          deploy_this_attachment = true
        }
      }
    },
    "Murali_vrf_02" : {
      attach_list : {
        "9D0ZV7JBFNM" : {
          deploy_this_attachment = true
        },
        "9N14Y8PVD2Y" : {
          deploy_this_attachment = true
        },
        "9AF57UDHKDI" : {
          deploy_this_attachment = true
        }
      }
    },
    "Murali_vrf_03" : {
      attach_list : {
        "9D0ZV7JBFNM" : {
          deploy_this_attachment = false
          vlan                   = 3200
        },
        "9N14Y8PVD2Y" : {
          deploy_this_attachment = false
          vlan                   = 3100
        },
        "9AF57UDHKDI" : {
          deploy_this_attachment = false
        }
      }

    },
    "Murali_vrf_04" : {

    },
    "Murali_vrf_05" : {
      "9D0ZV7JBFNM" : {
        deploy_this_attachment = false
      },
      "9N14Y8PVD2Y" : {
        deploy_this_attachment = false
      },
      "9AF57UDHKDI" : {
        deploy_this_attachment = false
      }

    },
    "Murali_vrf_06" : {

    },
    "Murali_vrf_07" : {

    },
    "Murali_vrf_08" : {

    },
    "Murali_vrf_09" : {
      vrf_id = 51109
    },
    "Murali_vrf_10" : {
      vrf_id = 51110
    }
  }
}

resource "ndfc_networks" "test_evpn_vxlan_deployment_nw1" {
  fabric_name = "Vxlan_vPC_Pair_Ak"
  networks = {
    "Murali_nw_01" : {
      network_id            = 31002
      gateway_ipv4_address  = "192.168.2.1/24"
      gateway_ipv6_address  = "2002::1/64"
      vlan_id               = 22
      vlan_name             = "TF_NW_2"
      #vrf_name              = "l2_only"
      layer2_only           = false
      interface_description = "TF_NW_2 SVI"
      mtu                   = 9100
      dhcp_relay_servers = [
        {
          address = "10.1.1.1",
          vrf     = "management"
        },
        {
          address = "20.1.1.1"
          vrf     = "default"
        },
        {
          address = "20.1.1.5"
          vrf     = "default"
        }
      ]
      dhcp_relay_loopback_id = 999
      //tag                    = 1234
      l3_gatway_border       = true
      igmp_version           = 3
      attachments = {
        "9D0ZV7JBFNM" : {
          switch_ports           = ["Ethernet1/2", "Ethernet1/3"]
          deploy_this_attachment = true
        },
        "9N14Y8PVD2Y" : {
          switch_ports           = ["Ethernet1/2", "Ethernet1/3"]
          deploy_this_attachment = true
        },
        "9AF57UDHKDI" : {
          switch_ports           = ["Ethernet1/2","Ethernet1/3"]
          deploy_this_attachment = true
        }
      }
    },
     "Murali_nw_02" : {
      vrf_name              = local.network_vrfs[1]
      vlan_id = 3
       attachments = {
        "9D0ZV7JBFNM" : {
          switch_ports           = ["Ethernet1/6", "Ethernet1/4", "Ethernet1/5"]
          deploy_this_attachment = true
        },
        "9N14Y8PVD2Y" : {
          switch_ports           = ["Ethernet1/4", "Ethernet1/5", "Ethernet1/6"]
          deploy_this_attachment = true
        },
        "9AF57UDHKDI" : {
          switch_ports           = ["Ethernet1/5", "Ethernet1/6", "Ethernet1/4"]
          deploy_this_attachment = true
        }
      }
     }
  }
}