### PR TITLE
AT case for integrated config with global deployment

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -122,7 +122,60 @@ func TestAccProviderIntegrationTest(t *testing.T) {
 				Config: func() string {
 					cfg := helper.GetProviderHeader()
 					cfg = cfg + "\n\n" + helper.GetProviderConfig(providerAttrs)
-					cfg = cfg + "\n\n" + helper.GetTFIntegrated(t.Name(), rsList, attrs)
+					cfg = cfg + "\n\n" + helper.GetTFIntegrated(t.Name(), rsList, attrs, true)
+					return cfg
+				}(),
+			},
+		},
+	})
+}
+
+func TestAccProviderIntegrationTestGlobalDeploy(t *testing.T) {
+	rsList := []string{
+		"ndfc_fabric_vxlan_evpn",
+		"ndfc_vpc_pair",
+		"ndfc_interface_ethernet",
+		"ndfc_interface_loopback",
+		"ndfc_interface_portchannel",
+		"ndfc_interface_vlan",
+		"ndfc_interface_vpc",
+		"ndfc_networks",
+		"ndfc_vrfs",
+		"ndfc_policy",
+		"ndfc_inventory_devices",
+		"ndfc_configuration_deploy",
+	}
+
+	if helper.GetConfig("global").NDFC.Integration.Fabric == "" {
+		t.Skip("Skipping TestAccProviderIntegrationTest, as configuration is not set in config file")
+	}
+
+	attrs := map[string]interface{}{
+		"fabric":            helper.GetConfig("global").NDFC.Integration.Fabric,
+		"user":              helper.GetConfig("global").NDFC.Integration.User,
+		"password":          helper.GetConfig("global").NDFC.Integration.Password,
+		"vpc_pair":          helper.GetConfig("global").NDFC.Integration.VpcPair,
+		"inventory_devices": helper.GetConfig("global").NDFC.Integration.Inventory.GetDevices(),
+		"inventory_roles":   helper.GetConfig("global").NDFC.Integration.Inventory.GetRoles(),
+		"switches":          helper.GetConfig("global").NDFC.Integration.Switches,
+	}
+
+	providerAttrs := map[string]interface{}{
+		"Host":     helper.GetConfig("global").NDFC.URL,
+		"User":     helper.GetConfig("global").NDFC.User,
+		"Password": helper.GetConfig("global").NDFC.Password,
+		"Insecure": helper.GetConfig("global").NDFC.Insecure,
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t, "provider") },
+		Steps: []resource.TestStep{
+			{
+				Config: func() string {
+					cfg := helper.GetProviderHeader()
+					cfg = cfg + "\n\n" + helper.GetProviderConfig(providerAttrs)
+					cfg = cfg + "\n\n" + helper.GetTFIntegrated(t.Name(), rsList, attrs, false)
 					return cfg
 				}(),
 			},

--- a/testing/at_testbeds/ndfc_161.yaml
+++ b/testing/at_testbeds/ndfc_161.yaml
@@ -14,3 +14,37 @@ ndfc:
   vpc_pair: 
     - "9TQYTJSZ1VJ"
     - "9Q34PHYLDB5"
+  integration_test:
+    fabric: at_test_vxlan
+    user: admin
+    pwd: "admin!@#"
+    resources:
+      - "ndfc_fabric_vxlan_evpn"
+      - "ndfc_inventory_devices"
+      - "ndfc_vrfs"
+      - "ndfc_networks"
+      - "ndfc_vpc_pairs"
+      - "ndfc_interface_ethernet"
+      - "ndfc_interface_portchannel"
+      - "ndfc_interface_vlan"
+      - "ndfc_interface_vpc"
+      - "ndfc_interface_loopback"
+      - "ndfc_configuration_deploy"
+    switches:
+      - "9FTY3OTO227"
+      - "9H6LWDOJEL5"
+      - "9XS8G428UBB"
+      - "9UP5BEPM31C"
+    inventory_devices:
+      - device : "192.168.20.225"
+        role: "spine"
+      - device : "192.168.20.95"
+        role: "leaf"
+      - device : "192.168.20.96"
+        role: "leaf"
+      - device : "192.168.20.97"
+        role: "leaf"
+
+    vpc_pair:
+      - "9H6LWDOJEL5"
+      - "9UP5BEPM31C"


### PR DESCRIPTION
Added a new test case which does integration testing of all resources, where the deployment is globally done using the `ndfc_configuration_deploy` resource at the end

Resource configs are taken from examples

