### PR TITLE
Fix for Default behavior for ndfc_interface_ethernet resource

### DIFF
--- a/internal/provider/ndfc/inventory.go
+++ b/internal/provider/ndfc/inventory.go
@@ -140,3 +140,11 @@ func (c NDFC) DeleteFabricInventoryDevices(ctx context.Context, diags *diag.Diag
 		diags.AddError("Delete Devices Failed", err.Error())
 	}
 }
+
+func (c NDFC) GetDeviceRole(ctx context.Context, diags *diag.Diagnostics, serialNum string) gjson.Result {
+	res, err := c.apiClient.Get(fmt.Sprintf("/rest/control/switches/roles?serialNumber=%s", serialNum))
+	if err != nil {
+		diags.AddError("Get Device Role Failed", err.Error())
+	}
+	return res
+}

--- a/internal/provider/ndfc/ndfc.go
+++ b/internal/provider/ndfc/ndfc.go
@@ -114,3 +114,7 @@ func ReleaseResourceLock(rscName string) {
 	instance.deployMutex.RUnlock()
 	log.Printf("+++++++++++++++ReleaseResourceLock for %s+++++++++++pid %d", rscName, os.Getpid())
 }
+
+func getNDFCClient() *NDFC {
+	return instance
+}


### PR DESCRIPTION
Issue:
The ndfc_interface_ethernet resource should default interfaces to access on leaf devices and trunk on spine devices

Fix:
Adding the code to support the same.
