### PR TITLE
Remove default values from schema in fabric resource 

### DIFF
--- a/generator/defs/fabric_common.yaml
+++ b/generator/defs/fabric_common.yaml
@@ -13,7 +13,9 @@ resource:
   - model_name: AAA_REMOTE_IP_ENABLED
     tf_name: aaa_remote_ip_enabled
     description: Enable only, when IP Authorization is enabled in the AAA Server
-    default_value: false
+   #default_value: false
+    computed: true
+    optional: true
     type: Bool
   - model_name: AAA_SERVER_CONF
     tf_name: aaa_server_conf

--- a/generator/defs/fabric_ipfm.yaml
+++ b/generator/defs/fabric_ipfm.yaml
@@ -23,7 +23,9 @@ resource:
     - model_name: AAA_REMOTE_IP_ENABLED
       tf_name: aaa_remote_ip_enabled
       description: Enable only when IP Authorization is enabled in the AAA Server
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: AAA_SERVER_CONF
@@ -44,15 +46,19 @@ resource:
     - model_name: BOOTSTRAP_ENABLE
       tf_name: bootstrap_enable
       description: Automatic IP Assignment For POAP
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BOOTSTRAP_MULTISUBNET
       tf_name: bootstrap_multisubnet
       description: 'lines with # prefix are ignored here'
-      default_value: >-
+#       default_value: >-
         #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
-        Scope_Subnet_Prefix
+        #Scope_Subnet_Prefix
+      computed: true
+      optional: true
       type: String
       example: >-
         #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
@@ -60,13 +66,17 @@ resource:
     - model_name: CDP_ENABLE
       tf_name: cdp_enable
       description: Enable CDP on management interface
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: DHCP_ENABLE
       tf_name: dhcp_enable
       description: Automatic IP Assignment For POAP From Local DHCP Server
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: DHCP_END
@@ -95,19 +105,25 @@ resource:
     - model_name: ENABLE_AAA
       tf_name: enable_aaa
       description: Include AAA configs from Manageability tab during device bootup
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_ASM
       tf_name: enable_asm
       description: 'Enable groups with receivers sending (*,G) joins'
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_NBM_PASSIVE
       tf_name: enable_nbm_passive
       description: Enable NBM mode to pim-passive for default VRF
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: EXTRA_CONF_INTRA_LINKS
@@ -129,27 +145,35 @@ resource:
     - model_name: FABRIC_INTERFACE_TYPE
       tf_name: fabric_interface_type
       description: Only Numbered(Point-to-Point) is supported
-      default_value: p2p
+#       default_value: p2p
+      computed: true
+      optional: true
       type: String
       validator: OneOf("p2p")
       example: p2p
     - model_name: FABRIC_MTU
       tf_name: fabric_mtu
       description: Must be an even number
-      default_value: 9216
+#       default_value: 9216
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 9216
     - model_name: FEATURE_PTP
       tf_name: feature_ptp
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ISIS_AUTH_ENABLE
       tf_name: isis_auth_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ISIS_AUTH_KEY
@@ -168,7 +192,9 @@ resource:
     - model_name: ISIS_LEVEL
       tf_name: isis_level
       description: 'Supported IS types: level-1, level-2'
-      default_value: level-2
+#       default_value: level-2
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("level-1", "level-2")'
       example: level-2
@@ -181,27 +207,35 @@ resource:
     - model_name: L2_HOST_INTF_MTU
       tf_name: l2_host_intf_mtu
       description: Must be an even number
-      default_value: 9216
+#       default_value: 9216
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 9216
     - model_name: LINK_STATE_ROUTING
       tf_name: link_state_routing
       description: Used for Spine-Leaf Connectivity
-      default_value: ospf
+#       default_value: ospf
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("ospf", "is-is")'
       example: ospf
     - model_name: LINK_STATE_ROUTING_TAG
       tf_name: link_state_routing_tag
       description: Routing process tag for the fabric
-      default_value: '1'
+#       default_value: '1'
+      computed: true
+      optional: true
       type: String
       example: '1'
     - model_name: LOOPBACK0_IP_RANGE
       tf_name: loopback0_ip_range
       description: Routing Loopback IP Address Range
-      default_value: 10.2.0.0/22
+#       default_value: 10.2.0.0/22
+      computed: true
+      optional: true
       type: String
       example: 10.2.0.0/22
     - model_name: MGMT_GW
@@ -226,20 +260,26 @@ resource:
     - model_name: NXAPI_VRF
       tf_name: nxapi_vrf
       description: VRF used for NX-API communication
-      default_value: management
+#       default_value: management
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("management", "default")'
       example: management
     - model_name: OSPF_AREA_ID
       tf_name: ospf_area_id
       description: OSPF Area Id in IP address format
-      default_value: 0.0.0.0
+#       default_value: 0.0.0.0
+      computed: true
+      optional: true
       type: String
       example: 0.0.0.0
     - model_name: OSPF_AUTH_ENABLE
       tf_name: ospf_auth_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: OSPF_AUTH_KEY
@@ -254,7 +294,9 @@ resource:
     - model_name: PIM_HELLO_AUTH_ENABLE
       tf_name: pim_hello_auth_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: PIM_HELLO_AUTH_KEY
@@ -264,13 +306,17 @@ resource:
     - model_name: PM_ENABLE
       tf_name: pm_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: POWER_REDUNDANCY_MODE
       tf_name: power_redundancy_mode
       description: Default power supply mode for the fabric
-      default_value: ps-redundant
+#       default_value: ps-redundant
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("ps-redundant", "combined", "insrc-redundant")'
       example: ps-redundant
@@ -292,7 +338,9 @@ resource:
     - model_name: ROUTING_LB_ID
       tf_name: routing_lb_id
       description: No description available
-      default_value: 0
+#       default_value: 0
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 0
@@ -308,25 +356,33 @@ resource:
     - model_name: SNMP_SERVER_HOST_TRAP
       tf_name: snmp_server_host_trap
       description: Configure NDFC as a receiver for SNMP traps
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: STATIC_UNDERLAY_IP_ALLOC
       tf_name: static_underlay_ip_alloc
       description: Checking this will disable Dynamic Fabric IP Address Allocations
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: SUBNET_RANGE
       tf_name: subnet_range
       description: Address range to assign Numbered IPs
-      default_value: 10.4.0.0/16
+#       default_value: 10.4.0.0/16
+      computed: true
+      optional: true
       type: String
       example: 10.4.0.0/16
     - model_name: SUBNET_TARGET_MASK
       tf_name: subnet_target_mask
       description: Mask for Fabric Subnet IP Range
-      default_value: 30
+#       default_value: 30
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       validator: 'OneOf(30, 31)'

--- a/generator/defs/fabric_lan_classic.yaml
+++ b/generator/defs/fabric_lan_classic.yaml
@@ -23,7 +23,9 @@ resource:
     - model_name: AAA_REMOTE_IP_ENABLED
       tf_name: aaa_remote_ip_enabled
       description: 'Enable only, when IP Authorization is enabled in the AAA Server'
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: AAA_SERVER_CONF
@@ -41,9 +43,11 @@ resource:
     - model_name: BOOTSTRAP_MULTISUBNET
       tf_name: bootstrap_multisubnet
       description: 'lines with # prefix are ignored here'
-      default_value: >-
+#       default_value: >-
         #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
-        Scope_Subnet_Prefix
+        #Scope_Subnet_Prefix
+      computed: true
+      optional: true
       type: String
       example: >-
         #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
@@ -51,13 +55,17 @@ resource:
     - model_name: CDP_ENABLE
       tf_name: cdp_enable
       description: Enable CDP on management interface
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: DHCP_ENABLE
       tf_name: dhcp_enable
       description: Automatic IP Assignment For POAP From Local DHCP Server
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: DHCP_END
@@ -80,19 +88,25 @@ resource:
     - model_name: ENABLE_NETFLOW
       tf_name: enable_netflow
       description: Enable Netflow on VTEPs
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_NXAPI
       tf_name: enable_nxapi
       description: Enable HTTPS NX-API
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_NXAPI_HTTP
       tf_name: enable_nxapi_http
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: FABRIC_FREEFORM
@@ -102,7 +116,9 @@ resource:
     - model_name: FEATURE_PTP
       tf_name: feature_ptp
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: INBAND_ENABLE
@@ -114,13 +130,17 @@ resource:
     - model_name: INBAND_MGMT
       tf_name: inband_mgmt
       description: Import switches with inband connectivity
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: IS_READ_ONLY
       tf_name: is_read_only
       description: 'If enabled, fabric is only monitored. No configuration will be deployed'
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: MGMT_GW
@@ -140,7 +160,9 @@ resource:
     - model_name: MPLS_HANDOFF
       tf_name: mpls_handoff
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: MPLS_LB_ID
@@ -183,27 +205,35 @@ resource:
     - model_name: NXAPI_HTTPS_PORT
       tf_name: nxapi_https_port
       description: No description available
-      default_value: 443
+#       default_value: 443
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 443
     - model_name: NXAPI_HTTP_PORT
       tf_name: nxapi_http_port
       description: No description available
-      default_value: 80
+#       default_value: 80
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 80
     - model_name: PM_ENABLE
       tf_name: pm_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: POWER_REDUNDANCY_MODE
       tf_name: power_redundancy_mode
       description: Default Power Supply Mode For Bootstrapped NX-OS Switches
-      default_value: ps-redundant
+#       default_value: ps-redundant
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("ps-redundant", "combined", "insrc-redundant")'
       example: ps-redundant
@@ -220,25 +250,33 @@ resource:
     - model_name: SNMP_SERVER_HOST_TRAP
       tf_name: snmp_server_host_trap
       description: Configure NDFC as a receiver for SNMP traps
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: SUBINTERFACE_RANGE
       tf_name: subinterface_range
       description: Per Border Dot1q Range For VRF Lite Connectivity
-      default_value: 2-511
+#       default_value: 2-511
+      computed: true
+      optional: true
       type: String
       example: 2-511
     - model_name: enableRealTimeBackup
       tf_name: enable_realtime_backup
       description: Backup hourly only if there is any config deployment since last backup
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: enableScheduledBackup
       tf_name: enable_scheduled_backup
       description: Backup at the specified time
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: scheduledTime

--- a/generator/defs/fabric_msite_ext_net.yaml
+++ b/generator/defs/fabric_msite_ext_net.yaml
@@ -23,7 +23,9 @@ resource:
     - model_name: AAA_REMOTE_IP_ENABLED
       tf_name: aaa_remote_ip_enabled
       description: 'Enable only, when IP Authorization is enabled in the AAA Server'
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: AAA_SERVER_CONF
@@ -53,9 +55,11 @@ resource:
     - model_name: BOOTSTRAP_MULTISUBNET
       tf_name: bootstrap_multisubnet
       description: 'lines with # prefix are ignored here'
-      default_value: >-
+#       default_value: >-
         #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
-        Scope_Subnet_Prefix
+        #Scope_Subnet_Prefix
+      computed: true
+      optional: true
       type: String
       example: >-
         #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
@@ -63,13 +67,17 @@ resource:
     - model_name: CDP_ENABLE
       tf_name: cdp_enable
       description: Enable CDP on management interface
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: DHCP_ENABLE
       tf_name: dhcp_enable
       description: Automatic IP Assignment For POAP From Local DHCP Server
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: DHCP_END
@@ -96,19 +104,25 @@ resource:
     - model_name: ENABLE_NETFLOW
       tf_name: enable_netflow
       description: Enable Netflow on VTEPs
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_NXAPI
       tf_name: enable_nxapi
       description: Enable HTTPS NX-API
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_NXAPI_HTTP
       tf_name: enable_nxapi_http
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
 #    - model_name: ENABLE_RT_INTF_STATS
@@ -126,7 +140,9 @@ resource:
     - model_name: FEATURE_PTP
       tf_name: feature_ptp
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: INBAND_ENABLE
@@ -138,7 +154,9 @@ resource:
     - model_name: INBAND_MGMT
       tf_name: inband_mgmt
       description: Import switches with inband connectivity
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: INTF_STAT_LOAD_INTERVAL
@@ -149,7 +167,9 @@ resource:
     - model_name: IS_READ_ONLY
       tf_name: is_read_only
       description: 'If enabled, fabric is only monitored. No configuration will be deployed'
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: MGMT_GW
@@ -169,7 +189,9 @@ resource:
     - model_name: MPLS_HANDOFF
       tf_name: mpls_handoff
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: MPLS_LB_ID
@@ -212,21 +234,27 @@ resource:
     - model_name: NXAPI_HTTPS_PORT
       tf_name: nxapi_https_port
       description: No description available
-      default_value: 443
+#       default_value: 443
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 443
     - model_name: NXAPI_HTTP_PORT
       tf_name: nxapi_http_port
       description: No description available
-      default_value: 80
+#       default_value: 80
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 80
     - model_name: PM_ENABLE
       tf_name: pm_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: PNP_ENABLE
@@ -236,7 +264,9 @@ resource:
     - model_name: POWER_REDUNDANCY_MODE
       tf_name: power_redundancy_mode
       description: Default Power Supply Mode For Bootstrapped NX-OS Switches
-      default_value: ps-redundant
+#       default_value: ps-redundant
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("ps-redundant", "combined", "insrc-redundant")'
       example: ps-redundant
@@ -253,13 +283,17 @@ resource:
     - model_name: SNMP_SERVER_HOST_TRAP
       tf_name: snmp_server_host_trap
       description: Configure NDFC as a receiver for SNMP traps
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: SUBINTERFACE_RANGE
       tf_name: subinterface_range
       description: Per Border Dot1q Range For VRF Lite Connectivity
-      default_value: 2-511
+#       default_value: 2-511
+      computed: true
+      optional: true
       type: String
       example: 2-511
     - model_name: enableRealTimeBackup

--- a/generator/defs/fabric_vxlan_evpn.yaml
+++ b/generator/defs/fabric_vxlan_evpn.yaml
@@ -24,7 +24,9 @@ resource:
     - model_name: AAA_REMOTE_IP_ENABLED
       tf_name: aaa_remote_ip_enabled
       description: 'Enable only, when IP Authorization is enabled in the AAA Server'
-      default_value: false
+      #default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: AAA_SERVER_CONF
@@ -33,8 +35,10 @@ resource:
       type: String
     - model_name: ADVERTISE_PIP_BGP
       tf_name: advertise_pip_bgp
+      optional: true
+      computed: true
       description: For Primary VTEP IP Advertisement As Next-Hop Of Prefix Routes
-      default_value: false
+      #default_value: false
       type: Bool
       example: false
     - model_name: ADVERTISE_PIP_ON_BORDER
@@ -42,7 +46,9 @@ resource:
       description: >-
         Enable advertise-pip on vPC borders and border gateways only. Applicable
         only when vPC advertise-pip is not enabled
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: ANYCAST_BGW_ADVERTISE_PIP
@@ -50,13 +56,17 @@ resource:
       description: >-
         To advertise Anycast Border Gateway PIP as VTEP. Effective on MSD fabric
         Recalculate Config
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ANYCAST_GW_MAC
       tf_name: anycast_gw_mac
       description: Shared MAC address for all leafs (xxxx.xxxx.xxxx)
-      default_value: 2020.0000.00aa
+#       default_value: 2020.0000.00aa
+      computed: true
+      optional: true
       type: String
       example: 2020.0000.00aa
     - model_name: ANYCAST_LB_ID
@@ -67,7 +77,9 @@ resource:
     - model_name: ANYCAST_RP_IP_RANGE
       tf_name: anycast_rp_ip_range
       description: Anycast or Phantom RP IP Address Range
-      default_value: 10.254.254.0/24
+#       default_value: 10.254.254.0/24
+      computed: true
+      optional: true
       type: String
       example: 10.254.254.0/24
     - model_name: AUTO_SYMMETRIC_DEFAULT_VRF
