### PR TITLE
save and deploy made default true in inventory_devices_resource

### DIFF
--- a/docs/resources/inventory_devices.md
+++ b/docs/resources/inventory_devices.md
@@ -49,12 +49,12 @@ resource "ndfc_inventory_devices" "test_resource_inventory_devices_1" {
 ### Optional
 
 - `auth_protocol` (String) The authentication protocol to use for the devices
-- `deploy` (Boolean) Deploy the configuration of the devices
+- `deploy` (Boolean) Default set to true. NDFC recommends deploying the configuration of the devices in inventory itself. Not doing so could lead to "out-of-sync" issues when configuring other resources during deployment in other resources.
 - `max_hops` (Number) The maximum number of hops to use during the discovery of devices
 - `preserve_config` (Boolean) Preserve the configuration of the devices
 - `retries` (Number) The number of retries to use validate fabric status before execution of requests
 - `retry_wait_timeout` (Number) The time to wait between retries to validate fabric status before execution of requests
-- `save` (Boolean) Save the configuration of the devices
+- `save` (Boolean) Default set to true. NDFC recommends saving the configuration of the devices in inventory itself. Not doing so could lead to "out-of-sync" issues when configuring other resources during deployment in other resources.
 - `seed_ip` (String) The seed IP address to use for the discovery devices
 - `set_as_individual_device_write_credential` (Boolean) Set and use discovery credentials for LAN devices
 

--- a/generator/defs/inventory-devices.yaml
+++ b/generator/defs/inventory-devices.yaml
@@ -83,16 +83,16 @@ resource:
       model_name: save
       tf_name: save
       type: Bool
-      default_value: false
-      description: Save the configuration of the devices
+      default_value: true
+      description:  Default set to true. NDFC recommends saving the device configuration during "add devices" to avoid "out-of-sync" issues when deploying in other resources.
       ndfc_type: bool
       example: true
     - &deploy
       model_name: deploy
       tf_name: deploy
       type: Bool
-      default_value: false
-      description: Deploy the configuration of the devices
+      default_value: true
+      description: Default set to true. NDFC recommends deploying the device configuration during "add devices" to avoid "out-of-sync" issues when deploying in other resources.
       ndfc_type: bool
       example: true
     - &retries

--- a/internal/provider/resources/resource_inventory_devices/inventory_devices_resource_gen.go
+++ b/internal/provider/resources/resource_inventory_devices/inventory_devices_resource_gen.go
@@ -39,9 +39,9 @@ func InventoryDevicesResourceSchema(ctx context.Context) schema.Schema {
 			"deploy": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Deploy the configuration of the devices",
-				MarkdownDescription: "Deploy the configuration of the devices",
-				Default:             booldefault.StaticBool(false),
+				Description:         "Default set to true. NDFC recommends deploying the configuration of the devices in inventory itself. Not doing so could lead to \"out-of-sync\" issues when configuring other resources during deployment in other resources.",
+				MarkdownDescription: "Default set to true. NDFC recommends deploying the configuration of the devices in inventory itself. Not doing so could lead to \"out-of-sync\" issues when configuring other resources during deployment in other resources.",
+				Default:             booldefault.StaticBool(true),
 			},
 			"devices": schema.MapNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
@@ -251,9 +251,9 @@ func InventoryDevicesResourceSchema(ctx context.Context) schema.Schema {
 			"save": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Save the configuration of the devices",
-				MarkdownDescription: "Save the configuration of the devices",
-				Default:             booldefault.StaticBool(false),
+				Description:         "Default set to true. NDFC recommends saving the configuration of the devices in inventory itself. Not doing so could lead to \"out-of-sync\" issues when configuring other resources during deployment in other resources.",
+				MarkdownDescription: "Default set to true. NDFC recommends saving the configuration of the devices in inventory itself. Not doing so could lead to \"out-of-sync\" issues when configuring other resources during deployment in other resources.",
+				Default:             booldefault.StaticBool(true),
 			},
 			"seed_ip": schema.StringAttribute{
 				Optional:            true,

--- a/internal/provider/test_utils_inventory_devices_test.go
+++ b/internal/provider/test_utils_inventory_devices_test.go
@@ -54,12 +54,12 @@ func InventoryDevicesModelHelperStateCheck(RscName string, c resource_inventory_
 	if c.Save != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("save").String(), strconv.FormatBool(*c.Save)))
 	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("save").String(), "false"))
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("save").String(), "true"))
 	}
 	if c.Deploy != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), strconv.FormatBool(*c.Deploy)))
 	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), "false"))
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), "true"))
 	}
 	if c.Retries != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("retries").String(), strconv.Itoa(int(*c.Retries))))


### PR DESCRIPTION
config_save and config_deploy is flag made default true in inventory_devices_resource, this avoids out-of-sync issues in NDFC