### PR TITLE
Deploy for Network attachment  fails when switch_ports are updated.

### DIFF
--- a/internal/provider/ndfc/net_attach_private.go
+++ b/internal/provider/ndfc/net_attach_private.go
@@ -231,11 +231,14 @@ func (c NDFC) checkNwAttachmentsAction(ctx context.Context, plan *resource_netwo
 					tflog.Debug(ctx, fmt.Sprintf("compareAttachments: Attachment %s/%s in plan needs un-deploy",
 						plan.NetworkName, serial))
 					controlFlag |= UnDeploy
-				} else if !stateAttachment.DeployThisAttachment && planAttach.DeployThisAttachment {
+				}  else if planAttach.DeployThisAttachment {
 					//deploy needed
 					tflog.Debug(ctx, fmt.Sprintf("compareAttachments: Attachment %s/%s in plan needs deploy",
 						plan.NetworkName, serial))
 					controlFlag |= Deploy
+				} else {
+					tflog.Debug(ctx, fmt.Sprintf("compareAttachments: Attachment %s/%s is changed but not to be deployed",
+						plan.NetworkName, serial))
 				}
 
 				// Look inside port lists to see if something has changed


### PR DESCRIPTION
Issue: Deployment to Network attach fails when switch_ports are updated

This fixes issue : https://github.com/CiscoDevNet/terraform-provider-ndfc/issues/73.

