### PR TITLE
Fabric delete fails in some cases randomly

### DIFF
--- a/internal/provider/ndfc/fabric_common.go
+++ b/internal/provider/ndfc/fabric_common.go
@@ -150,7 +150,7 @@ func (f *NDFC) RscDeleteFabric(ctx context.Context, dg *diag.Diagnostics, tf res
 	time.Sleep(3 * time.Second) // Wait for DB to sync
 	payload, err = fapi.Get()
 	tflog.Debug(ctx, fmt.Sprintf("RscDeleteFabric: payload %s", string(payload)))
-	if err != nil {
+	if err != nil  || len(payload) == 0 || string(payload) == "[]"{
 		tflog.Info(ctx, "RscDeleteFabric: Fabric deleted")
 		/* Fabric is deleted. */
 		return


### PR DESCRIPTION
Issue:
In NDFC, sometimes when fabric is deleted, the GET fabric response returns "200 OK" but with an empty payload. Normally, it should return a 404 status code to indicate that the fabric is not present. This causes failure when only response is checked for error.

Fix:
Added a check to see if the payload is empty even when the response is "200 OK" and consider it as absence of fabric.