@@ -76,7 +88,9 @@ resource:
         Whether to auto generate Default VRF interface and BGP peering
         configuration on managed neighbor devices. If set, auto created VRF Lite
         IFC links will have Auto Deploy Default VRF for Peer enabled.
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: AUTO_SYMMETRIC_VRF_LITE
@@ -85,7 +99,9 @@ resource:
         Whether to auto generate VRF LITE sub-interface and BGP peering
         configuration on managed neighbor devices. If set, auto created VRF Lite
         IFC links will have Auto Deploy for Peer enabled.
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: AUTO_UNIQUE_VRF_LITE_IP_PREFIX
@@ -94,7 +110,9 @@ resource:
         When enabled, IP prefix allocated to the VRF LITE IFC is not reused on
         VRF extension over VRF LITE IFC. Instead, unique IP Subnet is allocated
         for each VRF extension over VRF LITE IFC.
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: AUTO_VRFLITE_IFC_DEFAULT_VRF
@@ -103,7 +121,9 @@ resource:
         Whether to auto generate Default VRF interface and BGP peering
         configuration on VRF LITE IFC auto deployment. If set, auto created VRF
         Lite IFC links will have Auto Deploy Default VRF enabled.
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BANNER
@@ -115,7 +135,9 @@ resource:
     - model_name: BFD_AUTH_ENABLE
       tf_name: bfd_auth_enable
       description: Valid for P2P Interfaces only
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BFD_AUTH_KEY
@@ -130,31 +152,41 @@ resource:
     - model_name: BFD_ENABLE
       tf_name: bfd_enable
       description: Valid for IPv4 Underlay only
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BFD_IBGP_ENABLE
       tf_name: bfd_ibgp_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BFD_ISIS_ENABLE
       tf_name: bfd_isis_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BFD_OSPF_ENABLE
       tf_name: bfd_ospf_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BFD_PIM_ENABLE
       tf_name: bfd_pim_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BGP_AS
@@ -168,7 +200,9 @@ resource:
     - model_name: BGP_AUTH_ENABLE
       tf_name: bgp_auth_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BGP_AUTH_KEY
@@ -178,7 +212,9 @@ resource:
     - model_name: BGP_AUTH_KEY_TYPE
       tf_name: bgp_auth_key_type
       description: 'BGP Key Encryption Type: 3 - 3DES, 7 - Cisco'
-      default_value: 3
+#       default_value: 3
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       validator: 'OneOf(3, 7)'
@@ -186,7 +222,9 @@ resource:
     - model_name: BGP_LB_ID
       tf_name: bgp_lb_id
       description: No description available
-      default_value: 0
+#       default_value: 0
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 0
@@ -197,15 +235,19 @@ resource:
     - model_name: BOOTSTRAP_ENABLE
       tf_name: bootstrap_enable
       description: Automatic IP Assignment For POAP
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: BOOTSTRAP_MULTISUBNET
       tf_name: bootstrap_multisubnet
       description: '''lines with # prefix are ignored here'''
-      default_value: >-
+#       default_value: >-
         #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
-        Scope_Subnet_Prefix
+        #Scope_Subnet_Prefix
+      computed: true
+      optional: true
       type: String
       example: >-
         #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
@@ -213,7 +255,9 @@ resource:
     - model_name: BROWNFIELD_NETWORK_NAME_FORMAT
       tf_name: brownfield_network_name_format
       description: Generated network name should be < 64 characters
-      default_value: Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$
+#       default_value: Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$
+      computed: true
+      optional: true
       type: String
       example: Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$
     - model_name: BROWNFIELD_SKIP_OVERLAY_NETWORK_ATTACHMENTS
@@ -221,13 +265,17 @@ resource:
       description: >-
         Enable to skip overlay network interface attachments for Brownfield and
         Host Port Resync cases
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: CDP_ENABLE
       tf_name: cdp_enable
       description: Enable CDP on management interface
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: COPP_POLICY
@@ -235,20 +283,26 @@ resource:
       description: >-
         Fabric Wide CoPP Policy. Customized CoPP policy should be provided when
         manual is selected
-      default_value: strict
+#       default_value: strict
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("dense", "lenient", "moderate", "strict", "manual")'
       example: strict
     - model_name: DCI_SUBNET_RANGE
       tf_name: dci_subnet_range
       description: Address range to assign P2P Interfabric Connections
-      default_value: 10.33.0.0/16
+#       default_value: 10.33.0.0/16
+      computed: true
+      optional: true
       type: String
       example: 10.33.0.0/16
     - model_name: DCI_SUBNET_TARGET_MASK
       tf_name: dci_subnet_target_mask
       description: No description available
-      default_value: 30
+#       default_value: 30
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 30
@@ -257,7 +311,9 @@ resource:
       description: >-
         Queuing Policy for all 92xx, -EX, -FX, -FX2, -FX3, -GX series switches
         in the fabric
