### PR TITLE
Delete added switches in ndfc when inventory rsc fails

### DIFF
--- a/internal/provider/ndfc/fabric_common.go
+++ b/internal/provider/ndfc/fabric_common.go
@@ -82,10 +82,10 @@ func (f *NDFC) RscCreateFabric(ctx context.Context, dg *diag.Diagnostics, tf res
 		return
 	}
 
-	_, err := fapi.Post(payload)
+	resp, err := fapi.Post(payload)
 	if err != nil {
 		tflog.Error(ctx, "RscCreateFabric: POST failed with payload %s", map[string]interface{}{"Payload": payload})
-		dg.AddError("Failed to create fabric", fmt.Sprintf("Error: %q", err.Error()))
+		dg.AddError("Failed to create fabric", fmt.Sprintf("Error: %q Response :%s", err.Error(), resp.String()))
 		return
 	}
 

--- a/internal/provider/ndfc/inventory.go
+++ b/internal/provider/ndfc/inventory.go
@@ -138,7 +138,7 @@ func (c NDFC) UpdateSerialNumber(ctx context.Context, diags *diag.Diagnostics, f
 func (c NDFC) DeleteFabricInventoryDevices(ctx context.Context, diags *diag.Diagnostics, fabricName string, uuidList []string) {
 	_, err := c.apiClient.Delete(fmt.Sprintf("/lan-fabric/rest/control/fabrics/%s/switches/UUID/%s", fabricName, strings.Join(uuidList, ",")), "")
 	if err != nil {
-		diags.AddError("Delete Devices Failed", err.Error())
+		diags.Append(diag.NewErrorDiagnostic("Delete Devices Failed", err.Error()))
 	}
 }
 


### PR DESCRIPTION
Issue:
Inventory resource may fail if even one switch is not added in right state in NDFC. Terraform state is not updated when resource is failed but NDFC would have switches added causing inconsistency when resource is rerun.

Fix: Delete all added switches when inventory resource fails due to unexpected reason. Which would allow re-adding them on config apply.

