### PR TITLE
Network attachment update fails when serial numbers are part of vPC Pair

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -63,8 +63,11 @@ $GOPATH/bin/generator code -in generator/defs -template generator/templates -out
 
 # Add license headers to all generated files
 $GOPATH/bin/addlicense -c "Cisco Systems, Inc. and its affiliates" -l "mpl" -s  internal/provider/resources/**/*_gen.go
+$GOPATH/bin/addlicense -c "Cisco Systems, Inc. and its affiliates" -l "mpl" -s  internal/provider/ndfc/*_gen.go
+$GOPATH/bin/addlicense -c "Cisco Systems, Inc. and its affiliates" -l "mpl" -s  internal/provider/resources/**/*_test.go
 $GOPATH/bin/addlicense -c "Cisco Systems, Inc. and its affiliates" -l "mpl" -s  internal/provider/provider/**/*_gen.go
 $GOPATH/bin/addlicense -c "Cisco Systems, Inc. and its affiliates" -l "mpl" -s  internal/provider/datasources/**/*_gen.go
+$GOPATH/bin/addlicense -c "Cisco Systems, Inc. and its affiliates" -l "mpl" -s  internal/provider/datasources/**/*_test.go
 $GOPATH/bin/addlicense -c "Cisco Systems, Inc. and its affiliates" -l "mpl" -s  internal/provider/types/
 $GOPATH/bin/addlicense -c "Cisco Systems, Inc. and its affiliates" -l "mpl" -s  internal/provider/*_test.go
 

--- a/generator/defs/vpc-pair.yaml
+++ b/generator/defs/vpc-pair.yaml
@@ -44,14 +44,13 @@ resource:
       description: Set to true to use virtual peer link
       example: true
       mandatory: true
-    - &fabric_name
-      model_name: FABRIC_NAME
-      ndfc_nested: [nvPairs]
+    - &peer1_fabric_name
+      model_name: fabricName
+      ndfc_nested: [peerOneSwitchDetails]
       tf_name: fabric_name
+      tf_hide: true
       type: String
-      mandatory: true
-      tf_requires_replace: true
-      description: Fabric name to which the vPC pair belongs
+      description: Fabric name to which the vPC pair belongs, peer one and peer two will belong to the same fabric
       example: VXLAN_FABRIC
     - &deploy
       model_name: deploy

--- a/internal/provider/ndfc/api/vpc_pair_api.go
+++ b/internal/provider/ndfc/api/vpc_pair_api.go
@@ -18,14 +18,15 @@ import (
 const urlVpcPair = "/lan-fabric/rest/vpcpair"
 const urlVpcPairGet = urlVpcPair + "?serialNumber=%s"
 const urlVpcPairRecmd = urlVpcPair + "/recommendation?serialNumber=%s&useVirtualPeerlink=%t"
+const urlswitchesByFabric = "/lan-fabric/rest/control/fabrics/%s/inventory/switchesByFabric"
 
 type VpcPairAPI struct {
 	NDFCAPICommon
-	mutex                *sync.Mutex
-	CheckRecommendations bool
-	FabricName           string
-	VirtualPeerLink      bool
-	VpcPairID            string
+	mutex           *sync.Mutex
+	CheckStatus     map[string]bool
+	FabricName      string
+	VirtualPeerLink bool
+	VpcPairID       string
 }
 
 func (c *VpcPairAPI) GetLock() *sync.Mutex {
@@ -33,8 +34,10 @@ func (c *VpcPairAPI) GetLock() *sync.Mutex {
 }
 
 func (c *VpcPairAPI) GetUrl() string {
-	if c.CheckRecommendations {
+	if c.CheckStatus["recommendations"] {
 		return fmt.Sprintf(urlVpcPairRecmd, c.VpcPairID, c.VirtualPeerLink)
+	} else if c.CheckStatus["switchesByFabric"] {
+		return fmt.Sprintf(urlswitchesByFabric, c.FabricName)
 	} else {
 		return fmt.Sprintf(urlVpcPairGet, c.VpcPairID)
 	}

--- a/internal/provider/ndfc/network_attachments.go
+++ b/internal/provider/ndfc/network_attachments.go
@@ -28,7 +28,7 @@ func (c *NDFC) RscGetNetworkAttachments(ctx context.Context, nw *resource_networ
 		tflog.Error(ctx, "RscGetNetworkAttachments: Error getting network attachments", map[string]interface{}{"Err": err})
 		return err
 	}
-
+    c.createVpcPairMap(ctx,nw.FabricName)
 	nw.FillAttachmentsFromPayload(nwAttachPayload)
 
 	for netName, nwEntry := range nw.Networks {
@@ -86,7 +86,7 @@ func (c *NDFC) RscUpdateNetAttachments(ctx context.Context, dg *diag.Diagnostics
 	if updateNwAttach != nil && len(updateNwAttach.NetworkAttachments) == 0 {
 		tflog.Info(ctx, "RscUpdateNetAttachments: No attachments to update")
 	} else {
-
+		log.Printf("Network Attachments: %v", updateNwAttach.NetworkAttachments)
 		data, err := json.Marshal(updateNwAttach.NetworkAttachments)
 		if err != nil {
 			tflog.Error(ctx, "RscUpdateNetAttachments: Error marshalling attachments", map[string]interface{}{"Err": err})

--- a/internal/provider/resources/resource_networks/resource_custom_codec.go
+++ b/internal/provider/resources/resource_networks/resource_custom_codec.go
@@ -188,7 +188,7 @@ func (v NDFCNetworksValue) GetAttachmentValues(filters uint16, attach string) []
 			update(&attachEntry, serial)
 			attachmentValues = append(attachmentValues, attachEntry)
 		}
-
+		log.Printf("Loop GetAttachmentValues: %s %s %s %s", v.NetworkName, v.FabricName, serial, attachEntry.Deployment)
 	}
 	return attachmentValues
 }

--- a/internal/provider/resources/resource_vpc_pair/resource_codec_gen.go
+++ b/internal/provider/resources/resource_vpc_pair/resource_codec_gen.go
@@ -20,16 +20,16 @@ import (
 )
 
 type NDFCVpcPairModel struct {
-	SerialNumbers      []string         `json:"-"`
-	PeerOneId          string           `json:"peerOneId,omitempty"`
-	PeerTwoId          string           `json:"peerTwoId,omitempty"`
-	UseVirtualPeerlink *bool            `json:"useVirtualPeerlink,omitempty"`
-	Deploy             bool             `json:"-"`
-	NvPairs            NDFCNvPairsValue `json:"nvPairs,omitempty"`
+	SerialNumbers        []string                      `json:"-"`
+	PeerOneId            string                        `json:"peerOneId,omitempty"`
+	PeerTwoId            string                        `json:"peerTwoId,omitempty"`
+	UseVirtualPeerlink   *bool                         `json:"useVirtualPeerlink,omitempty"`
+	Deploy               bool                          `json:"-"`
+	PeerOneSwitchDetails NDFCPeerOneSwitchDetailsValue `json:"peerOneSwitchDetails,omitempty"`
 }
 
-type NDFCNvPairsValue struct {
-	FabricName string `json:"FABRIC_NAME,omitempty"`
+type NDFCPeerOneSwitchDetailsValue struct {
+	FabricName string `json:"fabricName,omitempty"`
 }
 
 func (v *VpcPairModel) SetModelData(jsonData *NDFCVpcPairModel) diag.Diagnostics {
@@ -62,12 +62,6 @@ func (v *VpcPairModel) SetModelData(jsonData *NDFCVpcPairModel) diag.Diagnostics
 		v.UseVirtualPeerlink = types.BoolNull()
 	}
 
-	if jsonData.NvPairs.FabricName != "" {
-		v.FabricName = types.StringValue(jsonData.NvPairs.FabricName)
-	} else {
-		v.FabricName = types.StringNull()
-	}
-
 	v.Deploy = types.BoolValue(jsonData.Deploy)
 
 	return err
@@ -93,12 +87,6 @@ func (v VpcPairModel) GetModelData() *NDFCVpcPairModel {
 		*data.UseVirtualPeerlink = v.UseVirtualPeerlink.ValueBool()
 	} else {
 		data.UseVirtualPeerlink = nil
-	}
-
-	if !v.FabricName.IsNull() && !v.FabricName.IsUnknown() {
-		data.NvPairs.FabricName = v.FabricName.ValueString()
-	} else {
-		data.NvPairs.FabricName = ""
 	}
 
 	if !v.Deploy.IsNull() && !v.Deploy.IsUnknown() {

--- a/internal/provider/resources/resource_vpc_pair/resource_custom_codec.go
+++ b/internal/provider/resources/resource_vpc_pair/resource_custom_codec.go
@@ -13,11 +13,16 @@ import (
 )
 
 type NDFCVpcPairRecommendations struct {
-	SerialNumber         string  `json:"serialNumber"`
-	RecommendationReason string  `json:"recommendationReason"`
-    LogicalName 		 string  `json:"logicalName"`
-	UseVirtualPeerlink   bool    `json:"useVirtualPeerlink"`
-	Recommended          bool    `json:"recommended"`
+	SerialNumber         string `json:"serialNumber"`
+	RecommendationReason string `json:"recommendationReason"`
+	LogicalName          string `json:"logicalName"`
+	UseVirtualPeerlink   bool   `json:"useVirtualPeerlink"`
+	Recommended          bool   `json:"recommended"`
+}
+
+type NDFCSwitchesByFabric struct {
+	SerialNumber string `json:"serialNumber"`
+	PeerSerialNumber string `json:"peerSerialNumber"`
 }
 
 type CustomNDFCVpcPairModel NDFCVpcPairModel
@@ -31,6 +36,7 @@ func (m *NDFCVpcPairModel) UnmarshalJSON(data []byte) error {
 	m.UseVirtualPeerlink = customModel.UseVirtualPeerlink
 	m.PeerOneId = customModel.PeerOneId
 	m.PeerTwoId = customModel.PeerTwoId
+	m.PeerOneSwitchDetails.FabricName = customModel.PeerOneSwitchDetails.FabricName
 	return nil
 }
 func (m *NDFCVpcPairModel) MarshalJSON() ([]byte, error) {

--- a/internal/provider/resources/resource_vpc_pair/vpc_pair_resource_gen.go
+++ b/internal/provider/resources/resource_vpc_pair/vpc_pair_resource_gen.go
@@ -5,8 +5,6 @@ package resource_vpc_pair
 import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -20,14 +18,6 @@ func VpcPairResourceSchema(ctx context.Context) schema.Schema {
 				Required:            true,
 				Description:         "Deploy vPC pair",
 				MarkdownDescription: "Deploy vPC pair",
-			},
-			"fabric_name": schema.StringAttribute{
-				Required:            true,
-				Description:         "Fabric name to which the vPC pair belongs",
-				MarkdownDescription: "Fabric name to which the vPC pair belongs",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -54,7 +44,6 @@ func VpcPairResourceSchema(ctx context.Context) schema.Schema {
 
 type VpcPairModel struct {
 	Deploy             types.Bool   `tfsdk:"deploy"`
-	FabricName         types.String `tfsdk:"fabric_name"`
 	Id                 types.String `tfsdk:"id"`
 	SerialNumbers      types.Set    `tfsdk:"serial_numbers"`
 	UseVirtualPeerlink types.Bool   `tfsdk:"use_virtual_peerlink"`

--- a/internal/provider/test_utils_vpc_pair_test.go
+++ b/internal/provider/test_utils_vpc_pair_test.go
@@ -24,9 +24,7 @@ func VpcPairModelHelperStateCheck(RscName string, c resource_vpc_pair.NDFCVpcPai
 	if c.UseVirtualPeerlink != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("use_virtual_peerlink").String(), strconv.FormatBool(*c.UseVirtualPeerlink)))
 	}
-	if c.NvPairs.FabricName != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_name").String(), c.NvPairs.FabricName))
-	}
+
 	if c.Deploy {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), "true"))
 	} else {


### PR DESCRIPTION
Network attachment update fails when serial numbers are part of vPC Pair.
Fixes issue : https://github.com/CiscoDevNet/terraform-provider-ndfc/issues/75