-      default_value: queuing_policy_default_8q_cloudscale
+#       default_value: queuing_policy_default_8q_cloudscale
+      computed: true
+      optional: true
       type: String
       validator: >-
         OneOf("queuing_policy_default_4q_cloudscale",
@@ -266,14 +322,18 @@ resource:
     - model_name: DEAFULT_QUEUING_POLICY_OTHER
       tf_name: default_queuing_policy_other
       description: Queuing Policy for all other switches in the fabric
-      default_value: queuing_policy_default_other
+#       default_value: queuing_policy_default_other
+      computed: true
+      optional: true
       type: String
       validator: OneOf("queuing_policy_default_other")
       example: queuing_policy_default_other
     - model_name: DEAFULT_QUEUING_POLICY_R_SERIES
       tf_name: default_queuing_policy_r_series
       description: Queuing Policy for all R-Series switches in the fabric
-      default_value: queuing_policy_default_r_series
+#       default_value: queuing_policy_default_r_series
+      computed: true
+      optional: true
       type: String
       validator: OneOf("queuing_policy_default_r_series")
       example: queuing_policy_default_r_series
@@ -286,7 +346,9 @@ resource:
     - model_name: DHCP_ENABLE
       tf_name: dhcp_enable
       description: Automatic IP Assignment For POAP From Local DHCP Server
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: DHCP_END
@@ -315,31 +377,41 @@ resource:
     - model_name: ENABLE_AAA
       tf_name: enable_aaa
       description: Include AAA configs from Manageability tab during device bootup
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_DEFAULT_QUEUING_POLICY
       tf_name: enable_default_queuing_policy
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_FABRIC_VPC_DOMAIN_ID
       tf_name: enable_fabric_vpc_domain_id
       description: (Not Recommended)
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_MACSEC
       tf_name: enable_macsec
       description: Enable MACsec in the fabric
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_NETFLOW
       tf_name: enable_netflow
       description: Enable Netflow on VTEPs
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_NGOAM
@@ -347,19 +419,25 @@ resource:
       description: >-
         Enable the Next Generation (NG) OAM feature for all switches in the
         fabric to aid in trouble-shooting VXLAN EVPN fabrics
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: ENABLE_NXAPI
       tf_name: enable_nxapi
       description: Enable HTTPS NX-API
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: ENABLE_NXAPI_HTTP
       tf_name: enable_nxapi_http
       description: No description available
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: ENABLE_PBR
@@ -367,31 +445,41 @@ resource:
       description: >-
         When ESR option is ePBR, enable ePBR will enable pbr, sla sender and
         epbr features on the switch
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_PVLAN
       tf_name: enable_pvlan
       description: Enable PVLAN on switches except spines and super spines
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_TENANT_DHCP
       tf_name: enable_tenant_dhcp
       description: No description available
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: ENABLE_TRM
       tf_name: enable_trm
       description: For Overlay Multicast Support In VXLAN Fabrics
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_VPC_PEER_LINK_NATIVE_VLAN
       tf_name: enable_vpc_peer_link_native_vlan
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: EXTRA_CONF_INTRA_LINKS
@@ -417,14 +505,18 @@ resource:
     - model_name: FABRIC_INTERFACE_TYPE
       tf_name: fabric_interface_type
       description: Numbered(Point-to-Point) or Unnumbered
-      default_value: p2p
+#       default_value: p2p
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("p2p", "unnumbered")'
       example: p2p
     - model_name: FABRIC_MTU
       tf_name: fabric_mtu
       description: Must be an even number
-      default_value: 9216
+#       default_value: 9216
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 9216
@@ -438,19 +530,25 @@ resource:
       description: >-
         Qos on spines for guaranteed delivery of vPC Fabric Peering
         communication
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: FABRIC_VPC_QOS_POLICY_NAME
       tf_name: fabric_vpc_qos_policy_name
       description: Qos Policy name should be same on all spines
-      default_value: spine_qos_for_fabric_vpc_peering
+#       default_value: spine_qos_for_fabric_vpc_peering
+      computed: true
+      optional: true
       type: String
       example: spine_qos_for_fabric_vpc_peering
     - model_name: FEATURE_PTP
       tf_name: feature_ptp
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: GRFIELD_DEBUG_FLAG
@@ -458,21 +556,27 @@ resource:
       description: >-
         Enable to clean switch configuration without reload when
         PreserveConfig=no
-      default_value: Disable
+#       default_value: Disable
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("Enable", "Disable")'
       example: Enable
     - model_name: HD_TIME
       tf_name: hd_time
       description: NVE Source Inteface HoldDown Time in seconds
-      default_value: 180
+#       default_value: 180
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 180
     - model_name: HOST_INTF_ADMIN_STATE
       tf_name: host_intf_admin_state
       description: No description available
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: IBGP_PEER_TEMPLATE
@@ -496,13 +600,17 @@ resource:
     - model_name: INBAND_MGMT
       tf_name: inband_mgmt
       description: Manage switches with only Inband connectivity
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ISIS_AUTH_ENABLE
       tf_name: isis_auth_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ISIS_AUTH_KEY
@@ -521,7 +629,9 @@ resource:
     - model_name: ISIS_LEVEL
       tf_name: isis_level
       description: 'Supported IS types: level-1, level-2'
-      default_value: level-2
+#       default_value: level-2
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("level-1", "level-2")'
       example: level-2
@@ -543,14 +653,18 @@ resource:
     - model_name: L2_HOST_INTF_MTU
       tf_name: l2_host_intf_mtu
       description: Must be an even number
-      default_value: 9216
+#       default_value: 9216
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 9216
     - model_name: L2_SEGMENT_ID_RANGE
       tf_name: l2_segment_id_range
       description: Overlay Network Identifier Range
-      default_value: 30000-49000
+#       default_value: 30000-49000
+      computed: true
+      optional: true
       type: String
       example: 30000-49000
     - model_name: L3VNI_MCAST_GROUP
@@ -560,7 +674,9 @@ resource:
     - model_name: L3_PARTITION_ID_RANGE
       tf_name: l3_partition_id_range
       description: Overlay VRF Identifier Range
-      default_value: 50000-59000
+#       default_value: 50000-59000
+      computed: true
+      optional: true
       type: String
       example: 50000-59000
 #    - model_name: ESR_OPTION
@@ -573,14 +689,18 @@ resource:
     - model_name: LINK_STATE_ROUTING
       tf_name: link_state_routing
       description: Used for Spine-Leaf Connectivity
-      default_value: ospf
+#       default_value: ospf
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("ospf", "is-is")'
       example: ospf
     - model_name: LINK_STATE_ROUTING_TAG
       tf_name: link_state_routing_tag
       description: Underlay Routing Process Tag
-      default_value: UNDERLAY
+#       default_value: UNDERLAY
+      computed: true
+      optional: true
       type: String
       example: UNDERLAY
     - model_name: LOOPBACK0_IPV6_RANGE
@@ -590,7 +710,9 @@ resource:
     - model_name: LOOPBACK0_IP_RANGE
       tf_name: loopback0_ip_range
       description: Typically Loopback0 IP Address Range
-      default_value: 10.2.0.0/22
+#       default_value: 10.2.0.0/22
+      computed: true
+      optional: true
       type: String
       example: 10.2.0.0/22
     - model_name: LOOPBACK1_IPV6_RANGE
@@ -600,7 +722,9 @@ resource:
     - model_name: LOOPBACK1_IP_RANGE
       tf_name: loopback1_ip_range
       description: Typically Loopback1 IP Address Range
-      default_value: 10.3.0.0/22
+#       default_value: 10.3.0.0/22
+      computed: true
+      optional: true
       type: String
       example: 10.3.0.0/22
     - model_name: MACSEC_ALGORITHM
@@ -645,7 +769,9 @@ resource:
     - model_name: MPLS_HANDOFF
       tf_name: mpls_handoff
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: MPLS_LB_ID
@@ -666,7 +792,9 @@ resource:
       description: >-
         Multicast pool prefix between 8 to 30. A multicast group IP from this
         pool is used for BUM traffic for each overlay network.
-      default_value: 239.1.1.0/25
+#       default_value: 239.1.1.0/25
+      computed: true
+      optional: true
       type: String
       example: 239.1.1.0/25
     - model_name: NETFLOW_EXPORTER_LIST
@@ -693,7 +821,9 @@ resource:
     - model_name: NETWORK_VLAN_RANGE
       tf_name: network_vlan_range
       description: Per Switch Overlay Network VLAN Range
-      default_value: 2300-2999
+#       default_value: 2300-2999
+      computed: true
+      optional: true
       type: String
       example: 2300-2999
     - model_name: NTP_SERVER_IP_LIST
@@ -709,40 +839,52 @@ resource:
     - model_name: NVE_LB_ID
       tf_name: nve_lb_id
       description: No description available
-      default_value: 1
+#       default_value: 1
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 1
     - model_name: NXAPI_HTTPS_PORT
       tf_name: nxapi_https_port
       description: No description available
-      default_value: 443
+#       default_value: 443
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 443
     - model_name: NXAPI_HTTP_PORT
       tf_name: nxapi_http_port
       description: No description available
-      default_value: 80
+#       default_value: 80
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 80
     - model_name: OBJECT_TRACKING_NUMBER_RANGE
       tf_name: object_tracking_number_range
       description: Per switch tracked object ID Range
-      default_value: 100-299
+#       default_value: 100-299
+      computed: true
+      optional: true
       type: String
       example: 100-299
     - model_name: OSPF_AREA_ID
       tf_name: ospf_area_id
       description: OSPF Area Id in IP address format
-      default_value: 0.0.0.0
+#       default_value: 0.0.0.0
+      computed: true
+      optional: true
       type: String
       example: 0.0.0.0
     - model_name: OSPF_AUTH_ENABLE
       tf_name: ospf_auth_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: OSPF_AUTH_KEY
@@ -757,13 +899,17 @@ resource:
     - model_name: OVERLAY_MODE
       tf_name: overlay_mode
       description: VRF/Network configuration using config-profile or CLI
-      default_value: cli
+#       default_value: cli
+      computed: true
+      optional: true
       type: String
       example: cli
     - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION
       tf_name: per_vrf_loopback_auto_provision
       description: Auto provision a loopback on a VTEP on VRF attachment
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: PER_VRF_LOOPBACK_IP_RANGE
@@ -795,7 +941,9 @@ resource:
     - model_name: PIM_HELLO_AUTH_ENABLE
       tf_name: pim_hello_auth_enable
       description: Valid for IPv4 Underlay only
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: PIM_HELLO_AUTH_KEY
@@ -805,7 +953,9 @@ resource:
     - model_name: PM_ENABLE
       tf_name: pm_enable
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
 #    - model_name: ENABLE_RT_INTF_STATS
@@ -817,7 +967,9 @@ resource:
     - model_name: POWER_REDUNDANCY_MODE
       tf_name: power_redundancy_mode
       description: Default Power Supply Mode For The Fabric
-      default_value: ps-redundant
+#       default_value: ps-redundant
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("ps-redundant", "combined", "insrc-redundant")'
       example: ps-redundant
@@ -834,7 +986,9 @@ resource:
     - model_name: REPLICATION_MODE
       tf_name: replication_mode
       description: Replication Mode for BUM Traffic
-      default_value: Multicast
+#       default_value: Multicast
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("Multicast", "Ingress")'
       example: Multicast
@@ -845,13 +999,17 @@ resource:
     - model_name: ROUTE_MAP_SEQUENCE_NUMBER_RANGE
       tf_name: route_map_sequence_number_range
       description: No description available
-      default_value: 1-65534
+#       default_value: 1-65534
+      computed: true
+      optional: true
       type: String
       example: 1-65534
     - model_name: RP_COUNT
       tf_name: rp_count
       description: Number of spines acting as Rendezvous-Point (RP)
-      default_value: 2
+#       default_value: 2
+      computed: true
+      optional: true
       type: Int64
       validator: 'OneOf(2, 4)'
       handle_empty: true
@@ -859,21 +1017,27 @@ resource:
     - model_name: RP_LB_ID
       tf_name: rp_lb_id
       description: No description available
-      default_value: 254
+#       default_value: 254
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 254
     - model_name: RP_MODE
       tf_name: rp_mode
       description: Multicast RP Mode
-      default_value: asm
+#       default_value: asm
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("asm", "bidir")'
       example: asm
     - model_name: RR_COUNT
       tf_name: rr_count
       description: Number of spines acting as Route-Reflectors
-      default_value: 2
+#       default_value: 2
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       validator: 'OneOf(2, 4)'
@@ -885,7 +1049,9 @@ resource:
     - model_name: SERVICE_NETWORK_VLAN_RANGE
       tf_name: service_network_vlan_range
       description: Per Switch Overlay Service Network VLAN Range
-      default_value: 3000-3199
+#       default_value: 3000-3199
+      computed: true
+      optional: true
       type: String
       example: 3000-3199
     - model_name: SITE_ID
@@ -897,13 +1063,17 @@ resource:
     - model_name: SLA_ID_RANGE
       tf_name: sla_id_range
       description: Per switch SLA ID Range
-      default_value: 10000-19999
+#       default_value: 10000-19999
+      computed: true
+      optional: true
       type: String
       example: 10000-19999
     - model_name: SNMP_SERVER_HOST_TRAP
       tf_name: snmp_server_host_trap
       description: Configure NDFC as a receiver for SNMP traps
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: SPINE_SWITCH_CORE_INTERFACES
@@ -913,7 +1083,9 @@ resource:
     - model_name: STATIC_UNDERLAY_IP_ALLOC
       tf_name: static_underlay_ip_alloc
       description: Checking this will disable Dynamic Underlay IP Address Allocations
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: STP_BRIDGE_PRIORITY
@@ -927,7 +1099,9 @@ resource:
         Which protocol to use for configuring root bridge? rpvst+: Rapid
         Per-VLAN Spanning Tree, mst: Multiple Spanning Tree, unmanaged
         (default): STP Root not managed by NDFC
-      default_value: unmanaged
+#       default_value: unmanaged
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("rpvst+", "mst", "unmanaged")'
       example: unmanaged
@@ -940,25 +1114,33 @@ resource:
       description: >-
         Enable bi-directional compliance checks to flag additional configs in
         the running config that are not in the intent/expected config
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: SUBINTERFACE_RANGE
       tf_name: subinterface_range
       description: Per Border Dot1q Range For VRF Lite Connectivity
-      default_value: 2-511
+#       default_value: 2-511
+      computed: true
+      optional: true
       type: String
       example: 2-511
     - model_name: SUBNET_RANGE
       tf_name: subnet_range
       description: Address range to assign Numbered and Peer Link SVI IPs
-      default_value: 10.4.0.0/16
+#       default_value: 10.4.0.0/16
+      computed: true
+      optional: true
       type: String
       example: 10.4.0.0/16
     - model_name: SUBNET_TARGET_MASK
       tf_name: subnet_target_mask
       description: Mask for Underlay Subnet IP Range
-      default_value: 30
+#       default_value: 30
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       validator: 'OneOf(30, 31)'
@@ -982,13 +1164,17 @@ resource:
       description: >-
         TCAM commands are automatically generated for VxLAN and vPC Fabric
         Peering when Enabled
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: UNDERLAY_IS_V6
       tf_name: underlay_is_v6
       description: 'If not enabled, IPv4 underlay is used'
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: UNNUM_BOOTSTRAP_LB_ID
@@ -1007,7 +1193,9 @@ resource:
     - model_name: USE_LINK_LOCAL
       tf_name: use_link_local
       description: 'If not enabled, Spine-Leaf interfaces will use global IPv6 addresses'
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: V6_SUBNET_RANGE
@@ -1017,7 +1205,9 @@ resource:
     - model_name: V6_SUBNET_TARGET_MASK
       tf_name: v6_subnet_target_mask
       description: Mask for Underlay Subnet IPv6 Range
-      default_value: 126
+#       default_value: 126
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       validator: 'OneOf(126, 127)'
@@ -1025,47 +1215,61 @@ resource:
     - model_name: VPC_AUTO_RECOVERY_TIME
       tf_name: vpc_auto_recovery_time
       description: No description available
-      default_value: 360
+#       default_value: 360
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 360
     - model_name: VPC_DELAY_RESTORE
       tf_name: vpc_delay_restore
       description: No description available
-      default_value: 150
+#       default_value: 150
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 150
     - model_name: VPC_DOMAIN_ID_RANGE
       tf_name: vpc_domain_id_range
       description: vPC Domain id range to use for new pairings
-      default_value: 1-1000
+#       default_value: 1-1000
+      computed: true
+      optional: true
       type: String
       example: 1-1000
     - model_name: VPC_ENABLE_IPv6_ND_SYNC
       tf_name: vpc_enable_ipv6_nd_sync
       description: Enable IPv6 ND synchronization between vPC peers
-      default_value: true
+#       default_value: true
+      computed: true
+      optional: true
       type: Bool
       example: true
     - model_name: VPC_PEER_KEEP_ALIVE_OPTION
       tf_name: vpc_peer_keep_alive_option
       description: Use vPC Peer Keep Alive with Loopback or Management
-      default_value: management
+#       default_value: management
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("loopback", "management")'
       example: management
     - model_name: VPC_PEER_LINK_PO
       tf_name: vpc_peer_link_po
       description: No description available
-      default_value: 500
+#       default_value: 500
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 500
     - model_name: VPC_PEER_LINK_VLAN
       tf_name: vpc_peer_link_vlan
       description: VLAN range for vPC Peer Link SVI
-      default_value: 3600
+#       default_value: 3600
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 3600
@@ -1077,20 +1281,26 @@ resource:
         border devices of two Easy Fabrics, and between border devices in Easy
         Fabric and edge routers in External Fabric. The IP address is taken from
         the VRF Lite Subnet IP Range pool.
-      default_value: Manual
+#       default_value: Manual
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("Manual", "Back2Back&ToExternal")'
       example: Manual
     - model_name: VRF_VLAN_RANGE
       tf_name: vrf_vlan_range
       description: Per Switch Overlay VRF VLAN Range
-      default_value: 2000-2299
+#       default_value: 2000-2299
+      computed: true
+      optional: true
       type: String
       example: 2000-2299
     - model_name: default_network
       tf_name: default_network
       description: Default Overlay Network Template For Leafs
-      default_value: Default_Network_Universal
+#       default_value: Default_Network_Universal
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("Default_Network_Universal", "Service_Network_Universal")'
       example: Default_Network_Universal
@@ -1101,7 +1311,9 @@ resource:
     - model_name: default_vrf
       tf_name: default_vrf
       description: Default Overlay VRF Template For Leafs
-      default_value: Default_VRF_Universal
+#       default_value: Default_VRF_Universal
+      computed: true
+      optional: true
       type: String
       example: Default_VRF_Universal
     - model_name: enableRealTimeBackup
@@ -1115,7 +1327,9 @@ resource:
     - model_name: network_extension_template
       tf_name: network_extension_template
       description: Default Overlay Network Template For Borders
-      default_value: Default_Network_Extension_Universal
+#       default_value: Default_Network_Extension_Universal
+      computed: true
+      optional: true
       type: String
       example: Default_Network_Extension_Universal
     - model_name: scheduledTime
@@ -1125,7 +1339,9 @@ resource:
     - model_name: vrf_extension_template
       tf_name: vrf_extension_template
       description: Default Overlay VRF Template For Borders
-      default_value: Default_VRF_Extension_Universal
+#       default_value: Default_VRF_Extension_Universal
+      computed: true
+      optional: true
       type: String
       example: Default_VRF_Extension_Universal
     - model_name: deploy

--- a/generator/defs/fabric_vxlan_msd.yaml
+++ b/generator/defs/fabric_vxlan_msd.yaml
@@ -23,7 +23,9 @@ resource:
     - model_name: ANYCAST_GW_MAC
       tf_name: anycast_gw_mac
       description: Shared MAC address for all leaves
-      default_value: 2020.0000.00aa
+#       default_value: 2020.0000.00aa
+      computed: true
+      optional: true
       type: String
       example: 2020.0000.00aa
     - model_name: BGP_RP_ASN
@@ -33,7 +35,9 @@ resource:
     - model_name: BGW_ROUTING_TAG
       tf_name: bgw_routing_tag
       description: Routing tag associated with IP address of loopback and DCI interfaces
-      default_value: 54321
+#       default_value: 54321
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 54321
@@ -42,7 +46,9 @@ resource:
       description: >-
         Manual, Auto Overlay EVPN Peering to Route Servers, Auto Overlay EVPN
         Direct Peering to Border Gateways
-      default_value: Manual
+#       default_value: Manual
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("Manual", "Centralized_To_Route_Server", "Direct_To_BGWS")'
       example: Manual
@@ -53,7 +59,9 @@ resource:
     - model_name: CLOUDSEC_AUTOCONFIG
       tf_name: cloudsec_autoconfig
       description: Auto Config CloudSec on Border Gateways
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: CLOUDSEC_ENFORCEMENT
@@ -72,13 +80,17 @@ resource:
     - model_name: DCI_SUBNET_RANGE
       tf_name: dci_subnet_range
       description: Address range to assign P2P DCI Links
-      default_value: 10.10.1.0/24
+#       default_value: 10.10.1.0/24
+      computed: true
+      optional: true
       type: String
       example: 10.10.1.0/24
     - model_name: DCI_SUBNET_TARGET_MASK
       tf_name: dci_subnet_target_mask
       description: Target Mask for Subnet Range
-      default_value: 30
+#       default_value: 30
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 30
@@ -87,7 +99,9 @@ resource:
       description: >-
         Multi-Site underlay and overlay control plane convergence time in
         seconds
-      default_value: 300
+#       default_value: 300
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 300
@@ -106,7 +120,9 @@ resource:
     - model_name: ENABLE_PVLAN
       tf_name: enable_pvlan
       description: Enable PVLAN on MSD and its child fabrics
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: ENABLE_RS_REDIST_DIRECT
@@ -119,19 +135,25 @@ resource:
     - model_name: L2_SEGMENT_ID_RANGE
       tf_name: l2_segment_id_range
       description: Overlay Network Identifier Range
-      default_value: 30000-49000
+#       default_value: 30000-49000
+      computed: true
+      optional: true
       type: String
       example: 30000-49000
     - model_name: L3_PARTITION_ID_RANGE
       tf_name: l3_partition_id_range
       description: Overlay VRF Identifier Range
-      default_value: 50000-59000
+#       default_value: 50000-59000
+      computed: true
+      optional: true
       type: String
       example: 50000-59000
     - model_name: LOOPBACK100_IP_RANGE
       tf_name: loopback100_ip_range
       description: Typically Loopback100 IP Address Range
-      default_value: 10.10.0.0/24
+#       default_value: 10.10.0.0/24
+      computed: true
+      optional: true
       type: String
       example: 10.10.0.0/24
     - model_name: MS_IFC_BGP_AUTH_KEY_TYPE
@@ -147,20 +169,26 @@ resource:
     - model_name: MS_IFC_BGP_PASSWORD_ENABLE
       tf_name: ms_ifc_bgp_password_enable
       description: eBGP password for Multi-Site underlay/overlay IFCs
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: MS_LOOPBACK_ID
       tf_name: ms_loopback_id
       description: No description available
-      default_value: 100
+#       default_value: 100
+      computed: true
+      optional: true
       type: Int64
       handle_empty: true
       example: 100
     - model_name: MS_UNDERLAY_AUTOCONFIG
       tf_name: ms_underlay_autoconfig
       description: No description available
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: RP_SERVER_IP
@@ -180,13 +208,17 @@ resource:
     - model_name: TOR_AUTO_DEPLOY
       tf_name: tor_auto_deploy
       description: Enables Overlay VLANs on uplink between ToRs and Leafs
-      default_value: false
+#       default_value: false
+      computed: true
+      optional: true
       type: Bool
       example: false
     - model_name: default_network
       tf_name: default_network
       description: Default Overlay Network Template For Leafs
-      default_value: Default_Network_Universal
+#       default_value: Default_Network_Universal
+      computed: true
+      optional: true
       type: String
       validator: 'OneOf("Default_Network_Universal", "Service_Network_Universal")'
       example: Default_Network_Universal
@@ -197,7 +229,9 @@ resource:
     - model_name: default_vrf
       tf_name: default_vrf
       description: Default Overlay VRF Template For Leafs
-      default_value: Default_VRF_Universal
+#       default_value: Default_VRF_Universal
+      computed: true
+      optional: true
       type: String
       example: Default_VRF_Universal
     - model_name: enableScheduledBackup
@@ -210,7 +244,9 @@ resource:
     - model_name: network_extension_template
       tf_name: network_extension_template
       description: Default Overlay Network Template For Borders
-      default_value: Default_Network_Extension_Universal
+#       default_value: Default_Network_Extension_Universal
+      computed: true
+      optional: true
       type: String
       example: Default_Network_Extension_Universal
     - model_name: scheduledTime
@@ -220,7 +256,9 @@ resource:
     - model_name: vrf_extension_template
       tf_name: vrf_extension_template
       description: Default Overlay VRF Template For Borders
-      default_value: Default_VRF_Extension_Universal
+#       default_value: Default_VRF_Extension_Universal
+      computed: true
+      optional: true
       type: String
       example: Default_VRF_Extension_Universal
     - model_name: deploy

--- a/internal/provider/resources/resource_fabric_ipfm/fabric_ipfm_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_ipfm/fabric_ipfm_resource_gen.go
@@ -6,10 +6,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -25,7 +22,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enable only when IP Authorization is enabled in the AAA Server",
 				MarkdownDescription: "Enable only when IP Authorization is enabled in the AAA Server",
-				Default:             booldefault.StaticBool(false),
 			},
 			"aaa_server_conf": schema.StringAttribute{
 				Optional:            true,
@@ -47,21 +43,18 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP",
 				MarkdownDescription: "Automatic IP Assignment For POAP",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bootstrap_multisubnet": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "lines with # prefix are ignored here",
 				MarkdownDescription: "lines with # prefix are ignored here",
-				Default:             stringdefault.StaticString("#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix"),
 			},
 			"cdp_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable CDP on management interface",
 				MarkdownDescription: "Enable CDP on management interface",
