### PR TITLE
Manage terraform state when vpc pair is deleted manually in NDFC

### DIFF
--- a/internal/provider/ndfc/api/vpc_pair_api.go
+++ b/internal/provider/ndfc/api/vpc_pair_api.go
@@ -50,9 +50,7 @@ func (c *VpcPairAPI) PutUrl() string {
 }
 
 func (c *VpcPairAPI) DeleteUrl() string {
-	url := urlVpcPair
-	url += "?serialNumber=" + c.VpcPairID
-	return url
+	return fmt.Sprintf(urlVpcPairGet, c.VpcPairID)
 }
 func (c *VpcPairAPI) GetDeleteQP() []string {
 	return nil


### PR DESCRIPTION
Fix for issue: https://github.com/CiscoDevNet/terraform-provider-ndfc/issues/170

Fix: Check if vpc pair is present in Read call. If no, remove it from state for recreation.