### PR TITLE
Fix for handling incomplete preview status in config deploy resource

### DIFF
--- a/internal/provider/resources/resource_configuration_deploy/resource_custom_codec.go
+++ b/internal/provider/resources/resource_configuration_deploy/resource_custom_codec.go
@@ -11,8 +11,8 @@ type SwitchStatusDB struct {
 }
 
 type SwitchStatus struct {
-	SwitchId string `json:"switchId"`
-	Status   string `json:"status"`
+	SerialNumber string `json:"serialNumber"`
+	Status       string `json:"ccStatus"`
 }
 
 func (m *SwitchStatusDB) UnmarshalJSON(data []byte) error {
@@ -22,7 +22,7 @@ func (m *SwitchStatusDB) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	for _, entry := range customModel {
-		m.SerialNumMap[entry.SwitchId] = entry
+		m.SerialNumMap[entry.SerialNumber] = entry
 	}
 	return nil
 }


### PR DESCRIPTION
Issue:

Config preview sometimes does fetch all switches in fabric. This causes code to assume all missing switches in payload to be IN-SYNC, leading to inconsistency in NDFC.

Fix:

Use switchesByFabric Api in NDFC to fetch all switches in NDFC. Which is the common API used finding switch details in NDFC.