-				Default:             booldefault.StaticBool(false),
 			},
 			"deploy": schema.BoolAttribute{
 				Required:            true,
@@ -78,7 +71,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP From Local DHCP Server",
 				MarkdownDescription: "Automatic IP Assignment For POAP From Local DHCP Server",
-				Default:             booldefault.StaticBool(false),
 			},
 			"dhcp_end": schema.StringAttribute{
 				Optional:            true,
@@ -113,21 +105,18 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Include AAA configs from Manageability tab during device bootup",
 				MarkdownDescription: "Include AAA configs from Manageability tab during device bootup",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_asm": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable groups with receivers sending (*,G) joins",
 				MarkdownDescription: "Enable groups with receivers sending (*,G) joins",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_nbm_passive": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable NBM mode to pim-passive for default VRF",
 				MarkdownDescription: "Enable NBM mode to pim-passive for default VRF",
-				Default:             booldefault.StaticBool(false),
 			},
 			"extra_conf_intra_links": schema.StringAttribute{
 				Optional:            true,
@@ -152,14 +141,12 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("p2p"),
 				},
-				Default: stringdefault.StaticString("p2p"),
 			},
 			"fabric_mtu": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Must be an even number",
 				MarkdownDescription: "Must be an even number",
-				Default:             int64default.StaticInt64(9216),
 			},
 			"fabric_name": schema.StringAttribute{
 				Required:            true,
@@ -174,7 +161,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -186,7 +172,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"isis_auth_key": schema.StringAttribute{
 				Optional:            true,
@@ -211,7 +196,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("level-1", "level-2"),
 				},
-				Default: stringdefault.StaticString("level-2"),
 			},
 			"isis_p2p_enable": schema.BoolAttribute{
 				Optional:            true,
@@ -223,7 +207,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Must be an even number",
 				MarkdownDescription: "Must be an even number",
-				Default:             int64default.StaticInt64(9216),
 			},
 			"link_state_routing": schema.StringAttribute{
 				Optional:            true,
@@ -233,21 +216,18 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("ospf", "is-is"),
 				},
-				Default: stringdefault.StaticString("ospf"),
 			},
 			"link_state_routing_tag": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Routing process tag for the fabric",
 				MarkdownDescription: "Routing process tag for the fabric",
-				Default:             stringdefault.StaticString("1"),
 			},
 			"loopback0_ip_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Routing Loopback IP Address Range",
 				MarkdownDescription: "Routing Loopback IP Address Range",
-				Default:             stringdefault.StaticString("10.2.0.0/22"),
 			},
 			"mgmt_gw": schema.StringAttribute{
 				Optional:            true,
@@ -277,21 +257,18 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("management", "default"),
 				},
-				Default: stringdefault.StaticString("management"),
 			},
 			"ospf_area_id": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "OSPF Area Id in IP address format",
 				MarkdownDescription: "OSPF Area Id in IP address format",
-				Default:             stringdefault.StaticString("0.0.0.0"),
 			},
 			"ospf_auth_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"ospf_auth_key": schema.StringAttribute{
 				Optional:            true,
@@ -308,7 +285,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"pim_hello_auth_key": schema.StringAttribute{
 				Optional:            true,
@@ -320,7 +296,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"power_redundancy_mode": schema.StringAttribute{
 				Optional:            true,
@@ -330,7 +305,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("ps-redundant", "combined", "insrc-redundant"),
 				},
-				Default: stringdefault.StaticString("ps-redundant"),
 			},
 			"ptp_domain_id": schema.Int64Attribute{
 				Optional:            true,
@@ -355,7 +329,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(0),
 			},
 			"rp_ip_range": schema.StringAttribute{
 				Optional:            true,
@@ -372,21 +345,18 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Configure NDFC as a receiver for SNMP traps",
 				MarkdownDescription: "Configure NDFC as a receiver for SNMP traps",
-				Default:             booldefault.StaticBool(true),
 			},
 			"static_underlay_ip_alloc": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Checking this will disable Dynamic Fabric IP Address Allocations",
 				MarkdownDescription: "Checking this will disable Dynamic Fabric IP Address Allocations",
-				Default:             booldefault.StaticBool(false),
 			},
 			"subnet_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Address range to assign Numbered IPs",
 				MarkdownDescription: "Address range to assign Numbered IPs",
-				Default:             stringdefault.StaticString("10.4.0.0/16"),
 			},
 			"subnet_target_mask": schema.Int64Attribute{
 				Optional:            true,
@@ -396,7 +366,6 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.Int64{
 					int64validator.OneOf(30, 31),
 				},
-				Default: int64default.StaticInt64(30),
 			},
 			"syslog_server_ip_list": schema.StringAttribute{
 				Optional:            true,

--- a/internal/provider/resources/resource_fabric_lan_classic/fabric_lan_classic_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_lan_classic/fabric_lan_classic_resource_gen.go
@@ -5,10 +5,7 @@ package resource_fabric_lan_classic
 import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -24,7 +21,6 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enable only, when IP Authorization is enabled in the AAA Server",
 				MarkdownDescription: "Enable only, when IP Authorization is enabled in the AAA Server",
-				Default:             booldefault.StaticBool(false),
 			},
 			"aaa_server_conf": schema.StringAttribute{
 				Optional:            true,
@@ -46,14 +42,12 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "lines with # prefix are ignored here",
 				MarkdownDescription: "lines with # prefix are ignored here",
-				Default:             stringdefault.StaticString("#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix"),
 			},
 			"cdp_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable CDP on management interface",
 				MarkdownDescription: "Enable CDP on management interface",
-				Default:             booldefault.StaticBool(false),
 			},
 			"deploy": schema.BoolAttribute{
 				Required:            true,
@@ -70,7 +64,6 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP From Local DHCP Server",
 				MarkdownDescription: "Automatic IP Assignment For POAP From Local DHCP Server",
-				Default:             booldefault.StaticBool(false),
 			},
 			"dhcp_end": schema.StringAttribute{
 				Optional:            true,
@@ -100,35 +93,30 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enable Netflow on VTEPs",
 				MarkdownDescription: "Enable Netflow on VTEPs",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_nxapi": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable HTTPS NX-API",
 				MarkdownDescription: "Enable HTTPS NX-API",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_nxapi_http": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_realtime_backup": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Backup hourly only if there is any config deployment since last backup",
 				MarkdownDescription: "Backup hourly only if there is any config deployment since last backup",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_scheduled_backup": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Backup at the specified time",
 				MarkdownDescription: "Backup at the specified time",
-				Default:             booldefault.StaticBool(false),
 			},
 			"fabric_freeform": schema.StringAttribute{
 				Optional:            true,
@@ -148,7 +136,6 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -165,14 +152,12 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Import switches with inband connectivity",
 				MarkdownDescription: "Import switches with inband connectivity",
-				Default:             booldefault.StaticBool(false),
 			},
 			"is_read_only": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "If enabled, fabric is only monitored. No configuration will be deployed",
 				MarkdownDescription: "If enabled, fabric is only monitored. No configuration will be deployed",
-				Default:             booldefault.StaticBool(true),
 			},
 			"mgmt_gw": schema.StringAttribute{
 				Optional:            true,
@@ -194,7 +179,6 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"mpls_lb_id": schema.Int64Attribute{
 				Optional:            true,
@@ -231,21 +215,18 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(80),
 			},
 			"nxapi_https_port": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(443),
 			},
 			"pm_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"power_redundancy_mode": schema.StringAttribute{
 				Optional:            true,
@@ -255,7 +236,6 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("ps-redundant", "combined", "insrc-redundant"),
 				},
-				Default: stringdefault.StaticString("ps-redundant"),
 			},
 			"ptp_domain_id": schema.Int64Attribute{
 				Optional:            true,
@@ -277,14 +257,12 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Configure NDFC as a receiver for SNMP traps",
 				MarkdownDescription: "Configure NDFC as a receiver for SNMP traps",
-				Default:             booldefault.StaticBool(true),
 			},
 			"subinterface_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Per Border Dot1q Range For VRF Lite Connectivity",
 				MarkdownDescription: "Per Border Dot1q Range For VRF Lite Connectivity",
-				Default:             stringdefault.StaticString("2-511"),
 			},
 		},
 		Description:         "Resource to configure and manage a LAN Classic Fabric",

--- a/internal/provider/resources/resource_fabric_msite_ext_net/fabric_msite_ext_net_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_msite_ext_net/fabric_msite_ext_net_resource_gen.go
@@ -5,10 +5,7 @@ package resource_fabric_msite_ext_net
 import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -24,7 +21,6 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enable only, when IP Authorization is enabled in the AAA Server",
 				MarkdownDescription: "Enable only, when IP Authorization is enabled in the AAA Server",
-				Default:             booldefault.StaticBool(false),
 			},
 			"aaa_server_conf": schema.StringAttribute{
 				Optional:            true,
@@ -56,14 +52,12 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "lines with # prefix are ignored here",
 				MarkdownDescription: "lines with # prefix are ignored here",
-				Default:             stringdefault.StaticString("#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix"),
 			},
 			"cdp_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable CDP on management interface",
 				MarkdownDescription: "Enable CDP on management interface",
-				Default:             booldefault.StaticBool(false),
 			},
 			"deploy": schema.BoolAttribute{
 				Required:            true,
@@ -80,7 +74,6 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP From Local DHCP Server",
 				MarkdownDescription: "Automatic IP Assignment For POAP From Local DHCP Server",
-				Default:             booldefault.StaticBool(false),
 			},
 			"dhcp_end": schema.StringAttribute{
 				Optional:            true,
@@ -115,21 +108,18 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enable Netflow on VTEPs",
 				MarkdownDescription: "Enable Netflow on VTEPs",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_nxapi": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable HTTPS NX-API",
 				MarkdownDescription: "Enable HTTPS NX-API",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_nxapi_http": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_realtime_backup": schema.BoolAttribute{
 				Optional:            true,
@@ -159,7 +149,6 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -176,7 +165,6 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Import switches with inband connectivity",
 				MarkdownDescription: "Import switches with inband connectivity",
-				Default:             booldefault.StaticBool(false),
 			},
 			"intf_stat_load_interval": schema.Int64Attribute{
 				Optional:            true,
@@ -188,7 +176,6 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "If enabled, fabric is only monitored. No configuration will be deployed",
 				MarkdownDescription: "If enabled, fabric is only monitored. No configuration will be deployed",
-				Default:             booldefault.StaticBool(true),
 			},
 			"mgmt_gw": schema.StringAttribute{
 				Optional:            true,
@@ -210,7 +197,6 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"mpls_lb_id": schema.Int64Attribute{
 				Optional:            true,
@@ -247,21 +233,18 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(80),
 			},
 			"nxapi_https_port": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(443),
 			},
 			"pm_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"pnp_enable": schema.BoolAttribute{
 				Optional:            true,
@@ -276,7 +259,6 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("ps-redundant", "combined", "insrc-redundant"),
 				},
-				Default: stringdefault.StaticString("ps-redundant"),
 			},
 			"ptp_domain_id": schema.Int64Attribute{
 				Optional:            true,
@@ -298,14 +280,12 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Configure NDFC as a receiver for SNMP traps",
 				MarkdownDescription: "Configure NDFC as a receiver for SNMP traps",
-				Default:             booldefault.StaticBool(true),
 			},
 			"subinterface_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Per Border Dot1q Range For VRF Lite Connectivity",
 				MarkdownDescription: "Per Border Dot1q Range For VRF Lite Connectivity",
-				Default:             stringdefault.StaticString("2-511"),
 			},
 		},
 		Description:         "Resource to configure an Multi-Site Network Fabric",

--- a/internal/provider/resources/resource_fabric_vxlan_evpn/fabric_vxlan_evpn_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_vxlan_evpn/fabric_vxlan_evpn_resource_gen.go
@@ -6,10 +6,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -25,7 +22,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enable only, when IP Authorization is enabled in the AAA Server",
 				MarkdownDescription: "Enable only, when IP Authorization is enabled in the AAA Server",
-				Default:             booldefault.StaticBool(false),
 			},
 			"aaa_server_conf": schema.StringAttribute{
 				Optional:            true,
@@ -37,28 +33,24 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "For Primary VTEP IP Advertisement As Next-Hop Of Prefix Routes",
 				MarkdownDescription: "For Primary VTEP IP Advertisement As Next-Hop Of Prefix Routes",
-				Default:             booldefault.StaticBool(false),
 			},
 			"advertise_pip_on_border": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable advertise-pip on vPC borders and border gateways only. Applicable only when vPC advertise-pip is not enabled",
 				MarkdownDescription: "Enable advertise-pip on vPC borders and border gateways only. Applicable only when vPC advertise-pip is not enabled",
-				Default:             booldefault.StaticBool(true),
 			},
 			"anycast_bgw_advertise_pip": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "To advertise Anycast Border Gateway PIP as VTEP. Effective on MSD fabric Recalculate Config",
 				MarkdownDescription: "To advertise Anycast Border Gateway PIP as VTEP. Effective on MSD fabric Recalculate Config",
-				Default:             booldefault.StaticBool(false),
 			},
 			"anycast_gw_mac": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Shared MAC address for all leafs (xxxx.xxxx.xxxx)",
 				MarkdownDescription: "Shared MAC address for all leafs (xxxx.xxxx.xxxx)",
-				Default:             stringdefault.StaticString("2020.0000.00aa"),
 			},
 			"anycast_lb_id": schema.Int64Attribute{
 				Optional:            true,
@@ -70,35 +62,30 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Anycast or Phantom RP IP Address Range",
 				MarkdownDescription: "Anycast or Phantom RP IP Address Range",
-				Default:             stringdefault.StaticString("10.254.254.0/24"),
 			},
 			"auto_symmetric_default_vrf": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Whether to auto generate Default VRF interface and BGP peering configuration on managed neighbor devices. If set, auto created VRF Lite IFC links will have Auto Deploy Default VRF for Peer enabled.",
 				MarkdownDescription: "Whether to auto generate Default VRF interface and BGP peering configuration on managed neighbor devices. If set, auto created VRF Lite IFC links will have Auto Deploy Default VRF for Peer enabled.",
-				Default:             booldefault.StaticBool(false),
 			},
 			"auto_symmetric_vrf_lite": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Whether to auto generate VRF LITE sub-interface and BGP peering configuration on managed neighbor devices. If set, auto created VRF Lite IFC links will have Auto Deploy for Peer enabled.",
 				MarkdownDescription: "Whether to auto generate VRF LITE sub-interface and BGP peering configuration on managed neighbor devices. If set, auto created VRF Lite IFC links will have Auto Deploy for Peer enabled.",
-				Default:             booldefault.StaticBool(false),
 			},
 			"auto_unique_vrf_lite_ip_prefix": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "When enabled, IP prefix allocated to the VRF LITE IFC is not reused on VRF extension over VRF LITE IFC. Instead, unique IP Subnet is allocated for each VRF extension over VRF LITE IFC.",
 				MarkdownDescription: "When enabled, IP prefix allocated to the VRF LITE IFC is not reused on VRF extension over VRF LITE IFC. Instead, unique IP Subnet is allocated for each VRF extension over VRF LITE IFC.",
-				Default:             booldefault.StaticBool(false),
 			},
 			"auto_vrflite_ifc_default_vrf": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Whether to auto generate Default VRF interface and BGP peering configuration on VRF LITE IFC auto deployment. If set, auto created VRF Lite IFC links will have Auto Deploy Default VRF enabled.",
 				MarkdownDescription: "Whether to auto generate Default VRF interface and BGP peering configuration on VRF LITE IFC auto deployment. If set, auto created VRF Lite IFC links will have Auto Deploy Default VRF enabled.",
