### PR TITLE
Fix for removing fabric name in policy and other additional fixes in vpc pair, fabric and networks

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -14,7 +14,6 @@ Resource to configure policies on a switch
 
 ```terraform
 resource "ndfc_policy" "test_resource_policy_1" {
-  fabric_name          = "CML"
   is_policy_group      = false
   deploy               = true
   entity_name          = "Switch"
@@ -42,7 +41,6 @@ resource "ndfc_policy" "test_resource_policy_1" {
 - `device_serial_number` (String) Serial number of the device
 - `entity_name` (String) Policy Name
 - `entity_type` (String) Type of the entity
-- `fabric_name` (String) Name of the fabric
 - `template_name` (String) Name of the template
 
 ### Optional

--- a/examples/resources/ndfc_policy/resource.tf
+++ b/examples/resources/ndfc_policy/resource.tf
@@ -1,6 +1,5 @@
 
 resource "ndfc_policy" "test_resource_policy_1" {
-  fabric_name          = "CML"
   is_policy_group      = false
   deploy               = true
   entity_name          = "Switch"

--- a/generator/defs/policy.yaml
+++ b/generator/defs/policy.yaml
@@ -6,7 +6,7 @@ resource:
   description: "Resource to configure policies on a switch"
   import_id:
     - "POLICY-26910"
-  import_desc: 
+  import_desc:
     - "Policy-ID"
   attributes:
     - model_name: id
@@ -21,14 +21,6 @@ resource:
       description: "Policy ID"
       computed: true
       use_state: true
-    - model_name: fabricName
-      tf_name: fabric_name
-      type: String
-      description: "Name of the fabric"
-      mandatory: true
-      payload_hide: true
-      tf_requires_replace: true
-      example: "CML"
     - model_name: policyGroup
       tf_name: is_policy_group
       type: Bool

--- a/internal/provider/ndfc/api/vpc_pair_api.go
+++ b/internal/provider/ndfc/api/vpc_pair_api.go
@@ -19,14 +19,13 @@ const urlVpcPair = "/lan-fabric/rest/vpcpair"
 const urlVpcPairGet = urlVpcPair + "?serialNumber=%s"
 const urlVpcPairRecmd = urlVpcPair + "/recommendation?serialNumber=%s&useVirtualPeerlink=%t"
 
-
 type VpcPairAPI struct {
 	NDFCAPICommon
-	mutex           *sync.Mutex
-	CheckStatus     map[string]bool
-	FabricName      string
-	VirtualPeerLink bool
-	VpcPairID       string
+	mutex              *sync.Mutex
+	GetRecommendations bool
+	FabricName         string
+	VirtualPeerLink    bool
+	VpcPairID          string
 }
 
 func (c *VpcPairAPI) GetLock() *sync.Mutex {
@@ -34,10 +33,8 @@ func (c *VpcPairAPI) GetLock() *sync.Mutex {
 }
 
 func (c *VpcPairAPI) GetUrl() string {
-	if c.CheckStatus["recommendations"] {
+	if c.GetRecommendations {
 		return fmt.Sprintf(urlVpcPairRecmd, c.VpcPairID, c.VirtualPeerLink)
-	} else if c.CheckStatus["switchesByFabric"] {
-		return fmt.Sprintf(UrlSwitchesByFabric, c.FabricName)
 	} else {
 		return fmt.Sprintf(urlVpcPairGet, c.VpcPairID)
 	}

--- a/internal/provider/ndfc/ndfc_global_deploy.go
+++ b/internal/provider/ndfc/ndfc_global_deploy.go
@@ -32,11 +32,7 @@ func (c NDFC) SaveConfiguration(ctx context.Context, diags *diag.Diagnostics, fa
 	_, err := saveApi.Post([]byte{})
 	if err != nil {
 		diags.AddError("Config Save failed", err.Error())
-		//saveApi.Preview = false
-		//time.Sleep(3 * time.Second)
-		//res, _ := saveApi.Get()
-		// TODO determine which error should be returned
-		///diags.AddError("Deploy Errors:", string(res))
+		return
 	}
 }
 

--- a/internal/provider/ndfc/net_attach_private.go
+++ b/internal/provider/ndfc/net_attach_private.go
@@ -467,13 +467,9 @@ func processPortListOrder(portList *types.CSVString, order []string) {
 	}
 }
 
-func (c NDFC) createVpcPairMap(ctx context.Context, FabricName string) map[string]string {
+func (c NDFC) createVpcPairMap(ctx context.Context, fabricName string) map[string]string {
 
-	api := api.NewVpcPairAPI(c.GetLock(ResourceVpcPair), &c.apiClient)
-	api.CheckStatus = make(map[string]bool)
-	api.CheckStatus["switchesByFabric"] = true
-	api.FabricName = FabricName
-	payload, err := api.Get()
+	payload, err := c.GetSwitchesInFabric(ctx, fabricName)
 	if err != nil || string(payload) == "[]" || payload == nil {
 		tflog.Debug(ctx, "createVpcPairMap: Failed to get switchesByFabric")
 		return nil

--- a/internal/provider/resources/resource_fabric_common/resource_custom_codec.go
+++ b/internal/provider/resources/resource_fabric_common/resource_custom_codec.go
@@ -18,13 +18,26 @@ type FabricModel interface {
 	GetModelData() *NDFCFabricCommonModel
 	SetModelData(*NDFCFabricCommonModel) diag.Diagnostics
 }
-
 type NdfcFabricPayload struct {
 	FabricName        string                `json:"fabricName,omitempty"`
 	FabricType        string                `json:"templateName,omitempty"`
 	NdfcFabricNvPairs NDFCFabricCommonModel `json:"nvPairs,omitempty"`
 }
+type NdfcFabricNamePayload struct {
+	FabricName string `json:"fabricName,omitempty"`
+}
+type CustomNdfcFabricNamePayload NdfcFabricNamePayload
 type CustomNdfcFabricPayload NdfcFabricPayload
+
+func (m *NdfcFabricNamePayload) UnmarshalJSON(data []byte) error {
+	var customModel CustomNdfcFabricNamePayload
+	err := json.Unmarshal(data, &customModel)
+	if err != nil {
+		return err
+	}
+	m.FabricName = customModel.FabricName
+	return nil
+}
 func (m *NdfcFabricPayload) UnmarshalJSON(data []byte) error {
 	var customModel CustomNdfcFabricPayload
 	err := json.Unmarshal(data, &customModel)

--- a/internal/provider/resources/resource_policy/policy_resource_gen.go
+++ b/internal/provider/resources/resource_policy/policy_resource_gen.go
@@ -58,14 +58,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Type of the entity",
 				MarkdownDescription: "Type of the entity",
 			},
-			"fabric_name": schema.StringAttribute{
-				Required:            true,
-				Description:         "Name of the fabric",
-				MarkdownDescription: "Name of the fabric",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
 			"id": schema.Int64Attribute{
 				Computed:            true,
 				Description:         "ID of the policy",
@@ -137,7 +129,6 @@ type PolicyModel struct {
 	DeviceSerialNumber types.String `tfsdk:"device_serial_number"`
 	EntityName         types.String `tfsdk:"entity_name"`
 	EntityType         types.String `tfsdk:"entity_type"`
-	FabricName         types.String `tfsdk:"fabric_name"`
 	Id                 types.Int64  `tfsdk:"id"`
 	IsPolicyGroup      types.Bool   `tfsdk:"is_policy_group"`
 	PolicyId           types.String `tfsdk:"policy_id"`

--- a/internal/provider/resources/resource_policy/resource_codec_gen.go
+++ b/internal/provider/resources/resource_policy/resource_codec_gen.go
@@ -22,7 +22,6 @@ import (
 type NDFCPolicyModel struct {
 	Id                 *int64            `json:"id,omitempty"`
 	PolicyId           string            `json:"policyId,omitempty"`
-	FabricName         string            `json:"-"`
 	IsPolicyGroup      bool              `json:"-"`
 	Deploy             bool              `json:"-"`
 	Status             string            `json:"status,omitempty"`
@@ -53,12 +52,6 @@ func (v *PolicyModel) SetModelData(jsonData *NDFCPolicyModel) diag.Diagnostics {
 		v.PolicyId = types.StringValue(jsonData.PolicyId)
 	} else {
 		v.PolicyId = types.StringNull()
-	}
-
-	if jsonData.FabricName != "" {
-		v.FabricName = types.StringValue(jsonData.FabricName)
-	} else {
-		v.FabricName = types.StringNull()
 	}
 
 	v.IsPolicyGroup = types.BoolValue(jsonData.IsPolicyGroup)
@@ -149,12 +142,6 @@ func (v PolicyModel) GetModelData() *NDFCPolicyModel {
 	var data = new(NDFCPolicyModel)
 
 	//MARSHAL_BODY
-
-	if !v.FabricName.IsNull() && !v.FabricName.IsUnknown() {
-		data.FabricName = v.FabricName.ValueString()
-	} else {
-		data.FabricName = ""
-	}
 
 	if !v.IsPolicyGroup.IsNull() && !v.IsPolicyGroup.IsUnknown() {
 		data.IsPolicyGroup = v.IsPolicyGroup.ValueBool()

--- a/internal/provider/test_utils_policy_test.go
+++ b/internal/provider/test_utils_policy_test.go
@@ -27,9 +27,6 @@ func PolicyModelHelperStateCheck(RscName string, c resource_policy.NDFCPolicyMod
 	if c.PolicyId != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("policy_id").String(), c.PolicyId))
 	}
-	if c.FabricName != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_name").String(), c.FabricName))
-	}
 	if c.IsPolicyGroup {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_policy_group").String(), "true"))
 	} else {


### PR DESCRIPTION
Fixes done:

1) Remove fabric name from policy resource, fabric name can be retrieved from serial number.
2) Move SwitchesByFabric rest api from vpc pair to fabric resource, changes to support the same in networks.
3) Add more debugging in fabric and vpc pair module.
