### PR TITLE
Changes to handle fabric rsc when it is deleted in NDFC manually.

### DIFF
--- a/internal/provider/fabric_ipfm_resource.go
+++ b/internal/provider/fabric_ipfm_resource.go
@@ -14,6 +14,7 @@ import (
 	"terraform-provider-ndfc/internal/provider/ndfc"
 	"terraform-provider-ndfc/internal/provider/resources/resource_fabric_ipfm"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -111,11 +112,20 @@ func (r *fabricIpfmResource) Read(ctx context.Context, req resource.ReadRequest,
 	r.client.RscReadFabric(ctx, &resp.Diagnostics, &data, ndfc.ResourceIpfmFabricType)
 	data.Deploy = types.BoolValue(deploy)
 	data.Id = types.String(data.FabricName)
-	if resp.Diagnostics.HasError() {
-		return
+	tflog.Debug(ctx, "data.FabricName = "+data.FabricName.ValueString())
+	if data.FabricName.IsNull() || data.FabricName.IsUnknown() {
+		// make diags error empty because fabric is not present in NDFC,
+		// it needs to be recreated.
+		resp.Diagnostics = diag.Diagnostics{}
+		// This will clear the state for current fabric, making it eligible for creation
+		resp.State.RemoveResource(ctx)
+	} else {
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		// Save updated data into Terraform state
+		resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 	}
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 
 }
 

--- a/internal/provider/fabric_vxlan_msd_resource.go
+++ b/internal/provider/fabric_vxlan_msd_resource.go
@@ -14,6 +14,7 @@ import (
 	"terraform-provider-ndfc/internal/provider/ndfc"
 	"terraform-provider-ndfc/internal/provider/resources/resource_fabric_vxlan_msd"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -108,15 +109,24 @@ func (r *fabricVxlanMsdResource) Read(ctx context.Context, req resource.ReadRequ
 	unique_id := data.Id.ValueString()
 	tflog.Info(ctx, fmt.Sprintf("Incoming ID %s", unique_id))
 	deploy := data.Deploy.ValueBool()
+
 	r.client.RscReadFabric(ctx, &resp.Diagnostics, &data, ndfc.ResourceVxlanMsdType)
 	data.Deploy = types.BoolValue(deploy)
 	data.Id = types.String(data.FabricName)
-	if resp.Diagnostics.HasError() {
-		return
+	tflog.Debug(ctx, "data.FabricName = "+data.FabricName.ValueString())
+	if data.FabricName.IsNull() || data.FabricName.IsUnknown() {
+		// make diags error empty because fabric is not present in NDFC,
+		// it needs to be recreated.
+		resp.Diagnostics = diag.Diagnostics{}
+		// This will clear the state for current fabric, making it eligible for creation
+		resp.State.RemoveResource(ctx)
+	} else {
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		// Save updated data into Terraform state
+		resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 	}
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
-
 }
 
 func (r *fabricVxlanMsdResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/provider/ndfc/fabric_common.go
+++ b/internal/provider/ndfc/fabric_common.go
@@ -38,6 +38,7 @@ const (
 
 func (c *NDFC) RscReadFabric(ctx context.Context, dg *diag.Diagnostics, tf resource_fabric_common.FabricModel, fabricType string) {
 	tflog.Info(ctx, "Read Fabric")
+	var nvPairsModel resource_fabric_common.NdfcFabricPayload
 	ndfcFabricModel := tf.GetModelData()
 	fabricApi, _ := c.RscGetFabricApiDetails(ctx, dg, ndfcFabricModel, fabricType)
 	if dg.HasError() {
@@ -51,15 +52,17 @@ func (c *NDFC) RscReadFabric(ctx context.Context, dg *diag.Diagnostics, tf resou
 		}
 		tflog.Error(ctx, "RscReadFabric: Failed to get fabric")
 		dg.AddError("Failed to get fabric", fmt.Sprintf("Error: %q", err.Error()))
+		tf.SetModelData(&nvPairsModel.NdfcFabricNvPairs)
 		return
 	}
-	var nvPairsModel resource_fabric_common.NdfcFabricPayload
+	tflog.Debug(ctx, fmt.Sprintf("RscReadFabric: payload %s", string(payload)))
 	err = json.Unmarshal(payload, &nvPairsModel)
 	if err != nil {
 		tflog.Error(ctx, "RscReadFabric: Failed to unmarshal Fabric data")
 		dg.AddError("Failed to unmarshal fabric data", fmt.Sprintf("Error: %q", err.Error()))
 		return
 	}
+	tflog.Debug(ctx, fmt.Sprintf("RscReadFabric: nvPairsModel %v", nvPairsModel))
 	tf.SetModelData(&nvPairsModel.NdfcFabricNvPairs)
 }
 


### PR DESCRIPTION
Issue :
When a fabric is deleted in the NDFC manually via UI. Fabric resource is unable to do a plan what is expected as a next step.

Fix:
When a terraform plan happens with state file present, a 'Read' call is issued to the provider where if fabric is not present , we would remove the state file for the particular fabric, causing the terraform infra to send a fabric create again.

Tests:

bash-3.2$ ./run_accept_tests.sh TestAccFabric
+ echo 'export ACC_TEST_CFG to use a different test environment configuration file; default testing/ndfc_config.yaml'
export ACC_TEST_CFG to use a different test environment configuration file; default testing/ndfc_config.yaml
+ PATTERN=TestAccFabric
+ CFG=187
+ TIMEOUT=5h
+ echo TestAccFabric
TestAccFabric
+ export TF_ACC=1
+ TF_ACC=1
+ export TF_LOG=DEBUG
+ TF_LOG=DEBUG
+ export TF_ACC_LOG=DEBUG
+ TF_ACC_LOG=DEBUG
++ date +%Y-%m-%d-%H-%M-%S
+ export TF_ACC_LOG_PATH=/tmp/terraform-acceptance-tests_2025-03-08-23-20-52.log
+ TF_ACC_LOG_PATH=/tmp/terraform-acceptance-tests_2025-03-08-23-20-52.log
++ pwd
+ export NDFC_TEST_CONFIG_FILE=/Users/akabhask/go/src/terraform-provider-ndfc/testing/at_testbeds/ndfc_187.yaml
+ NDFC_TEST_CONFIG_FILE=/Users/akabhask/go/src/terraform-provider-ndfc/testing/at_testbeds/ndfc_187.yaml
+ rm -rf /tmp/terraform-acceptance-tests_2025-03-08-23-20-52.log
+ GOFLAGS=-count=1
+ go test -timeout 5h -v -run '^TestAccFabric' ./...
?   	terraform-provider-ndfc	[no test files]
?   	terraform-provider-ndfc/internal/provider/datasources/datasource_inventory_devices	[no test files]
?   	terraform-provider-ndfc/internal/provider/datasources/datasource_inventory_reachability	[no test files]
?   	terraform-provider-ndfc/internal/provider/ndfc/api	[no test files]
?   	terraform-provider-ndfc/internal/provider/resources/resource_fabric_common	[no test files]
?   	terraform-provider-ndfc/internal/provider/resources/resource_configuration_deploy	[no test files]
?   	terraform-provider-ndfc/internal/provider/provider/provider_ndfc	[no test files]
?   	terraform-provider-ndfc/internal/provider/resources/resource_interface_common	[no test files]
?   	terraform-provider-ndfc/internal/provider/resources/resource_network_attachments	[no test files]
?   	terraform-provider-ndfc/internal/provider/testing	[no test files]
?   	terraform-provider-ndfc/internal/provider/types	[no test files]
=== RUN   TestAccFabricVxlanEvpnResource
    provider_test.go:46: Starting testAccPreCheck for fabric_vxlan_evpn
--- PASS: TestAccFabricVxlanEvpnResource (34.96s)
=== RUN   TestAccFabricVxlanMsdResource
    provider_test.go:46: Starting testAccPreCheck for fabric_vxlan_msd
--- PASS: TestAccFabricVxlanMsdResource (16.11s)
=== RUN   TestAccFabricLanClassicResource
    provider_test.go:46: Starting testAccPreCheck for fabric_lan_classic
--- PASS: TestAccFabricLanClassicResource (14.69s)
=== RUN   TestAccFabricMsiteExtNetResource
    provider_test.go:46: Starting testAccPreCheck for fabric_msite_ext_net
--- PASS: TestAccFabricMsiteExtNetResource (15.08s)
PASS
ok  	terraform-provider-ndfc/internal/provider	81.797s
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/datasources/datasource_fabric	1.900s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/datasources/datasource_interfaces	0.386s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/datasources/datasource_networks	1.413s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/datasources/datasource_vrf	0.610s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/datasources/datasource_vrf_bulk	1.654s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/ndfc	1.170s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_fabric_ipfm	2.118s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_fabric_lan_classic	2.362s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_fabric_msite_ext_net	2.479s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_fabric_vxlan_evpn	2.327s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_fabric_vxlan_msd	2.399s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_interface_ethernet	2.395s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_interface_loopback	2.404s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_interface_portchannel	2.404s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_interface_vlan	2.402s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_interface_vpc	2.417s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_inventory_devices	2.398s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_networks	2.400s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_policy	2.422s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_template	2.357s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_vpc_pair	2.057s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_vrf	2.042s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_vrf_attachments	1.914s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/internal/provider/resources/resource_vrf_bulk	2.026s [no tests to run]
testing: warning: no tests to run
PASS
ok  	terraform-provider-ndfc/tfutils/go-nd	2.042s [no tests to run]
bash-3.2$