-				Default:             booldefault.StaticBool(false),
 			},
 			"banner": schema.StringAttribute{
 				Optional:            true,
@@ -110,7 +97,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Valid for P2P Interfaces only",
 				MarkdownDescription: "Valid for P2P Interfaces only",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bfd_auth_key": schema.StringAttribute{
 				Optional:            true,
@@ -127,35 +113,30 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Valid for IPv4 Underlay only",
 				MarkdownDescription: "Valid for IPv4 Underlay only",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bfd_ibgp_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bfd_isis_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bfd_ospf_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bfd_pim_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bgp_as": schema.StringAttribute{
 				Required:            true,
@@ -167,7 +148,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bgp_auth_key": schema.StringAttribute{
 				Optional:            true,
@@ -182,14 +162,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.Int64{
 					int64validator.OneOf(3, 7),
 				},
-				Default: int64default.StaticInt64(3),
 			},
 			"bgp_lb_id": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(0),
 			},
 			"bootstrap_conf": schema.StringAttribute{
 				Optional:            true,
@@ -201,35 +179,30 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP",
 				MarkdownDescription: "Automatic IP Assignment For POAP",
-				Default:             booldefault.StaticBool(false),
 			},
 			"bootstrap_multisubnet": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "'lines with # prefix are ignored here'",
 				MarkdownDescription: "'lines with # prefix are ignored here'",
-				Default:             stringdefault.StaticString("#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix"),
 			},
 			"brownfield_network_name_format": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Generated network name should be < 64 characters",
 				MarkdownDescription: "Generated network name should be < 64 characters",
-				Default:             stringdefault.StaticString("Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$"),
 			},
 			"brownfield_skip_overlay_network_attachments": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable to skip overlay network interface attachments for Brownfield and Host Port Resync cases",
 				MarkdownDescription: "Enable to skip overlay network interface attachments for Brownfield and Host Port Resync cases",
-				Default:             booldefault.StaticBool(false),
 			},
 			"cdp_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable CDP on management interface",
 				MarkdownDescription: "Enable CDP on management interface",
-				Default:             booldefault.StaticBool(false),
 			},
 			"copp_policy": schema.StringAttribute{
 				Optional:            true,
@@ -239,21 +212,18 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("dense", "lenient", "moderate", "strict", "manual"),
 				},
-				Default: stringdefault.StaticString("strict"),
 			},
 			"dci_subnet_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Address range to assign P2P Interfabric Connections",
 				MarkdownDescription: "Address range to assign P2P Interfabric Connections",
-				Default:             stringdefault.StaticString("10.33.0.0/16"),
 			},
 			"dci_subnet_target_mask": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(30),
 			},
 			"default_network": schema.StringAttribute{
 				Optional:            true,
@@ -263,7 +233,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("Default_Network_Universal", "Service_Network_Universal"),
 				},
-				Default: stringdefault.StaticString("Default_Network_Universal"),
 			},
 			"default_pvlan_sec_network": schema.StringAttribute{
 				Optional:            true,
@@ -278,7 +247,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("queuing_policy_default_4q_cloudscale", "queuing_policy_default_8q_cloudscale"),
 				},
-				Default: stringdefault.StaticString("queuing_policy_default_8q_cloudscale"),
 			},
 			"default_queuing_policy_other": schema.StringAttribute{
 				Optional:            true,
@@ -288,7 +256,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("queuing_policy_default_other"),
 				},
-				Default: stringdefault.StaticString("queuing_policy_default_other"),
 			},
 			"default_queuing_policy_r_series": schema.StringAttribute{
 				Optional:            true,
@@ -298,14 +265,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("queuing_policy_default_r_series"),
 				},
-				Default: stringdefault.StaticString("queuing_policy_default_r_series"),
 			},
 			"default_vrf": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Default Overlay VRF Template For Leafs",
 				MarkdownDescription: "Default Overlay VRF Template For Leafs",
-				Default:             stringdefault.StaticString("Default_VRF_Universal"),
 			},
 			"default_vrf_redis_bgp_rmap": schema.StringAttribute{
 				Optional:            true,
@@ -327,7 +292,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP From Local DHCP Server",
 				MarkdownDescription: "Automatic IP Assignment For POAP From Local DHCP Server",
-				Default:             booldefault.StaticBool(false),
 			},
 			"dhcp_end": schema.StringAttribute{
 				Optional:            true,
@@ -362,70 +326,60 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Include AAA configs from Manageability tab during device bootup",
 				MarkdownDescription: "Include AAA configs from Manageability tab during device bootup",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_default_queuing_policy": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_fabric_vpc_domain_id": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "(Not Recommended)",
 				MarkdownDescription: "(Not Recommended)",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_macsec": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable MACsec in the fabric",
 				MarkdownDescription: "Enable MACsec in the fabric",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_netflow": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable Netflow on VTEPs",
 				MarkdownDescription: "Enable Netflow on VTEPs",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_ngoam": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable the Next Generation (NG) OAM feature for all switches in the fabric to aid in trouble-shooting VXLAN EVPN fabrics",
 				MarkdownDescription: "Enable the Next Generation (NG) OAM feature for all switches in the fabric to aid in trouble-shooting VXLAN EVPN fabrics",
-				Default:             booldefault.StaticBool(true),
 			},
 			"enable_nxapi": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable HTTPS NX-API",
 				MarkdownDescription: "Enable HTTPS NX-API",
-				Default:             booldefault.StaticBool(true),
 			},
 			"enable_nxapi_http": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(true),
 			},
 			"enable_pbr": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "When ESR option is ePBR, enable ePBR will enable pbr, sla sender and epbr features on the switch",
 				MarkdownDescription: "When ESR option is ePBR, enable ePBR will enable pbr, sla sender and epbr features on the switch",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_pvlan": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable PVLAN on switches except spines and super spines",
 				MarkdownDescription: "Enable PVLAN on switches except spines and super spines",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_realtime_backup": schema.BoolAttribute{
 				Optional:            true,
@@ -442,21 +396,18 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(true),
 			},
 			"enable_trm": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "For Overlay Multicast Support In VXLAN Fabrics",
 				MarkdownDescription: "For Overlay Multicast Support In VXLAN Fabrics",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_vpc_peer_link_native_vlan": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"extra_conf_intra_links": schema.StringAttribute{
 				Optional:            true,
@@ -486,14 +437,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("p2p", "unnumbered"),
 				},
-				Default: stringdefault.StaticString("p2p"),
 			},
 			"fabric_mtu": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Must be an even number",
 				MarkdownDescription: "Must be an even number",
-				Default:             int64default.StaticInt64(9216),
 			},
 			"fabric_name": schema.StringAttribute{
 				Required:            true,
@@ -513,21 +462,18 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Qos on spines for guaranteed delivery of vPC Fabric Peering communication",
 				MarkdownDescription: "Qos on spines for guaranteed delivery of vPC Fabric Peering communication",
-				Default:             booldefault.StaticBool(false),
 			},
 			"fabric_vpc_qos_policy_name": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Qos Policy name should be same on all spines",
 				MarkdownDescription: "Qos Policy name should be same on all spines",
-				Default:             stringdefault.StaticString("spine_qos_for_fabric_vpc_peering"),
 			},
 			"feature_ptp": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"grfield_debug_flag": schema.StringAttribute{
 				Optional:            true,
@@ -537,21 +483,18 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("Enable", "Disable"),
 				},
-				Default: stringdefault.StaticString("Disable"),
 			},
 			"hd_time": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "NVE Source Inteface HoldDown Time in seconds",
 				MarkdownDescription: "NVE Source Inteface HoldDown Time in seconds",
-				Default:             int64default.StaticInt64(180),
 			},
 			"host_intf_admin_state": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(true),
 			},
 			"ibgp_peer_template": schema.StringAttribute{
 				Optional:            true,
@@ -578,14 +521,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Manage switches with only Inband connectivity",
 				MarkdownDescription: "Manage switches with only Inband connectivity",
-				Default:             booldefault.StaticBool(false),
 			},
 			"isis_auth_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"isis_auth_key": schema.StringAttribute{
 				Optional:            true,
@@ -610,7 +551,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("level-1", "level-2"),
 				},
-				Default: stringdefault.StaticString("level-2"),
 			},
 			"isis_overload_elapse_time": schema.Int64Attribute{
 				Optional:            true,
@@ -632,21 +572,18 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Must be an even number",
 				MarkdownDescription: "Must be an even number",
-				Default:             int64default.StaticInt64(9216),
 			},
 			"l2_segment_id_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Overlay Network Identifier Range",
 				MarkdownDescription: "Overlay Network Identifier Range",
-				Default:             stringdefault.StaticString("30000-49000"),
 			},
 			"l3_partition_id_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Overlay VRF Identifier Range",
 				MarkdownDescription: "Overlay VRF Identifier Range",
-				Default:             stringdefault.StaticString("50000-59000"),
 			},
 			"l3vni_mcast_group": schema.StringAttribute{
 				Optional:            true,
@@ -661,21 +598,18 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("ospf", "is-is"),
 				},
-				Default: stringdefault.StaticString("ospf"),
 			},
 			"link_state_routing_tag": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Underlay Routing Process Tag",
 				MarkdownDescription: "Underlay Routing Process Tag",
-				Default:             stringdefault.StaticString("UNDERLAY"),
 			},
 			"loopback0_ip_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Typically Loopback0 IP Address Range",
 				MarkdownDescription: "Typically Loopback0 IP Address Range",
-				Default:             stringdefault.StaticString("10.2.0.0/22"),
 			},
 			"loopback0_ipv6_range": schema.StringAttribute{
 				Optional:            true,
@@ -687,7 +621,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Typically Loopback1 IP Address Range",
 				MarkdownDescription: "Typically Loopback1 IP Address Range",
-				Default:             stringdefault.StaticString("10.3.0.0/22"),
 			},
 			"loopback1_ipv6_range": schema.StringAttribute{
 				Optional:            true,
@@ -744,7 +677,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"mpls_lb_id": schema.Int64Attribute{
 				Optional:            true,
@@ -766,7 +698,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Multicast pool prefix between 8 to 30. A multicast group IP from this pool is used for BUM traffic for each overlay network.",
 				MarkdownDescription: "Multicast pool prefix between 8 to 30. A multicast group IP from this pool is used for BUM traffic for each overlay network.",
-				Default:             stringdefault.StaticString("239.1.1.0/25"),
 			},
 			"netflow_exporter_list": schema.StringAttribute{
 				Optional:            true,
@@ -788,14 +719,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Default Overlay Network Template For Borders",
 				MarkdownDescription: "Default Overlay Network Template For Borders",
-				Default:             stringdefault.StaticString("Default_Network_Extension_Universal"),
 			},
 			"network_vlan_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Per Switch Overlay Network VLAN Range",
 				MarkdownDescription: "Per Switch Overlay Network VLAN Range",
-				Default:             stringdefault.StaticString("2300-2999"),
 			},
 			"ntp_server_ip_list": schema.StringAttribute{
 				Optional:            true,
@@ -812,42 +741,36 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(1),
 			},
 			"nxapi_http_port": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(80),
 			},
 			"nxapi_https_port": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(443),
 			},
 			"object_tracking_number_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Per switch tracked object ID Range",
 				MarkdownDescription: "Per switch tracked object ID Range",
-				Default:             stringdefault.StaticString("100-299"),
 			},
 			"ospf_area_id": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "OSPF Area Id in IP address format",
 				MarkdownDescription: "OSPF Area Id in IP address format",
-				Default:             stringdefault.StaticString("0.0.0.0"),
 			},
 			"ospf_auth_enable": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"ospf_auth_key": schema.StringAttribute{
 				Optional:            true,
@@ -864,14 +787,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "VRF/Network configuration using config-profile or CLI",
 				MarkdownDescription: "VRF/Network configuration using config-profile or CLI",
-				Default:             stringdefault.StaticString("cli"),
 			},
 			"per_vrf_loopback_auto_provision": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Auto provision a loopback on a VTEP on VRF attachment",
 				MarkdownDescription: "Auto provision a loopback on a VTEP on VRF attachment",
-				Default:             booldefault.StaticBool(false),
 			},
 			"per_vrf_loopback_ip_range": schema.StringAttribute{
 				Optional:            true,
@@ -903,7 +824,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Valid for IPv4 Underlay only",
 				MarkdownDescription: "Valid for IPv4 Underlay only",
-				Default:             booldefault.StaticBool(false),
 			},
 			"pim_hello_auth_key": schema.StringAttribute{
 				Optional:            true,
@@ -915,7 +835,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"power_redundancy_mode": schema.StringAttribute{
 				Optional:            true,
@@ -925,7 +844,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("ps-redundant", "combined", "insrc-redundant"),
 				},
-				Default: stringdefault.StaticString("ps-redundant"),
 			},
 			"ptp_domain_id": schema.Int64Attribute{
 				Optional:            true,
@@ -945,14 +863,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("Multicast", "Ingress"),
 				},
-				Default: stringdefault.StaticString("Multicast"),
 			},
 			"route_map_sequence_number_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             stringdefault.StaticString("1-65534"),
 			},
 			"router_id_range": schema.StringAttribute{
 				Optional:            true,
@@ -967,14 +883,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.Int64{
 					int64validator.OneOf(2, 4),
 				},
-				Default: int64default.StaticInt64(2),
 			},
 			"rp_lb_id": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(254),
 			},
 			"rp_mode": schema.StringAttribute{
 				Optional:            true,
@@ -984,7 +898,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("asm", "bidir"),
 				},
-				Default: stringdefault.StaticString("asm"),
 			},
 			"rr_count": schema.Int64Attribute{
 				Optional:            true,
@@ -994,7 +907,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.Int64{
 					int64validator.OneOf(2, 4),
 				},
-				Default: int64default.StaticInt64(2),
 			},
 			"scheduled_time": schema.StringAttribute{
 				Optional:            true,
@@ -1011,7 +923,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Per Switch Overlay Service Network VLAN Range",
 				MarkdownDescription: "Per Switch Overlay Service Network VLAN Range",
-				Default:             stringdefault.StaticString("3000-3199"),
 			},
 			"site_id": schema.StringAttribute{
 				Optional:            true,
@@ -1024,14 +935,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Per switch SLA ID Range",
 				MarkdownDescription: "Per switch SLA ID Range",
-				Default:             stringdefault.StaticString("10000-19999"),
 			},
 			"snmp_server_host_trap": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Configure NDFC as a receiver for SNMP traps",
 				MarkdownDescription: "Configure NDFC as a receiver for SNMP traps",
-				Default:             booldefault.StaticBool(true),
 			},
 			"spine_switch_core_interfaces": schema.StringAttribute{
 				Optional:            true,
@@ -1043,7 +952,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Checking this will disable Dynamic Underlay IP Address Allocations",
 				MarkdownDescription: "Checking this will disable Dynamic Underlay IP Address Allocations",
-				Default:             booldefault.StaticBool(false),
 			},
 			"stp_bridge_priority": schema.Int64Attribute{
 				Optional:            true,
@@ -1058,7 +966,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("rpvst+", "mst", "unmanaged"),
 				},
-				Default: stringdefault.StaticString("unmanaged"),
 			},
 			"stp_vlan_range": schema.StringAttribute{
 				Optional:            true,
@@ -1070,21 +977,18 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enable bi-directional compliance checks to flag additional configs in the running config that are not in the intent/expected config",
 				MarkdownDescription: "Enable bi-directional compliance checks to flag additional configs in the running config that are not in the intent/expected config",
-				Default:             booldefault.StaticBool(false),
 			},
 			"subinterface_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Per Border Dot1q Range For VRF Lite Connectivity",
 				MarkdownDescription: "Per Border Dot1q Range For VRF Lite Connectivity",
-				Default:             stringdefault.StaticString("2-511"),
 			},
 			"subnet_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Address range to assign Numbered and Peer Link SVI IPs",
 				MarkdownDescription: "Address range to assign Numbered and Peer Link SVI IPs",
-				Default:             stringdefault.StaticString("10.4.0.0/16"),
 			},
 			"subnet_target_mask": schema.Int64Attribute{
 				Optional:            true,
@@ -1094,7 +998,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.Int64{
 					int64validator.OneOf(30, 31),
 				},
-				Default: int64default.StaticInt64(30),
 			},
 			"syslog_server_ip_list": schema.StringAttribute{
 				Optional:            true,
@@ -1116,14 +1019,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "TCAM commands are automatically generated for VxLAN and vPC Fabric Peering when Enabled",
 				MarkdownDescription: "TCAM commands are automatically generated for VxLAN and vPC Fabric Peering when Enabled",
-				Default:             booldefault.StaticBool(true),
 			},
 			"underlay_is_v6": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "If not enabled, IPv4 underlay is used",
 				MarkdownDescription: "If not enabled, IPv4 underlay is used",
-				Default:             booldefault.StaticBool(false),
 			},
 			"unnum_bootstrap_lb_id": schema.Int64Attribute{
 				Optional:            true,
@@ -1145,7 +1046,6 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "If not enabled, Spine-Leaf interfaces will use global IPv6 addresses",
 				MarkdownDescription: "If not enabled, Spine-Leaf interfaces will use global IPv6 addresses",
-				Default:             booldefault.StaticBool(true),
 			},
 			"v6_subnet_range": schema.StringAttribute{
 				Optional:            true,
@@ -1160,35 +1060,30 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.Int64{
 					int64validator.OneOf(126, 127),
 				},
-				Default: int64default.StaticInt64(126),
 			},
 			"vpc_auto_recovery_time": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(360),
 			},
 			"vpc_delay_restore": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(150),
 			},
 			"vpc_domain_id_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "vPC Domain id range to use for new pairings",
 				MarkdownDescription: "vPC Domain id range to use for new pairings",
-				Default:             stringdefault.StaticString("1-1000"),
 			},
 			"vpc_enable_ipv6_nd_sync": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Enable IPv6 ND synchronization between vPC peers",
 				MarkdownDescription: "Enable IPv6 ND synchronization between vPC peers",
-				Default:             booldefault.StaticBool(true),
 			},
 			"vpc_peer_keep_alive_option": schema.StringAttribute{
 				Optional:            true,
@@ -1198,28 +1093,24 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("loopback", "management"),
 				},
-				Default: stringdefault.StaticString("management"),
 			},
 			"vpc_peer_link_po": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(500),
 			},
 			"vpc_peer_link_vlan": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "VLAN range for vPC Peer Link SVI",
 				MarkdownDescription: "VLAN range for vPC Peer Link SVI",
-				Default:             int64default.StaticInt64(3600),
 			},
 			"vrf_extension_template": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Default Overlay VRF Template For Borders",
 				MarkdownDescription: "Default Overlay VRF Template For Borders",
-				Default:             stringdefault.StaticString("Default_VRF_Extension_Universal"),
 			},
 			"vrf_lite_autoconfig": schema.StringAttribute{
 				Optional:            true,
@@ -1229,14 +1120,12 @@ func FabricVxlanEvpnResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("Manual", "Back2Back&ToExternal"),
 				},
-				Default: stringdefault.StaticString("Manual"),
 			},
 			"vrf_vlan_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Per Switch Overlay VRF VLAN Range",
 				MarkdownDescription: "Per Switch Overlay VRF VLAN Range",
-				Default:             stringdefault.StaticString("2000-2299"),
 			},
 		},
 		Description:         "Resource to configure and manage a VXLAN EVPN Fabric",

--- a/internal/provider/resources/resource_fabric_vxlan_msd/fabric_vxlan_msd_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_vxlan_msd/fabric_vxlan_msd_resource_gen.go
@@ -6,10 +6,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -25,7 +22,6 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Shared MAC address for all leaves",
 				MarkdownDescription: "Shared MAC address for all leaves",
-				Default:             stringdefault.StaticString("2020.0000.00aa"),
 			},
 			"bgp_rp_asn": schema.StringAttribute{
 				Optional:            true,
@@ -37,7 +33,6 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Routing tag associated with IP address of loopback and DCI interfaces",
 				MarkdownDescription: "Routing tag associated with IP address of loopback and DCI interfaces",
-				Default:             int64default.StaticInt64(54321),
 			},
 			"border_gwy_connections": schema.StringAttribute{
 				Optional:            true,
@@ -47,7 +42,6 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("Manual", "Centralized_To_Route_Server", "Direct_To_BGWS"),
 				},
-				Default: stringdefault.StaticString("Manual"),
 			},
 			"cloudsec_algorithm": schema.StringAttribute{
 				Optional:            true,
@@ -59,7 +53,6 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Auto Config CloudSec on Border Gateways",
 				MarkdownDescription: "Auto Config CloudSec on Border Gateways",
-				Default:             booldefault.StaticBool(false),
 			},
 			"cloudsec_enforcement": schema.StringAttribute{
 				Optional:            true,
@@ -81,14 +74,12 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Address range to assign P2P DCI Links",
 				MarkdownDescription: "Address range to assign P2P DCI Links",
-				Default:             stringdefault.StaticString("10.10.1.0/24"),
 			},
 			"dci_subnet_target_mask": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Target Mask for Subnet Range",
 				MarkdownDescription: "Target Mask for Subnet Range",
-				Default:             int64default.StaticInt64(30),
 			},
 			"default_network": schema.StringAttribute{
 				Optional:            true,
@@ -98,7 +89,6 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.String{
 					stringvalidator.OneOf("Default_Network_Universal", "Service_Network_Universal"),
 				},
-				Default: stringdefault.StaticString("Default_Network_Universal"),
 			},
 			"default_pvlan_sec_network": schema.StringAttribute{
 				Optional:            true,
@@ -110,14 +100,12 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Default Overlay VRF Template For Leafs",
 				MarkdownDescription: "Default Overlay VRF Template For Leafs",
-				Default:             stringdefault.StaticString("Default_VRF_Universal"),
 			},
 			"delay_restore": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Multi-Site underlay and overlay control plane convergence time in seconds",
 				MarkdownDescription: "Multi-Site underlay and overlay control plane convergence time in seconds",
-				Default:             int64default.StaticInt64(300),
 			},
 			"deploy": schema.BoolAttribute{
 				Required:            true,
@@ -149,7 +137,6 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enable PVLAN on MSD and its child fabrics",
 				MarkdownDescription: "Enable PVLAN on MSD and its child fabrics",
-				Default:             booldefault.StaticBool(false),
 			},
 			"enable_rs_redist_direct": schema.BoolAttribute{
 				Optional:            true,
@@ -179,21 +166,18 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Overlay Network Identifier Range",
 				MarkdownDescription: "Overlay Network Identifier Range",
-				Default:             stringdefault.StaticString("30000-49000"),
 			},
 			"l3_partition_id_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Overlay VRF Identifier Range",
 				MarkdownDescription: "Overlay VRF Identifier Range",
-				Default:             stringdefault.StaticString("50000-59000"),
 			},
 			"loopback100_ip_range": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Typically Loopback100 IP Address Range",
 				MarkdownDescription: "Typically Loopback100 IP Address Range",
-				Default:             stringdefault.StaticString("10.10.0.0/24"),
 			},
 			"ms_ifc_bgp_auth_key_type": schema.Int64Attribute{
 				Optional:            true,
@@ -213,28 +197,24 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "eBGP password for Multi-Site underlay/overlay IFCs",
 				MarkdownDescription: "eBGP password for Multi-Site underlay/overlay IFCs",
-				Default:             booldefault.StaticBool(false),
 			},
 			"ms_loopback_id": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             int64default.StaticInt64(100),
 			},
 			"ms_underlay_autoconfig": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
-				Default:             booldefault.StaticBool(false),
 			},
 			"network_extension_template": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Default Overlay Network Template For Borders",
 				MarkdownDescription: "Default Overlay Network Template For Borders",
-				Default:             stringdefault.StaticString("Default_Network_Extension_Universal"),
 			},
 			"rp_server_ip": schema.StringAttribute{
 				Optional:            true,
@@ -256,14 +236,12 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Enables Overlay VLANs on uplink between ToRs and Leafs",
 				MarkdownDescription: "Enables Overlay VLANs on uplink between ToRs and Leafs",
-				Default:             booldefault.StaticBool(false),
 			},
 			"vrf_extension_template": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Default Overlay VRF Template For Borders",
 				MarkdownDescription: "Default Overlay VRF Template For Borders",
-				Default:             stringdefault.StaticString("Default_VRF_Extension_Universal"),
 			},
 		},
 		Description:         "Resource to configure and manage a VXLAN MSD Fabric",

--- a/internal/provider/test_utils_fabric_ipfm_test.go
+++ b/internal/provider/test_utils_fabric_ipfm_test.go
@@ -26,8 +26,6 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.AaaRemoteIpEnabled != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_remote_ip_enabled").String(), c.AaaRemoteIpEnabled))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_remote_ip_enabled").String(), "false"))
 	}
 	if c.AaaServerConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_server_conf").String(), c.AaaServerConf))
@@ -40,23 +38,15 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.BootstrapEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_enable").String(), c.BootstrapEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_enable").String(), "false"))
 	}
 	if c.BootstrapMultisubnet != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), c.BootstrapMultisubnet))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), "#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix"))
 	}
 	if c.CdpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), c.CdpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), "false"))
 	}
 	if c.DhcpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), c.DhcpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), "false"))
 	}
 	if c.DhcpEnd != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end").String(), c.DhcpEnd))
@@ -75,18 +65,12 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.EnableAaa != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_aaa").String(), c.EnableAaa))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_aaa").String(), "false"))
 	}
 	if c.EnableAsm != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_asm").String(), c.EnableAsm))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_asm").String(), "false"))
 	}
 	if c.EnableNbmPassive != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nbm_passive").String(), c.EnableNbmPassive))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nbm_passive").String(), "false"))
 	}
 	if c.ExtraConfIntraLinks != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("extra_conf_intra_links").String(), c.ExtraConfIntraLinks))
@@ -99,23 +83,15 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.FabricInterfaceType != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_interface_type").String(), c.FabricInterfaceType))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_interface_type").String(), "p2p"))
 	}
 	if c.FabricMtu != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_mtu").String(), strconv.Itoa(int(*c.FabricMtu))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_mtu").String(), "9216"))
 	}
 	if c.FeaturePtp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), c.FeaturePtp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), "false"))
 	}
 	if c.IsisAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_auth_enable").String(), c.IsisAuthEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_auth_enable").String(), "false"))
 	}
 	if c.IsisAuthKey != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_auth_key").String(), c.IsisAuthKey))
@@ -128,31 +104,21 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.IsisLevel != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_level").String(), c.IsisLevel))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_level").String(), "level-2"))
 	}
 	if c.IsisP2pEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_p2p_enable").String(), c.IsisP2pEnable))
 	}
 	if c.L2HostIntfMtu != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_host_intf_mtu").String(), strconv.Itoa(int(*c.L2HostIntfMtu))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_host_intf_mtu").String(), "9216"))
 	}
 	if c.LinkStateRouting != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing").String(), c.LinkStateRouting))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing").String(), "ospf"))
 	}
 	if c.LinkStateRoutingTag != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing_tag").String(), c.LinkStateRoutingTag))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing_tag").String(), "1"))
 	}
 	if c.Loopback0IpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback0_ip_range").String(), c.Loopback0IpRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback0_ip_range").String(), "10.2.0.0/22"))
 	}
 	if c.MgmtGw != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw").String(), c.MgmtGw))
@@ -168,18 +134,12 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.NxapiVrf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_vrf").String(), c.NxapiVrf))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_vrf").String(), "management"))
 	}
 	if c.OspfAreaId != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_area_id").String(), c.OspfAreaId))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_area_id").String(), "0.0.0.0"))
 	}
 	if c.OspfAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_auth_enable").String(), c.OspfAuthEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_auth_enable").String(), "false"))
 	}
 	if c.OspfAuthKey != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_auth_key").String(), c.OspfAuthKey))
@@ -189,21 +149,15 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.PimHelloAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pim_hello_auth_enable").String(), c.PimHelloAuthEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pim_hello_auth_enable").String(), "false"))
 	}
 	if c.PimHelloAuthKey != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pim_hello_auth_key").String(), c.PimHelloAuthKey))
 	}
 	if c.PmEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), c.PmEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), "false"))
 	}
 	if c.PowerRedundancyMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), c.PowerRedundancyMode))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), "ps-redundant"))
 	}
 	if c.PtpDomainId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ptp_domain_id").String(), strconv.Itoa(int(*c.PtpDomainId))))
@@ -216,8 +170,6 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.RoutingLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("routing_lb_id").String(), strconv.Itoa(int(*c.RoutingLbId))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("routing_lb_id").String(), "0"))
 	}
 	if c.RpIpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_ip_range").String(), c.RpIpRange))
@@ -227,23 +179,15 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.SnmpServerHostTrap != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), c.SnmpServerHostTrap))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), "true"))
 	}
 	if c.StaticUnderlayIpAlloc != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("static_underlay_ip_alloc").String(), c.StaticUnderlayIpAlloc))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("static_underlay_ip_alloc").String(), "false"))
 	}
 	if c.SubnetRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subnet_range").String(), c.SubnetRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subnet_range").String(), "10.4.0.0/16"))
 	}
 	if c.SubnetTargetMask != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subnet_target_mask").String(), strconv.Itoa(int(*c.SubnetTargetMask))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subnet_target_mask").String(), "30"))
 	}
 	if c.SyslogServerIpList != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("syslog_server_ip_list").String(), c.SyslogServerIpList))

--- a/internal/provider/test_utils_fabric_lan_classic_test.go
+++ b/internal/provider/test_utils_fabric_lan_classic_test.go
@@ -26,8 +26,6 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	}
 	if c.AaaRemoteIpEnabled != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_remote_ip_enabled").String(), c.AaaRemoteIpEnabled))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_remote_ip_enabled").String(), "false"))
 	}
 	if c.AaaServerConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_server_conf").String(), c.AaaServerConf))
@@ -40,18 +38,12 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	}
 	if c.BootstrapMultisubnet != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), c.BootstrapMultisubnet))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), "#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix"))
 	}
 	if c.CdpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), c.CdpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), "false"))
 	}
 	if c.DhcpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), c.DhcpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), "false"))
 	}
 	if c.DhcpEnd != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end").String(), c.DhcpEnd))
@@ -67,39 +59,27 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	}
 	if c.EnableNetflow != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow").String(), c.EnableNetflow))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow").String(), "false"))
 	}
 	if c.EnableNxapi != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), c.EnableNxapi))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), "false"))
 	}
 	if c.EnableNxapiHttp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi_http").String(), c.EnableNxapiHttp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi_http").String(), "false"))
 	}
 	if c.FabricFreeform != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_freeform").String(), c.FabricFreeform))
 	}
 	if c.FeaturePtp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), c.FeaturePtp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), "false"))
 	}
 	if c.InbandEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_enable").String(), c.InbandEnable))
 	}
 	if c.InbandMgmt != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt").String(), c.InbandMgmt))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt").String(), "false"))
 	}
 	if c.IsReadOnly != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_read_only").String(), c.IsReadOnly))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_read_only").String(), "true"))
 	}
 	if c.MgmtGw != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw").String(), c.MgmtGw))
@@ -112,8 +92,6 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	}
 	if c.MplsHandoff != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_handoff").String(), c.MplsHandoff))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_handoff").String(), "false"))
 	}
 	if c.MplsLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_lb_id").String(), strconv.Itoa(int(*c.MplsLbId))))
@@ -135,23 +113,15 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	}
 	if c.NxapiHttpsPort != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_https_port").String(), strconv.Itoa(int(*c.NxapiHttpsPort))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_https_port").String(), "443"))
 	}
 	if c.NxapiHttpPort != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), strconv.Itoa(int(*c.NxapiHttpPort))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), "80"))
 	}
 	if c.PmEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), c.PmEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), "false"))
 	}
 	if c.PowerRedundancyMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), c.PowerRedundancyMode))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), "ps-redundant"))
 	}
 	if c.PtpDomainId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ptp_domain_id").String(), strconv.Itoa(int(*c.PtpDomainId))))
@@ -161,23 +131,15 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	}
 	if c.SnmpServerHostTrap != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), c.SnmpServerHostTrap))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), "true"))
 	}
 	if c.SubinterfaceRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subinterface_range").String(), c.SubinterfaceRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subinterface_range").String(), "2-511"))
 	}
 	if c.EnableRealtimeBackup != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_realtime_backup").String(), c.EnableRealtimeBackup))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_realtime_backup").String(), "false"))
 	}
 	if c.EnableScheduledBackup != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_scheduled_backup").String(), c.EnableScheduledBackup))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_scheduled_backup").String(), "false"))
 	}
 	if c.ScheduledTime != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("scheduled_time").String(), c.ScheduledTime))

--- a/internal/provider/test_utils_fabric_msite_ext_net_test.go
+++ b/internal/provider/test_utils_fabric_msite_ext_net_test.go
@@ -26,8 +26,6 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	}
 	if c.AaaRemoteIpEnabled != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_remote_ip_enabled").String(), c.AaaRemoteIpEnabled))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_remote_ip_enabled").String(), "false"))
 	}
 	if c.AaaServerConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_server_conf").String(), c.AaaServerConf))
@@ -46,18 +44,12 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	}
 	if c.BootstrapMultisubnet != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), c.BootstrapMultisubnet))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), "#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix"))
 	}
 	if c.CdpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), c.CdpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), "false"))
 	}
 	if c.DhcpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), c.DhcpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), "false"))
 	}
 	if c.DhcpEnd != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end").String(), c.DhcpEnd))
@@ -76,42 +68,30 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	}
 	if c.EnableNetflow != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow").String(), c.EnableNetflow))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow").String(), "false"))
 	}
 	if c.EnableNxapi != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), c.EnableNxapi))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), "false"))
 	}
 	if c.EnableNxapiHttp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi_http").String(), c.EnableNxapiHttp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi_http").String(), "false"))
 	}
 	if c.FabricFreeform != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_freeform").String(), c.FabricFreeform))
 	}
 	if c.FeaturePtp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), c.FeaturePtp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), "false"))
 	}
 	if c.InbandEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_enable").String(), c.InbandEnable))
 	}
 	if c.InbandMgmt != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt").String(), c.InbandMgmt))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt").String(), "false"))
 	}
 	if c.IntfStatLoadInterval != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("intf_stat_load_interval").String(), strconv.Itoa(int(*c.IntfStatLoadInterval))))
 	}
 	if c.IsReadOnly != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_read_only").String(), c.IsReadOnly))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_read_only").String(), "true"))
 	}
 	if c.MgmtGw != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw").String(), c.MgmtGw))
@@ -124,8 +104,6 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	}
 	if c.MplsHandoff != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_handoff").String(), c.MplsHandoff))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_handoff").String(), "false"))
 	}
 	if c.MplsLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_lb_id").String(), strconv.Itoa(int(*c.MplsLbId))))
@@ -147,26 +125,18 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	}
 	if c.NxapiHttpsPort != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_https_port").String(), strconv.Itoa(int(*c.NxapiHttpsPort))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_https_port").String(), "443"))
 	}
 	if c.NxapiHttpPort != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), strconv.Itoa(int(*c.NxapiHttpPort))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), "80"))
 	}
 	if c.PmEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), c.PmEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), "false"))
 	}
 	if c.PnpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pnp_enable").String(), c.PnpEnable))
 	}
 	if c.PowerRedundancyMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), c.PowerRedundancyMode))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), "ps-redundant"))
 	}
 	if c.PtpDomainId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ptp_domain_id").String(), strconv.Itoa(int(*c.PtpDomainId))))
@@ -176,13 +146,9 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	}
 	if c.SnmpServerHostTrap != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), c.SnmpServerHostTrap))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), "true"))
 	}
 	if c.SubinterfaceRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subinterface_range").String(), c.SubinterfaceRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subinterface_range").String(), "2-511"))
 	}
 	if c.EnableRealtimeBackup != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_realtime_backup").String(), c.EnableRealtimeBackup))

--- a/internal/provider/test_utils_fabric_vxlan_evpn_test.go
+++ b/internal/provider/test_utils_fabric_vxlan_evpn_test.go
@@ -26,67 +26,45 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.AaaRemoteIpEnabled != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_remote_ip_enabled").String(), c.AaaRemoteIpEnabled))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_remote_ip_enabled").String(), "false"))
 	}
 	if c.AaaServerConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_server_conf").String(), c.AaaServerConf))
 	}
 	if c.AdvertisePipBgp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("advertise_pip_bgp").String(), c.AdvertisePipBgp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("advertise_pip_bgp").String(), "false"))
 	}
 	if c.AdvertisePipOnBorder != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("advertise_pip_on_border").String(), c.AdvertisePipOnBorder))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("advertise_pip_on_border").String(), "true"))
 	}
 	if c.AnycastBgwAdvertisePip != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_bgw_advertise_pip").String(), c.AnycastBgwAdvertisePip))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_bgw_advertise_pip").String(), "false"))
 	}
 	if c.AnycastGwMac != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_gw_mac").String(), c.AnycastGwMac))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_gw_mac").String(), "2020.0000.00aa"))
 	}
 	if c.AnycastLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_lb_id").String(), strconv.Itoa(int(*c.AnycastLbId))))
 	}
 	if c.AnycastRpIpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_rp_ip_range").String(), c.AnycastRpIpRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_rp_ip_range").String(), "10.254.254.0/24"))
 	}
 	if c.AutoSymmetricDefaultVrf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("auto_symmetric_default_vrf").String(), c.AutoSymmetricDefaultVrf))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("auto_symmetric_default_vrf").String(), "false"))
 	}
 	if c.AutoSymmetricVrfLite != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("auto_symmetric_vrf_lite").String(), c.AutoSymmetricVrfLite))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("auto_symmetric_vrf_lite").String(), "false"))
 	}
 	if c.AutoUniqueVrfLiteIpPrefix != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("auto_unique_vrf_lite_ip_prefix").String(), c.AutoUniqueVrfLiteIpPrefix))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("auto_unique_vrf_lite_ip_prefix").String(), "false"))
 	}
 	if c.AutoVrfliteIfcDefaultVrf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("auto_vrflite_ifc_default_vrf").String(), c.AutoVrfliteIfcDefaultVrf))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("auto_vrflite_ifc_default_vrf").String(), "false"))
 	}
 	if c.Banner != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("banner").String(), c.Banner))
 	}
 	if c.BfdAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_auth_enable").String(), c.BfdAuthEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_auth_enable").String(), "false"))
 	}
 	if c.BfdAuthKey != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_auth_key").String(), c.BfdAuthKey))
@@ -96,115 +74,75 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.BfdEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_enable").String(), c.BfdEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_enable").String(), "false"))
 	}
 	if c.BfdIbgpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_ibgp_enable").String(), c.BfdIbgpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_ibgp_enable").String(), "false"))
 	}
 	if c.BfdIsisEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_isis_enable").String(), c.BfdIsisEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_isis_enable").String(), "false"))
 	}
 	if c.BfdOspfEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_ospf_enable").String(), c.BfdOspfEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_ospf_enable").String(), "false"))
 	}
 	if c.BfdPimEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_pim_enable").String(), c.BfdPimEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bfd_pim_enable").String(), "false"))
 	}
 	if c.BgpAs != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_as").String(), c.BgpAs))
 	}
 	if c.BgpAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_auth_enable").String(), c.BgpAuthEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_auth_enable").String(), "false"))
 	}
 	if c.BgpAuthKey != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_auth_key").String(), c.BgpAuthKey))
 	}
 	if c.BgpAuthKeyType != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_auth_key_type").String(), strconv.Itoa(int(*c.BgpAuthKeyType))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_auth_key_type").String(), "3"))
 	}
 	if c.BgpLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_lb_id").String(), strconv.Itoa(int(*c.BgpLbId))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_lb_id").String(), "0"))
 	}
 	if c.BootstrapConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_conf").String(), c.BootstrapConf))
 	}
 	if c.BootstrapEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_enable").String(), c.BootstrapEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_enable").String(), "false"))
 	}
 	if c.BootstrapMultisubnet != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), c.BootstrapMultisubnet))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), "#Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway, Scope_Subnet_Prefix"))
 	}
 	if c.BrownfieldNetworkNameFormat != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("brownfield_network_name_format").String(), c.BrownfieldNetworkNameFormat))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("brownfield_network_name_format").String(), "Auto_Net_VNI$$VNI$$_VLAN$$VLAN_ID$$"))
 	}
 	if c.BrownfieldSkipOverlayNetworkAttachments != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("brownfield_skip_overlay_network_attachments").String(), c.BrownfieldSkipOverlayNetworkAttachments))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("brownfield_skip_overlay_network_attachments").String(), "false"))
 	}
 	if c.CdpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), c.CdpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), "false"))
 	}
 	if c.CoppPolicy != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("copp_policy").String(), c.CoppPolicy))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("copp_policy").String(), "strict"))
 	}
 	if c.DciSubnetRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_range").String(), c.DciSubnetRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_range").String(), "10.33.0.0/16"))
 	}
 	if c.DciSubnetTargetMask != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_target_mask").String(), strconv.Itoa(int(*c.DciSubnetTargetMask))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_target_mask").String(), "30"))
 	}
 	if c.DefaultQueuingPolicyCloudscale != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_queuing_policy_cloudscale").String(), c.DefaultQueuingPolicyCloudscale))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_queuing_policy_cloudscale").String(), "queuing_policy_default_8q_cloudscale"))
 	}
 	if c.DefaultQueuingPolicyOther != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_queuing_policy_other").String(), c.DefaultQueuingPolicyOther))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_queuing_policy_other").String(), "queuing_policy_default_other"))
 	}
 	if c.DefaultQueuingPolicyRSeries != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_queuing_policy_r_series").String(), c.DefaultQueuingPolicyRSeries))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_queuing_policy_r_series").String(), "queuing_policy_default_r_series"))
 	}
 	if c.DefaultVrfRedisBgpRmap != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_vrf_redis_bgp_rmap").String(), c.DefaultVrfRedisBgpRmap))
 	}
 	if c.DhcpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), c.DhcpEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), "false"))
 	}
 	if c.DhcpEnd != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end").String(), c.DhcpEnd))
@@ -223,68 +161,42 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.EnableAaa != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_aaa").String(), c.EnableAaa))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_aaa").String(), "false"))
 	}
 	if c.EnableDefaultQueuingPolicy != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_default_queuing_policy").String(), c.EnableDefaultQueuingPolicy))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_default_queuing_policy").String(), "false"))
 	}
 	if c.EnableFabricVpcDomainId != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_fabric_vpc_domain_id").String(), c.EnableFabricVpcDomainId))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_fabric_vpc_domain_id").String(), "false"))
 	}
 	if c.EnableMacsec != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_macsec").String(), c.EnableMacsec))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_macsec").String(), "false"))
 	}
 	if c.EnableNetflow != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow").String(), c.EnableNetflow))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow").String(), "false"))
 	}
 	if c.EnableNgoam != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_ngoam").String(), c.EnableNgoam))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_ngoam").String(), "true"))
 	}
 	if c.EnableNxapi != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), c.EnableNxapi))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), "true"))
 	}
 	if c.EnableNxapiHttp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi_http").String(), c.EnableNxapiHttp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi_http").String(), "true"))
 	}
 	if c.EnablePbr != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_pbr").String(), c.EnablePbr))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_pbr").String(), "false"))
 	}
 	if c.EnablePvlan != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_pvlan").String(), c.EnablePvlan))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_pvlan").String(), "false"))
 	}
 	if c.EnableTenantDhcp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_tenant_dhcp").String(), c.EnableTenantDhcp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_tenant_dhcp").String(), "true"))
 	}
 	if c.EnableTrm != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_trm").String(), c.EnableTrm))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_trm").String(), "false"))
 	}
 	if c.EnableVpcPeerLinkNativeVlan != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_vpc_peer_link_native_vlan").String(), c.EnableVpcPeerLinkNativeVlan))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_vpc_peer_link_native_vlan").String(), "false"))
 	}
 	if c.ExtraConfIntraLinks != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("extra_conf_intra_links").String(), c.ExtraConfIntraLinks))
@@ -300,46 +212,30 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.FabricInterfaceType != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_interface_type").String(), c.FabricInterfaceType))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_interface_type").String(), "p2p"))
 	}
 	if c.FabricMtu != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_mtu").String(), strconv.Itoa(int(*c.FabricMtu))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_mtu").String(), "9216"))
 	}
 	if c.FabricVpcDomainId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_vpc_domain_id").String(), strconv.Itoa(int(*c.FabricVpcDomainId))))
 	}
 	if c.FabricVpcQos != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_vpc_qos").String(), c.FabricVpcQos))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_vpc_qos").String(), "false"))
 	}
 	if c.FabricVpcQosPolicyName != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_vpc_qos_policy_name").String(), c.FabricVpcQosPolicyName))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_vpc_qos_policy_name").String(), "spine_qos_for_fabric_vpc_peering"))
 	}
 	if c.FeaturePtp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), c.FeaturePtp))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), "false"))
 	}
 	if c.GrfieldDebugFlag != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("grfield_debug_flag").String(), c.GrfieldDebugFlag))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("grfield_debug_flag").String(), "Disable"))
 	}
 	if c.HdTime != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("hd_time").String(), strconv.Itoa(int(*c.HdTime))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("hd_time").String(), "180"))
 	}
 	if c.HostIntfAdminState != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("host_intf_admin_state").String(), c.HostIntfAdminState))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("host_intf_admin_state").String(), "true"))
 	}
 	if c.IbgpPeerTemplate != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ibgp_peer_template").String(), c.IbgpPeerTemplate))
@@ -352,13 +248,9 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.InbandMgmt != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt").String(), c.InbandMgmt))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt").String(), "false"))
 	}
 	if c.IsisAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_auth_enable").String(), c.IsisAuthEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_auth_enable").String(), "false"))
 	}
 	if c.IsisAuthKey != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_auth_key").String(), c.IsisAuthKey))
@@ -371,8 +263,6 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.IsisLevel != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_level").String(), c.IsisLevel))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_level").String(), "level-2"))
 	}
 	if c.IsisOverloadElapseTime != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_overload_elapse_time").String(), strconv.Itoa(int(*c.IsisOverloadElapseTime))))
@@ -385,47 +275,33 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.L2HostIntfMtu != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_host_intf_mtu").String(), strconv.Itoa(int(*c.L2HostIntfMtu))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_host_intf_mtu").String(), "9216"))
 	}
 	if c.L2SegmentIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_segment_id_range").String(), c.L2SegmentIdRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_segment_id_range").String(), "30000-49000"))
 	}
 	if c.L3vniMcastGroup != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l3vni_mcast_group").String(), c.L3vniMcastGroup))
 	}
 	if c.L3PartitionIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l3_partition_id_range").String(), c.L3PartitionIdRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l3_partition_id_range").String(), "50000-59000"))
 	}
 	if c.LinkStateRouting != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing").String(), c.LinkStateRouting))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing").String(), "ospf"))
 	}
 	if c.LinkStateRoutingTag != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing_tag").String(), c.LinkStateRoutingTag))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing_tag").String(), "UNDERLAY"))
 	}
 	if c.Loopback0Ipv6Range != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback0_ipv6_range").String(), c.Loopback0Ipv6Range))
 	}
 	if c.Loopback0IpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback0_ip_range").String(), c.Loopback0IpRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback0_ip_range").String(), "10.2.0.0/22"))
 	}
 	if c.Loopback1Ipv6Range != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback1_ipv6_range").String(), c.Loopback1Ipv6Range))
 	}
 	if c.Loopback1IpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback1_ip_range").String(), c.Loopback1IpRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback1_ip_range").String(), "10.3.0.0/22"))
 	}
 	if c.MacsecAlgorithm != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("macsec_algorithm").String(), c.MacsecAlgorithm))
@@ -456,8 +332,6 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.MplsHandoff != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_handoff").String(), c.MplsHandoff))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_handoff").String(), "false"))
 	}
 	if c.MplsLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_lb_id").String(), strconv.Itoa(int(*c.MplsLbId))))
@@ -470,8 +344,6 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.MulticastGroupSubnet != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("multicast_group_subnet").String(), c.MulticastGroupSubnet))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("multicast_group_subnet").String(), "239.1.1.0/25"))
 	}
 	if c.NetflowExporterList != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("netflow_exporter_list").String(), c.NetflowExporterList))
@@ -484,8 +356,6 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.NetworkVlanRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("network_vlan_range").String(), c.NetworkVlanRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("network_vlan_range").String(), "2300-2999"))
 	}
 	if c.NtpServerIpList != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ntp_server_ip_list").String(), c.NtpServerIpList))
@@ -495,33 +365,21 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.NveLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nve_lb_id").String(), strconv.Itoa(int(*c.NveLbId))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nve_lb_id").String(), "1"))
 	}
 	if c.NxapiHttpsPort != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_https_port").String(), strconv.Itoa(int(*c.NxapiHttpsPort))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_https_port").String(), "443"))
 	}
 	if c.NxapiHttpPort != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), strconv.Itoa(int(*c.NxapiHttpPort))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), "80"))
 	}
 	if c.ObjectTrackingNumberRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("object_tracking_number_range").String(), c.ObjectTrackingNumberRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("object_tracking_number_range").String(), "100-299"))
 	}
 	if c.OspfAreaId != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_area_id").String(), c.OspfAreaId))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_area_id").String(), "0.0.0.0"))
 	}
 	if c.OspfAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_auth_enable").String(), c.OspfAuthEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_auth_enable").String(), "false"))
 	}
 	if c.OspfAuthKey != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ospf_auth_key").String(), c.OspfAuthKey))
@@ -531,13 +389,9 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.OverlayMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("overlay_mode").String(), c.OverlayMode))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("overlay_mode").String(), "cli"))
 	}
 	if c.PerVrfLoopbackAutoProvision != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("per_vrf_loopback_auto_provision").String(), c.PerVrfLoopbackAutoProvision))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("per_vrf_loopback_auto_provision").String(), "false"))
 	}
 	if c.PerVrfLoopbackIpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("per_vrf_loopback_ip_range").String(), c.PerVrfLoopbackIpRange))
@@ -556,21 +410,15 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.PimHelloAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pim_hello_auth_enable").String(), c.PimHelloAuthEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pim_hello_auth_enable").String(), "false"))
 	}
 	if c.PimHelloAuthKey != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pim_hello_auth_key").String(), c.PimHelloAuthKey))
 	}
 	if c.PmEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), c.PmEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), "false"))
 	}
 	if c.PowerRedundancyMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), c.PowerRedundancyMode))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), "ps-redundant"))
 	}
 	if c.PtpDomainId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ptp_domain_id").String(), strconv.Itoa(int(*c.PtpDomainId))))
@@ -580,96 +428,66 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.ReplicationMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("replication_mode").String(), c.ReplicationMode))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("replication_mode").String(), "Multicast"))
 	}
 	if c.RouterIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("router_id_range").String(), c.RouterIdRange))
 	}
 	if c.RouteMapSequenceNumberRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("route_map_sequence_number_range").String(), c.RouteMapSequenceNumberRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("route_map_sequence_number_range").String(), "1-65534"))
 	}
 	if c.RpCount != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_count").String(), strconv.Itoa(int(*c.RpCount))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_count").String(), "2"))
 	}
 	if c.RpLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_lb_id").String(), strconv.Itoa(int(*c.RpLbId))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_lb_id").String(), "254"))
 	}
 	if c.RpMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_mode").String(), c.RpMode))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_mode").String(), "asm"))
 	}
 	if c.RrCount != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rr_count").String(), strconv.Itoa(int(*c.RrCount))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rr_count").String(), "2"))
 	}
 	if c.SeedSwitchCoreInterfaces != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("seed_switch_core_interfaces").String(), c.SeedSwitchCoreInterfaces))
 	}
 	if c.ServiceNetworkVlanRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("service_network_vlan_range").String(), c.ServiceNetworkVlanRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("service_network_vlan_range").String(), "3000-3199"))
 	}
 	if c.SiteId != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("site_id").String(), c.SiteId))
 	}
 	if c.SlaIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sla_id_range").String(), c.SlaIdRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sla_id_range").String(), "10000-19999"))
 	}
 	if c.SnmpServerHostTrap != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), c.SnmpServerHostTrap))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), "true"))
 	}
 	if c.SpineSwitchCoreInterfaces != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("spine_switch_core_interfaces").String(), c.SpineSwitchCoreInterfaces))
 	}
 	if c.StaticUnderlayIpAlloc != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("static_underlay_ip_alloc").String(), c.StaticUnderlayIpAlloc))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("static_underlay_ip_alloc").String(), "false"))
 	}
 	if c.StpBridgePriority != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("stp_bridge_priority").String(), strconv.Itoa(int(*c.StpBridgePriority))))
 	}
 	if c.StpRootOption != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("stp_root_option").String(), c.StpRootOption))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("stp_root_option").String(), "unmanaged"))
 	}
 	if c.StpVlanRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("stp_vlan_range").String(), c.StpVlanRange))
 	}
 	if c.StrictCcMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("strict_cc_mode").String(), c.StrictCcMode))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("strict_cc_mode").String(), "false"))
 	}
 	if c.SubinterfaceRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subinterface_range").String(), c.SubinterfaceRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subinterface_range").String(), "2-511"))
 	}
 	if c.SubnetRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subnet_range").String(), c.SubnetRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subnet_range").String(), "10.4.0.0/16"))
 	}
 	if c.SubnetTargetMask != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subnet_target_mask").String(), strconv.Itoa(int(*c.SubnetTargetMask))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("subnet_target_mask").String(), "30"))
 	}
 	if c.SyslogServerIpList != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("syslog_server_ip_list").String(), c.SyslogServerIpList))
@@ -682,13 +500,9 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.TcamAllocation != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("tcam_allocation").String(), c.TcamAllocation))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("tcam_allocation").String(), "true"))
 	}
 	if c.UnderlayIsV6 != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("underlay_is_v6").String(), c.UnderlayIsV6))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("underlay_is_v6").String(), "false"))
 	}
 	if c.UnnumBootstrapLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("unnum_bootstrap_lb_id").String(), strconv.Itoa(int(*c.UnnumBootstrapLbId))))
@@ -701,74 +515,48 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.UseLinkLocal != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("use_link_local").String(), c.UseLinkLocal))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("use_link_local").String(), "true"))
 	}
 	if c.V6SubnetRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("v6_subnet_range").String(), c.V6SubnetRange))
 	}
 	if c.V6SubnetTargetMask != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("v6_subnet_target_mask").String(), strconv.Itoa(int(*c.V6SubnetTargetMask))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("v6_subnet_target_mask").String(), "126"))
 	}
 	if c.VpcAutoRecoveryTime != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_auto_recovery_time").String(), strconv.Itoa(int(*c.VpcAutoRecoveryTime))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_auto_recovery_time").String(), "360"))
 	}
 	if c.VpcDelayRestore != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_delay_restore").String(), strconv.Itoa(int(*c.VpcDelayRestore))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_delay_restore").String(), "150"))
 	}
 	if c.VpcDomainIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_domain_id_range").String(), c.VpcDomainIdRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_domain_id_range").String(), "1-1000"))
 	}
 	if c.VpcEnableIpv6NdSync != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_enable_ipv6_nd_sync").String(), c.VpcEnableIpv6NdSync))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_enable_ipv6_nd_sync").String(), "true"))
 	}
 	if c.VpcPeerKeepAliveOption != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_peer_keep_alive_option").String(), c.VpcPeerKeepAliveOption))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_peer_keep_alive_option").String(), "management"))
 	}
 	if c.VpcPeerLinkPo != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_peer_link_po").String(), strconv.Itoa(int(*c.VpcPeerLinkPo))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_peer_link_po").String(), "500"))
 	}
 	if c.VpcPeerLinkVlan != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_peer_link_vlan").String(), strconv.Itoa(int(*c.VpcPeerLinkVlan))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vpc_peer_link_vlan").String(), "3600"))
 	}
 	if c.VrfLiteAutoconfig != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_lite_autoconfig").String(), c.VrfLiteAutoconfig))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_lite_autoconfig").String(), "Manual"))
 	}
 	if c.VrfVlanRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_vlan_range").String(), c.VrfVlanRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_vlan_range").String(), "2000-2299"))
 	}
 	if c.DefaultNetwork != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_network").String(), c.DefaultNetwork))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_network").String(), "Default_Network_Universal"))
 	}
 	if c.DefaultPvlanSecNetwork != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_pvlan_sec_network").String(), c.DefaultPvlanSecNetwork))
 	}
 	if c.DefaultVrf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_vrf").String(), c.DefaultVrf))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_vrf").String(), "Default_VRF_Universal"))
 	}
 	if c.EnableRealtimeBackup != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_realtime_backup").String(), c.EnableRealtimeBackup))
@@ -778,16 +566,12 @@ func FabricVxlanEvpnModelHelperStateCheck(RscName string, c resource_fabric_comm
 	}
 	if c.NetworkExtensionTemplate != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("network_extension_template").String(), c.NetworkExtensionTemplate))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("network_extension_template").String(), "Default_Network_Extension_Universal"))
 	}
 	if c.ScheduledTime != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("scheduled_time").String(), c.ScheduledTime))
 	}
 	if c.VrfExtensionTemplate != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_extension_template").String(), c.VrfExtensionTemplate))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_extension_template").String(), "Default_VRF_Extension_Universal"))
 	}
 	if c.Deploy {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), "true"))

--- a/internal/provider/test_utils_fabric_vxlan_msd_test.go
+++ b/internal/provider/test_utils_fabric_vxlan_msd_test.go
@@ -26,29 +26,21 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	}
 	if c.AnycastGwMac != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_gw_mac").String(), c.AnycastGwMac))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("anycast_gw_mac").String(), "2020.0000.00aa"))
 	}
 	if c.BgpRpAsn != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_rp_asn").String(), c.BgpRpAsn))
 	}
 	if c.BgwRoutingTag != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgw_routing_tag").String(), strconv.Itoa(int(*c.BgwRoutingTag))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgw_routing_tag").String(), "54321"))
 	}
 	if c.BorderGwyConnections != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("border_gwy_connections").String(), c.BorderGwyConnections))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("border_gwy_connections").String(), "Manual"))
 	}
 	if c.CloudsecAlgorithm != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cloudsec_algorithm").String(), c.CloudsecAlgorithm))
 	}
 	if c.CloudsecAutoconfig != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cloudsec_autoconfig").String(), c.CloudsecAutoconfig))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cloudsec_autoconfig").String(), "false"))
 	}
 	if c.CloudsecEnforcement != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cloudsec_enforcement").String(), c.CloudsecEnforcement))
@@ -61,18 +53,12 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	}
 	if c.DciSubnetRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_range").String(), c.DciSubnetRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_range").String(), "10.10.1.0/24"))
 	}
 	if c.DciSubnetTargetMask != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_target_mask").String(), strconv.Itoa(int(*c.DciSubnetTargetMask))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_target_mask").String(), "30"))
 	}
 	if c.DelayRestore != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("delay_restore").String(), strconv.Itoa(int(*c.DelayRestore))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("delay_restore").String(), "300"))
 	}
 	if c.EnableBgpBfd != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_bgp_bfd").String(), c.EnableBgpBfd))
@@ -85,26 +71,18 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	}
 	if c.EnablePvlan != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_pvlan").String(), c.EnablePvlan))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_pvlan").String(), "false"))
 	}
 	if c.EnableRsRedistDirect != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_rs_redist_direct").String(), c.EnableRsRedistDirect))
 	}
 	if c.L2SegmentIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_segment_id_range").String(), c.L2SegmentIdRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_segment_id_range").String(), "30000-49000"))
 	}
 	if c.L3PartitionIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l3_partition_id_range").String(), c.L3PartitionIdRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l3_partition_id_range").String(), "50000-59000"))
 	}
 	if c.Loopback100IpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback100_ip_range").String(), c.Loopback100IpRange))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback100_ip_range").String(), "10.10.0.0/24"))
 	}
 	if c.MsIfcBgpAuthKeyType != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_auth_key_type").String(), strconv.Itoa(int(*c.MsIfcBgpAuthKeyType))))
@@ -114,18 +92,12 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	}
 	if c.MsIfcBgpPasswordEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_password_enable").String(), c.MsIfcBgpPasswordEnable))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_password_enable").String(), "false"))
 	}
 	if c.MsLoopbackId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_loopback_id").String(), strconv.Itoa(int(*c.MsLoopbackId))))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_loopback_id").String(), "100"))
 	}
 	if c.MsUnderlayAutoconfig != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_underlay_autoconfig").String(), c.MsUnderlayAutoconfig))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_underlay_autoconfig").String(), "false"))
 	}
 	if c.RpServerIp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_server_ip").String(), c.RpServerIp))
@@ -135,37 +107,27 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	}
 	if c.TorAutoDeploy != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("tor_auto_deploy").String(), c.TorAutoDeploy))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("tor_auto_deploy").String(), "false"))
 	}
 	if c.DefaultNetwork != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_network").String(), c.DefaultNetwork))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_network").String(), "Default_Network_Universal"))
 	}
 	if c.DefaultPvlanSecNetwork != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_pvlan_sec_network").String(), c.DefaultPvlanSecNetwork))
 	}
 	if c.DefaultVrf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_vrf").String(), c.DefaultVrf))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_vrf").String(), "Default_VRF_Universal"))
 	}
 	if c.EnableScheduledBackup != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_scheduled_backup").String(), c.EnableScheduledBackup))
 	}
 	if c.NetworkExtensionTemplate != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("network_extension_template").String(), c.NetworkExtensionTemplate))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("network_extension_template").String(), "Default_Network_Extension_Universal"))
 	}
 	if c.ScheduledTime != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("scheduled_time").String(), c.ScheduledTime))
 	}
 	if c.VrfExtensionTemplate != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_extension_template").String(), c.VrfExtensionTemplate))
-	} else {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vrf_extension_template").String(), "Default_VRF_Extension_Universal"))
 	}
 	if c.Deploy {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), "true"))


### PR DESCRIPTION
Removing default values in fabric resource attributes and making it has computed values.
This fixes issues https://github.com/CiscoDevNet/terraform-provider-ndfc/issues/155 and https://github.com/CiscoDevNet/terraform-provider-ndfc/issues/157