### PR TITLE
Support all fields based on respective template for non-evpn-vxlan fabric types

### DIFF
--- a/docs/data-sources/fabric.md
+++ b/docs/data-sources/fabric.md
@@ -87,6 +87,8 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `bgp_auth_key` (String) Encrypted BGP Authentication Key based on type
 - `bgp_auth_key_type` (Number) BGP Key Encryption Type: 3 - 3DES, 7 - Cisco
 - `bgp_lb_id` (Number) No description available
+- `bgw_routing_tag` (Number) Routing tag associated with IP address of loopback and DCI interfaces
+- `bgw_routing_tag_prev` (String) Previous state of Border Gateway Routing Tag
 - `bootstrap_conf` (String) Additional CLIs required during device bootup/login e.g. AAA/Radius
 - `bootstrap_enable` (Boolean) Automatic IP Assignment For POAP
 - `bootstrap_enable_prev` (Boolean) Previous state of Bootstrap Enable
@@ -104,6 +106,7 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `dci_macsec_key_string` (String) Cisco Type 7 Encrypted Octet String
 - `dci_subnet_range` (String) Address range to assign P2P Interfabric Connections
 - `dci_subnet_target_mask` (Number) No description available
+- `dcnm_id` (String) DCNM ID
 - `default_network` (String) Default Overlay Network Template For Leafs
 - `default_pvlan_sec_network` (String) Default PVLAN Secondary Network Template
 - `default_queuing_policy_cloudscale` (String) Queuing Policy for all 92xx, -EX, -FX, -FX2, -FX3, -GX series switches in the fabric
@@ -122,11 +125,13 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `dhcp_start_internal` (String) Internal DHCP Scope Start Address
 - `dns_server_ip_list` (String) Comma separated list of IP Addresses(v4/v6)
 - `dns_server_vrf` (String) One VRF for all DNS servers or a comma separated list of VRFs, one per DNS server
+- `domain_name_internal` (String) Internal Domain Name
 - `enable_aaa` (Boolean) Include AAA configs from Manageability tab during device bootup
 - `enable_agent` (Boolean) Enable Agnet (development purpose only)
 - `enable_agg_acc_id_range` (Boolean) Use specific vPC/Port-channel ID range for leaf-tor pairings
 - `enable_ai_ml_qos_policy` (Boolean) Configures QoS and Queuing Policies specific to N9K Cloud Scale switch fabric for AI/ML network loads
 - `enable_ai_ml_qos_policy_flap` (Boolean) Previous state of Enable AI/ML QoS Policy Flap
+- `enable_asm` (Boolean) Enable groups with receivers sending (*,G) joins
 - `enable_dci_macsec` (Boolean) Enable DCI MACsec - Enable MACsec on DCI links. DCI MACsec fabric parameters are used for configuring MACsec on a DCI link if 'Use Link MACsec Setting' is disabled on the link.
 - `enable_dci_macsec_prev` (Boolean) Previous state of Enable DCI MACsec
 - `enable_default_queuing_policy` (Boolean) No description available
@@ -136,6 +141,7 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `enable_l3vni_no_vlan` (Boolean) L3 VNI configuration without VLAN configuration. This value is propagated on vrf creation as the default value of 'Enable L3VNI w/o VLAN' in vrf
 - `enable_macsec` (Boolean) Enable MACsec in the fabric
 - `enable_macsec_prev` (Boolean) Previous state of Enable MACsec
+- `enable_nbm_passive_prev` (Boolean) Previous state of Enable NBM Passive Mode
 - `enable_netflow` (Boolean) Enable Netflow on VTEPs
 - `enable_netflow_prev` (Boolean) Previous state of Enable Netflow
 - `enable_ngoam` (Boolean) Enable the Next Generation (NG) OAM feature for all switches in the fabric to aid in trouble-shooting VXLAN EVPN fabrics
@@ -152,6 +158,8 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `enable_sgt_prev` (Boolean) Previous state of Enable Security Groups
 - `enable_tenant_dhcp` (Boolean) No description available
 - `enable_trm` (Boolean) For Overlay Multicast Support In VXLAN Fabrics
+- `enable_trm_trmv6` (Boolean) Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites
+- `enable_trm_trmv6_prev` (Boolean) Previous state of Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites
 - `enable_trmv6` (Boolean) For Overlay IPv6 Multicast Support In VXLAN Fabrics
 - `enable_vpc_peer_link_native_vlan` (Boolean) No description available
 - `enable_vri_id_realloc` (Boolean) One time VRI ID re-allocation based on 'MVPN VRI ID Range'
@@ -164,6 +172,7 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `fabric_interface_type` (String) Numbered(Point-to-Point) or Unnumbered
 - `fabric_mtu` (Number) Must be an even number
 - `fabric_mtu_prev` (Number) Previous state of Fabric MTU
+- `fabric_technology` (String) Fabric Technology
 - `fabric_type` (String) Fabric Type
 - `fabric_vpc_domain_id` (Number) vPC Domain Id to be used on all vPC pairs
 - `fabric_vpc_domain_id_prev` (Number) Internal Fabric Wide vPC Domain ID
@@ -179,8 +188,13 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `ibgp_peer_template_leaf` (String) Specifies the config used for leaf, border or border gateway. If this field is empty, the peer template defined in iBGP Peer-Template Config is used on all BGP enabled devices (RRs,leafs, border or border gateway roles.
 - `ignore_cert` (Boolean) Skip verification of incoming certificate
 - `inband_dhcp_servers` (String) Comma separated list of IPv4 Addresses (Max 3)
+- `inband_enable_prev` (Boolean) Previous state of Enable POAP over Inband Interface
 - `inband_mgmt` (Boolean) Manage switches with only Inband connectivity
 - `inband_mgmt_prev` (Boolean) Previous state of Inband Management
+- `interface_ethernet_default_policy` (String) Default policy for Ethernet interface of spine/leaf/tier2-leaf switches
+- `interface_loopback_default_policy` (String) Loopback Interface Default Policy
+- `interface_port_channel_default_policy` (String) Port Channel Interface Default Policy
+- `interface_vlan_default_policy` (String) VLAN Interface Default Policy
 - `ipv6_anycast_rp_ip_range` (String) Anycast RP IPv6 Address Range
 - `ipv6_anycast_rp_ip_range_internal` (String) Internal IPv6 Anycast RP IP Range
 - `ipv6_multicast_group_subnet` (String) IPv6 Multicast Group Subnet - IPv6 Multicast address with prefix 112 to 128
@@ -207,6 +221,7 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `link_state_routing_tag_prev` (String) Previous Link State Routing Tag
 - `loopback0_ip_range` (String) Typically Loopback0 IP Address Range
 - `loopback0_ipv6_range` (String) Typically Loopback0 IPv6 Address Range
+- `loopback100_ipv6_range` (String) Multi-Site VTEP VIP Loopback IPv6 Range
 - `loopback1_ip_range` (String) Typically Loopback1 IP Address Range
 - `loopback1_ipv6_range` (String) Typically Loopback1 and Anycast Loopback IPv6 Address Range
 - `macsec_algorithm` (String) AES_128_CMAC or AES_256_CMAC
@@ -226,6 +241,10 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `mpls_isis_area_num_prev` (String) Previous state of MPLS IS-IS Area Number
 - `mpls_lb_id` (Number) Used for VXLAN to MPLS SR/LDP Handoff
 - `mpls_loopback_ip_range` (String) Used for VXLAN to MPLS SR/LDP Handoff
+- `ms_ifc_bgp_auth_key_type` (Number) BGP Key Encryption Type: 3 - 3DES, 7 - Cisco
+- `ms_ifc_bgp_auth_key_type_prev` (Number) BGP Key Encryption Type: 3 - 3DES, 7 - Cisco
+- `ms_ifc_bgp_password_enable_prev` (Boolean) Previous state of Enable Multi-Site eBGP Password
+- `ms_ifc_bgp_password_prev` (String) Previous state of eBGP Password
 - `mso_connectivity_deployed` (String) MSO Connectivity Deployed
 - `mso_controler_id` (String) MSO Controller ID
 - `mso_site_group_name` (String) MSO Site Group Name
@@ -255,6 +274,7 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `overlay_mode` (String) VRF/Network configuration using config-profile or CLI
 - `overlay_mode_prev` (String) Previous Overlay Mode value
 - `overwrite_global_nxc` (Boolean) If enabled, Fabric NxCloud Settings will be used
+- `parent_onemanage_fabric` (String) Parent OneManage Fabric
 - `per_vrf_loopback_auto_provision` (Boolean) Auto provision a loopback on a VTEP on VRF attachment
 - `per_vrf_loopback_auto_provision_prev` (Boolean) Previous state of Per VRF Loopback Auto Provisioning
 - `per_vrf_loopback_auto_provision_v6` (Boolean) Auto provision a loopback IPv6 on a VTEP on VRF attachment
@@ -271,6 +291,7 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `pim_hello_auth_key` (String) 3DES Encrypted
 - `pm_enable` (Boolean) No description available
 - `pm_enable_prev` (Boolean) Previous state of Performance Monitoring Enable
+- `pnp_enable_internal` (Boolean) Internal PnP Enable
 - `power_redundancy_mode` (String) Default Power Supply Mode For The Fabric
 - `premso_parent_fabric` (String) Pre-MSO Parent Fabric
 - `ptp_domain_id` (Number) Multiple Independent PTP Clocking Subdomains on a Single Network
@@ -282,6 +303,7 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `route_map_sequence_number_range` (String) No description available
 - `router_id_range` (String) No description available
 - `rp_count` (Number) Number of spines acting as Rendezvous-Point (RP)
+- `rp_ip_range_internal` (String) Internal RP IP Range
 - `rp_lb_id` (Number) No description available
 - `rp_mode` (String) Multicast RP Mode
 - `rr_count` (Number) Number of spines acting as Route-Reflectors
@@ -289,7 +311,9 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `seed_switch_core_interfaces` (String) Core-facing Interface list on Seed Switch (e.g. e1/1-30,e1/32)
 - `service_network_vlan_range` (String) Per Switch Overlay Service Network VLAN Range
 - `sgt_id_range` (String) Security Group Tag (SGT) ID Range - Min:16, Max:65535. Reserved Range: 0-15
+- `sgt_id_range_prev` (String) Previous state of Security Group Tag (SGT) ID Range
 - `sgt_name_prefix` (String) Security Group Name Prefix - Prefix to be used when a new Security Group is created (Min:1, Max:10 characters)
+- `sgt_name_prefix_prev` (String) Previous state of Security Group Name Prefix
 - `sgt_oper_status` (String) Operational status for Security Group
 - `sgt_preprov_recalc_status` (String) Recalculation status for Security Group pre-provisioning
 - `sgt_preprovision` (Boolean) Security Groups Pre-provision - Generate security groups configuration for non-enforced VRFs
@@ -329,6 +353,8 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `unnum_dhcp_start_internal` (String) Internal Unnumbered DHCP Start Address
 - `upgrade_from_version` (String) Upgrade from Version
 - `use_link_local` (Boolean) If not enabled, Spine-Leaf interfaces will use global IPv6 addresses
+- `v6_dci_subnet_range` (String) Address range to assign P2P DCI Links
+- `v6_dci_subnet_target_mask` (Number) Target IPv6 Mask for Subnet Range (Min:120, Max:127)
 - `v6_subnet_range` (String) IPv6 Address range to assign Numbered and Peer Link SVI IPs
 - `v6_subnet_target_mask` (Number) Mask for Underlay Subnet IPv6 Range
 - `vpc_auto_recovery_time` (Number) No description available
@@ -342,3 +368,4 @@ data "ndfc_fabric" "test_resource_fabric_1" {
 - `vrf_extension_template` (String) Default Overlay VRF Template For Borders
 - `vrf_lite_autoconfig` (String) VRF Lite Inter-Fabric Connection Deployment Options. If Back2Back&ToExternal is selected, VRF Lite IFCs are auto created between border devices of two Easy Fabrics, and between border devices in Easy Fabric and edge routers in External Fabric. The IP address is taken from the VRF Lite Subnet IP Range pool.
 - `vrf_vlan_range` (String) Per Switch Overlay VRF VLAN Range
+- `vxlan_underlay_is_v6` (Boolean) If not enabled, IPv4 underlay is used in child VXLAN fabric

--- a/docs/resources/fabric_ipfm.md
+++ b/docs/resources/fabric_ipfm.md
@@ -3,12 +3,12 @@
 page_title: "ndfc_fabric_ipfm Resource - terraform-provider-ndfc"
 subcategory: ""
 description: |-
-  Resource to configure and manage IP Fabric Media
+  Resource to configure and manage IP Fabric Media.  Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.
 ---
 
 # ndfc_fabric_ipfm (Resource)
 
-Resource to configure and manage IP Fabric Media
+Resource to configure and manage IP Fabric Media.  Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.
 
 ## Example Usage
 
@@ -23,7 +23,6 @@ resource "ndfc_fabric_ipfm" "test_resource_fabric_ipfm_1" {
   enable_aaa               = false
   enable_asm               = false
   enable_nbm_passive       = false
-  fabric_interface_type    = "p2p"
   fabric_mtu               = 9216
   feature_ptp              = false
   isis_auth_enable         = false
@@ -53,17 +52,21 @@ resource "ndfc_fabric_ipfm" "test_resource_fabric_ipfm_1" {
 ### Required
 
 - `deploy` (Boolean) This flag does configuration save and deploy
-- `fabric_name` (String) Fabric name to be created, updated or deleted (Max Size 64).
+- `fabric_name` (String) Fabric name to be created, updated or deleted.
 
 ### Optional
 
-- `aaa_remote_ip_enabled` (Boolean) Enable only when IP Authorization is enabled in the AAA Server
+- `aaa_remote_ip_enabled` (Boolean) Enable only, when IP Authorization is enabled in the AAA \ Server
 - `aaa_server_conf` (String) AAA Configurations
+- `active_migration` (Boolean) Active Migration
+- `agent_intf` (String) Interface to connect to Agent
 - `asm_group_ranges` (String) ASM group ranges with prefixes (len:4-32) example: 239.1.1.0/25, max 20 ranges. Enabling SPT-Threshold Infinity to prevent switchover to source-tree.
 - `bootstrap_conf` (String) Additional CLIs required during device bootup/login e.g. AAA/Radius
 - `bootstrap_enable` (Boolean) Automatic IP Assignment For POAP
-- `bootstrap_multisubnet` (String) lines with # prefix are ignored here
+- `bootstrap_multisubnet` (String) DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here
+- `brfield_debug_flag` (String) Only for brf debugging purpose !!!
 - `cdp_enable` (Boolean) Enable CDP on management interface
+- `deployment_freeze` (Boolean) Disable all deployments in this fabric
 - `dhcp_enable` (Boolean) Automatic IP Assignment For POAP From Local DHCP Server
 - `dhcp_end` (String) End Address For Switch Out-of-Band POAP
 - `dhcp_ipv6_enable` (String) No description available
@@ -71,18 +74,25 @@ resource "ndfc_fabric_ipfm" "test_resource_fabric_ipfm_1" {
 - `dns_server_ip_list` (String) Comma separated list of IP Addresses (v4/v6)
 - `dns_server_vrf` (String) One VRF for all DNS servers or a comma separated list of VRFs, one per DNS server
 - `enable_aaa` (Boolean) Include AAA configs from Manageability tab during device bootup
+- `enable_agent` (Boolean) Enable Agent (development purpose only)
 - `enable_asm` (Boolean) Enable groups with receivers sending (*,G) joins
 - `enable_nbm_passive` (Boolean) Enable NBM mode to pim-passive for default VRF
+- `enable_nxapi` (Boolean) Enable HTTPS NX-API
+- `enable_nxapi_http` (Boolean) Enable HTTP NX-API
+- `enable_rt_intf_stats` (Boolean) Valid for NX-OS only
+- `ext_fabric_type` (String) External Fabric Type
 - `extra_conf_intra_links` (String) Additional CLIs For All Intra-Fabric Links
 - `extra_conf_leaf` (String) Additional CLIs For All Leafs and Tier2 Leafs As Captured From Show Running Configuration
 - `extra_conf_spine` (String) Additional CLIs For All Spines As Captured From Show Running Configuration
-- `fabric_interface_type` (String) Only Numbered(Point-to-Point) is supported
 - `fabric_mtu` (Number) Must be an even number
-- `feature_ptp` (Boolean) No description available
-- `isis_auth_enable` (Boolean) No description available
+- `feature_ptp` (Boolean) Enable Precision Time Protocol (PTP)
+- `ff` (String) Template Family
+- `grfield_debug_flag` (String) Enable to clean switch configuration without reload when PreserveConfig=no
+- `intf_stat_load_interval` (Number) Time in seconds (Min:5, Max:300)
+- `isis_auth_enable` (Boolean) Enable IS-IS Authentication
 - `isis_auth_key` (String) Cisco Type 7 Encrypted
-- `isis_auth_keychain_key_id` (Number) No description available
-- `isis_auth_keychain_name` (String) No description available
+- `isis_auth_keychain_key_id` (Number) IS-IS Authentication Key ID (Min:0, Max:65535)
+- `isis_auth_keychain_name` (String) IS-IS Authentication Keychain Name
 - `isis_level` (String) Supported IS types: level-1, level-2
 - `isis_p2p_enable` (Boolean) This will enable network point-to-point on fabric interfaces which are numbered
 - `l2_host_intf_mtu` (Number) Must be an even number
@@ -90,21 +100,24 @@ resource "ndfc_fabric_ipfm" "test_resource_fabric_ipfm_1" {
 - `link_state_routing_tag` (String) Routing process tag for the fabric
 - `loopback0_ip_range` (String) Routing Loopback IP Address Range
 - `mgmt_gw` (String) Default Gateway For Management VRF On The Switch
-- `mgmt_prefix` (Number) No description available
+- `mgmt_prefix` (Number) Switch Mgmt IP Subnet Prefix (Min:8, Max:30)
 - `ntp_server_ip_list` (String) Comma separated list of IP Addresses (v4/v6)
 - `ntp_server_vrf` (String) One VRF for all NTP servers or a comma separated list of VRFs, one per NTP server
+- `nxapi_http_port` (Number) NX-API HTTP Port Number
+- `nxapi_https_port` (Number) NX-API HTTPS Port Number
 - `nxapi_vrf` (String) VRF used for NX-API communication
 - `ospf_area_id` (String) OSPF Area Id in IP address format
-- `ospf_auth_enable` (Boolean) No description available
+- `ospf_auth_enable` (Boolean) Enable OSPF Authentication
 - `ospf_auth_key` (String) 3DES Encrypted
 - `ospf_auth_key_id` (Number) No description available
-- `pim_hello_auth_enable` (Boolean) No description available
+- `pim_hello_auth_enable` (Boolean) Enable PIM Hello Authentication
 - `pim_hello_auth_key` (String) 3DES Encrypted
-- `pm_enable` (Boolean) No description available
+- `pm_enable` (Boolean) Enable Performance Monitoring
 - `power_redundancy_mode` (String) Default power supply mode for the fabric
-- `ptp_domain_id` (Number) Multiple Independent PTP Clocking Subdomains on a Single Network
+- `ptp_domain_id` (Number) Multiple Independent PTP Clocking Subdomains on a Single Network (Min:0, Max:127)
 - `ptp_lb_id` (Number) No description available
 - `ptp_profile` (String) Enabled on ISL links only
+- `replication_mode` (String) Replication Mode
 - `routing_lb_id` (Number) No description available
 - `rp_ip_range` (String) RP Loopback IP Address Range
 - `rp_lb_id` (Number) No description available
@@ -114,9 +127,44 @@ resource "ndfc_fabric_ipfm" "test_resource_fabric_ipfm_1" {
 - `subnet_target_mask` (Number) Mask for Fabric Subnet IP Range
 - `syslog_server_ip_list` (String) Comma separated list of IP Addresses (v4/v6)
 - `syslog_server_vrf` (String) One VRF for all Syslog servers or a comma separated list of VRFs, one per Syslog server
-- `syslog_sev` (String) Comma separated list of Syslog severity values, one per Syslog server
+- `syslog_sev` (String) Comma separated list of Syslog severity values, one per Syslog server (Min:0, Max:7)
 
 ### Read-Only
 
+- `abstract_dhcp` (String) DHCP Configuration
+- `abstract_extra_config_bootstrap` (String) Add Extra Configuration for Bootstrap
+- `abstract_extra_config_leaf` (String) Add Extra Configuration for Leaf
+- `abstract_extra_config_spine` (String) Add Extra Configuration for Spine
+- `abstract_isis` (String) ISIS Network Configuration
+- `abstract_isis_interface` (String) ISIS Interface Configuration
+- `abstract_loopback_interface` (String) Primary Loopback Interface Configuration
+- `abstract_ospf` (String) OSPF Network Configuration
+- `abstract_ospf_interface` (String) OSPF Interface Configuration
+- `abstract_pim_interface` (String) PIM Interface Configuration
+- `abstract_routed_host` (String) L3 Port Configuration
+- `bootstrap_multisubnet_internal` (String) Internal Bootstrap Multi Subnet Scope
 - `deployment_status` (String) This fields shows the actual status of the deployment. It can be one of the following: Deployment pending Deployment successful
-- `id` (String) Terraform unique Id for the fabric resource
+- `dhcp_end_internal` (String) Internal DHCP End Address
+- `dhcp_ipv6_enable_internal` (String) Internal DHCP IPv6 Enable
+- `dhcp_start_internal` (String) Internal DHCP Start Address
+- `enable_nbm_passive_prev` (Boolean) Previous state of Enable NBM Passive Mode
+- `fabric_interface_type` (String) Only Numbered(Point-to-Point) is supported
+- `fabric_mtu_prev` (Number) Previous state of Fabric MTU
+- `fabric_technology` (String) Fabric Technology
+- `fabric_type` (String) Fabric Type
+- `feature_ptp_internal` (Boolean) Internal Feature PTP
+- `id` (String) Terraform unique Id for the ipfm fabric resource
+- `interface_ethernet_default_policy` (String) Default policy for Ethernet interface of spine/leaf/ tier2-leaf switches
+- `interface_loopback_default_policy` (String) Loopback Interface Default Policy
+- `interface_port_channel_default_policy` (String) Port Channel Interface Default Policy
+- `interface_vlan_default_policy` (String) VLAN Interface Default Policy
+- `l2_host_intf_mtu_prev` (Number) Previous state of Layer 2 Host Interface MTU
+- `link_state_routing_tag_prev` (String) Previous state of Link State Routing Tag
+- `mgmt_gw_internal` (String) Internal Management Gateway
+- `mgmt_prefix_internal` (Number) Internal Management Prefix
+- `mgmt_v6prefix` (Number) Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)
+- `mgmt_v6prefix_internal` (Number) Internal Management IPv6 Prefix
+- `pm_enable_prev` (Boolean) Previous state of Enable Performance Monitoring
+- `rp_ip_range_internal` (String) Internal RP IP Range
+- `spine_count` (Number) Spine Count
+- `upgrade_from_version` (String) Upgrade From Version

--- a/docs/resources/fabric_lan_classic.md
+++ b/docs/resources/fabric_lan_classic.md
@@ -3,12 +3,12 @@
 page_title: "ndfc_fabric_lan_classic Resource - terraform-provider-ndfc"
 subcategory: ""
 description: |-
-  Resource to configure and manage a LAN Classic Fabric
+  Resource to configure and manage a LAN Classic Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.
 ---
 
 # ndfc_fabric_lan_classic (Resource)
 
-Resource to configure and manage a LAN Classic Fabric
+Resource to configure and manage a LAN Classic Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.
 
 ## Example Usage
 
@@ -91,52 +91,81 @@ resource "ndfc_fabric_lan_classic" "test_resource_fabric_lan_classic_1" {
 ### Required
 
 - `deploy` (Boolean) This flag does configuration save and deploy
-- `fabric_name` (String) Fabric name to be created, updated or deleted (Max Size 64).
+- `fabric_name` (String) Fabric name to be created, updated or deleted.
 
 ### Optional
 
 - `aaa_remote_ip_enabled` (Boolean) Enable only, when IP Authorization is enabled in the AAA Server
 - `aaa_server_conf` (String) AAA Configurations
+- `allow_nxc` (Boolean) Allow onboarding of this fabric to Nexus Cloud
 - `bootstrap_conf` (String) Additional CLIs required during device bootup/login e.g. AAA/Radius
-- `bootstrap_enable` (Boolean) Automatic IP Assignment For POAP
-- `bootstrap_multisubnet` (String) lines with # prefix are ignored here
+- `bootstrap_enable` (Boolean) Automatic IP Assignment For POAP (For NX-OS Switches Only)
+- `bootstrap_multisubnet` (String) DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here
 - `cdp_enable` (Boolean) Enable CDP on management interface
+- `dci_subnet_range` (String) Address range to assign P2P DCI Links
+- `dci_subnet_target_mask` (Number) Target Mask for Subnet Range (Min:8, Max:31)
+- `deployment_freeze` (Boolean) Disable all deployments in this fabric
 - `dhcp_enable` (Boolean) Automatic IP Assignment For POAP From Local DHCP Server
 - `dhcp_end` (String) End Address For Switch POAP
-- `dhcp_ipv6_enable` (String) No description available
+- `dhcp_ipv6_enable` (String) DHCP Version
 - `dhcp_start` (String) Start Address For Switch POAP
 - `enable_aaa` (Boolean) Include AAA configs from Advanced tab during device bootup
 - `enable_netflow` (Boolean) Enable Netflow on VTEPs
 - `enable_nxapi` (Boolean) Enable HTTPS NX-API
-- `enable_nxapi_http` (Boolean) No description available
+- `enable_nxapi_http` (Boolean) Enable HTTP NX-API
 - `enable_real_time_backup` (Boolean) Backup hourly only if there is any config deployment since last backup
+- `enable_rt_intf_stats` (Boolean) Valid for NX-OS only
 - `enable_scheduled_backup` (Boolean) Backup at the specified time
+- `ext_fabric_type` (String) External Fabric Type
 - `fabric_freeform` (String) Additional supported CLIs for all same OS (e.g. all NxOS etc) switches
-- `feature_ptp` (Boolean) No description available
+- `feature_ptp` (Boolean) Enable Precision Time Protocol (PTP)
+- `ff` (String) Template Family
 - `inband_enable` (Boolean) Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should be Enabled)
 - `inband_mgmt` (Boolean) Import switches with inband connectivity
+- `intf_stat_load_interval` (Number) Time in seconds (Min:5, Max:300)
 - `is_read_only` (Boolean) If enabled, fabric is only monitored. No configuration will be deployed
+- `loopback0_ip_range` (String) Underlay Routing Loopback IP Range
 - `mgmt_gw` (String) Default Gateway For Management VRF On The Switch
-- `mgmt_prefix` (Number) No description available
-- `mgmt_v6prefix` (Number) No description available
-- `mpls_handoff` (Boolean) No description available
-- `mpls_lb_id` (Number) No description available
+- `mgmt_prefix` (Number) Switch Mgmt IP Subnet Prefix (Min:8, Max:30)
+- `mpls_handoff` (Boolean) Enable MPLS Handoff
+- `mpls_lb_id` (Number) (Min:0, Max:1023)
 - `mpls_loopback_ip_range` (String) MPLS Loopback IP Address Range
 - `netflow_exporter_list` (String) One or Multiple Netflow Exporters
 - `netflow_monitor_list` (String) One or Multiple Netflow Monitors
 - `netflow_record_list` (String) One or Multiple Netflow Records
-- `netflow_sampler_list` (String) One or multiple netflow Samplers. Applicable to N7K only
-- `nxapi_http_port` (Number) No description available
-- `nxapi_https_port` (Number) No description available
-- `pm_enable` (Boolean) No description available
+- `netflow_sampler_list` (String) One or multiple Netflow Samplers. Applicable to N7K only
+- `nxapi_http_port` (Number) NX-API HTTP Port Number
+- `nxapi_https_port` (Number) NX-API HTTPS Port Number
+- `nxc_dest_vrf` (String) VRF to be used to reach Nexus Cloud, enter 'management' for management VRF and 'default' for default VRF
+- `nxc_proxy_port` (Number) Proxy port number, default is 8080
+- `nxc_proxy_server` (String) IPv4 or IPv6 address, or DNS name of the proxy server
+- `nxc_src_intf` (String) Source interface for communication to Nexus Cloud, mandatory if Destination VRF is not management
+- `overwrite_global_nxc` (Boolean) If enabled, Fabric NxCloud Settings will be used
+- `pm_enable` (Boolean) Enable Performance Monitoring (For NX-OS Switches Only)
 - `power_redundancy_mode` (String) Default Power Supply Mode For Bootstrapped NX-OS Switches
-- `ptp_domain_id` (Number) Multiple Independent PTP Clocking Subdomains on a Single Network
-- `ptp_lb_id` (Number) No description available
+- `ptp_domain_id` (Number) Multiple Independent PTP Clocking Subdomains on a Single Network (Min:0, Max:127)
+- `ptp_lb_id` (Number) (Min:0, Max:1023)
 - `scheduled_time` (String) Time (UTC) in 24hr format. (00:00 to 23:59)
 - `snmp_server_host_trap` (Boolean) Configure NDFC as a receiver for SNMP traps
-- `subinterface_range` (String) Per Border Dot1q Range For VRF Lite Connectivity
+- `subinterface_range` (String) Per Border Dot1q Range For VRF Lite Connectivity (Min:2, Max:4093)
 
 ### Read-Only
 
+- `allow_nxc_prev` (Boolean) Previous state of Allow onboarding of this fabric to Nexus Cloud
+- `bootstrap_multisubnet_internal` (String) Internal Bootstrap Multi Subnet Scope
 - `deployment_status` (String) This fields shows the  status of the deployment. It can be one of the following: Deployment pending Deployment successful
+- `dhcp_end_internal` (String) Internal DHCP End Address
+- `dhcp_ipv6_enable_internal` (String) Internal DHCP IPv6 Enable
+- `dhcp_start_internal` (String) Internal DHCP Start Address
+- `enable_netflow_prev` (Boolean) Previous state of Enable Netflow on VTEPs
+- `fabric_technology` (String) Fabric Technology
+- `fabric_type` (String) Fabric Type
+- `feature_ptp_internal` (Boolean) Internal Feature PTP
 - `id` (String) Terraform unique Id for the fabric resource
+- `inband_enable_prev` (Boolean) Previous state of Enable POAP over Inband Interface
+- `inband_mgmt_prev` (Boolean) Previous state of Inband Management
+- `mgmt_gw_internal` (String) Internal Management Gateway
+- `mgmt_prefix_internal` (Number) Internal Management Prefix
+- `mgmt_v6prefix` (Number) Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)
+- `mgmt_v6prefix_internal` (Number) Internal Management IPv6 Prefix
+- `pm_enable_prev` (Boolean) Previous state of Enable Performance Monitoring

--- a/docs/resources/fabric_msite_ext_net.md
+++ b/docs/resources/fabric_msite_ext_net.md
@@ -3,12 +3,12 @@
 page_title: "ndfc_fabric_msite_ext_net Resource - terraform-provider-ndfc"
 subcategory: ""
 description: |-
-  Resource to configure an Multi-Site Network Fabric
+  Resource to configure an Multi-Site Network Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.
 ---
 
 # ndfc_fabric_msite_ext_net (Resource)
 
-Resource to configure an Multi-Site Network Fabric
+Resource to configure an Multi-Site Network Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.
 
 ## Example Usage
 
@@ -89,59 +89,92 @@ resource "ndfc_fabric_msite_ext_net" "test_resource_fabric_msite_ext_net_1" {
 
 ### Required
 
-- `bgp_as` (String) 1-4294967295 | 1-65535.0-65535 It is a good practice to have a unique ASN for each Fabric.
+- `bgp_as` (String) 1-4294967295 | 1-65535.0-65535. It is a good practice to have a unique ASN for each Fabric.
 - `deploy` (Boolean) This flag does configuration save and deploy
-- `fabric_name` (String) Fabric name to be created, updated or deleted (Max Size 64).
+- `fabric_name` (String) Fabric name to be created, updated or deleted.
 
 ### Optional
 
 - `aaa_remote_ip_enabled` (Boolean) Enable only, when IP Authorization is enabled in the AAA Server
 - `aaa_server_conf` (String) AAA Configurations
+- `allow_nxc` (Boolean) Allow onboarding of this fabric to Nexus Cloud
 - `bootstrap_conf` (String) Additional CLIs required during device bootup/login e.g. AAA/Radius
 - `bootstrap_conf_xe` (String) Additional CLIs required during device bootup/login e.g. AAA/Radius
-- `bootstrap_enable` (Boolean) Automatic IP Assignment For POAP
-- `bootstrap_multisubnet` (String) lines with # prefix are ignored here
+- `bootstrap_enable` (Boolean) Automatic IP Assignment For POAP (For NX-OS and IOS XE (Cat9K) Switches Only)
+- `bootstrap_multisubnet` (String) "DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here"
 - `cdp_enable` (Boolean) Enable CDP on management interface
+- `dci_subnet_range` (String) Address range to assign P2P DCI Links
+- `dci_subnet_target_mask` (Number) Target Mask for Subnet Range (Min:8, Max:31)
+- `deployment_freeze` (Boolean) Disable all deployments in this fabric
+- `deployment_status` (String) This fields shows the actual status of the deployment. It can be one of the following: Deployment pending Deployment successful
 - `dhcp_enable` (Boolean) Automatic IP Assignment For POAP From Local DHCP Server
 - `dhcp_end` (String) End Address For Switch POAP
-- `dhcp_ipv6_enable` (String) No description available
+- `dhcp_ipv6_enable` (String) DHCP Version
 - `dhcp_start` (String) Start Address For Switch POAP
 - `domain_name` (String) Domain name for DHCP server PnP block
 - `enable_aaa` (Boolean) Include AAA configs from Advanced tab during device bootup
 - `enable_netflow` (Boolean) Enable Netflow on VTEPs
 - `enable_nxapi` (Boolean) Enable HTTPS NX-API
-- `enable_nxapi_http` (Boolean) No description available
+- `enable_nxapi_http` (Boolean) Enable HTTP NX-API
 - `enable_real_time_backup` (Boolean) Backup hourly only if there is any config deployment since last backup
 - `enable_rt_intf_stats` (Boolean) Valid for NX-OS only
 - `enable_scheduled_backup` (Boolean) Backup at the specified time
+- `ext_fabric_type` (String) External Fabric Type
 - `fabric_freeform` (String) Additional supported CLIs for all same OS (e.g. all NxOS or IOS-XE, etc) switches
-- `feature_ptp` (Boolean) No description available
+- `feature_ptp` (Boolean) Enable Precision Time Protocol (PTP)
+- `ff` (String) Template Family
 - `inband_enable` (Boolean) Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should be Enabled)
 - `inband_mgmt` (Boolean) Import switches with inband connectivity
 - `intf_stat_load_interval` (Number) Time in seconds
 - `is_read_only` (Boolean) If enabled, fabric is only monitored. No configuration will be deployed
+- `loopback0_ip_range` (String) Underlay Routing Loopback IP Range
 - `mgmt_gw` (String) Default Gateway For Management VRF On The Switch
-- `mgmt_prefix` (Number) No description available
-- `mgmt_v6prefix` (Number) No description available
-- `mpls_handoff` (Boolean) No description available
-- `mpls_lb_id` (Number) No description available
+- `mgmt_prefix` (Number) Switch Mgmt IP Subnet Prefix
+- `mgmt_v6prefix` (Number) Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)
+- `mpls_handoff` (Boolean) Enable MPLS Handoff
+- `mpls_lb_id` (Number) (Min:0, Max:1023)
 - `mpls_loopback_ip_range` (String) MPLS Loopback IP Address Range
 - `netflow_exporter_list` (String) One or Multiple Netflow Exporters
 - `netflow_monitor_list` (String) One or Multiple Netflow Monitors
 - `netflow_record_list` (String) One or Multiple Netflow Records
 - `netflow_sampler_list` (String) One or multiple netflow Samplers. Applicable to N7K only
-- `nxapi_http_port` (Number) No description available
-- `nxapi_https_port` (Number) No description available
-- `pm_enable` (Boolean) No description available
+- `nxapi_http_port` (Number) NX-API HTTP Port Number
+- `nxapi_https_port` (Number) NX-API HTTPS Port Number
+- `nxc_dest_vrf` (String) VRF to be used to reach Nexus Cloud, enter 'management' for management VRF and 'default' for default VRF
+- `nxc_proxy_port` (Number) Proxy port number, default is 8080
+- `nxc_proxy_server` (String) IPv4 or IPv6 address, or DNS name of the proxy server
+- `nxc_src_intf` (String) Source interface for communication to Nexus Cloud, mandatory if Destination VRF is not management
+- `overwrite_global_nxc` (Boolean) If enabled, Fabric NxCloud Settings will be used
+- `pm_enable` (Boolean) Enable Performance Monitoring (For NX-OS and IOS XE Switches Only)
 - `pnp_enable` (Boolean) Enable Plug n Play (Automatic IP Assignment) for Cat9K switches
 - `power_redundancy_mode` (String) Default Power Supply Mode For Bootstrapped NX-OS Switches
 - `ptp_domain_id` (Number) Multiple Independent PTP Clocking Subdomains on a Single Network
-- `ptp_lb_id` (Number) No description available
+- `ptp_lb_id` (Number) (Min:0, Max:1023)
 - `scheduled_time` (String) Time (UTC) in 24hr format. (00:00 to 23:59)
 - `snmp_server_host_trap` (Boolean) Configure NDFC as a receiver for SNMP traps
-- `subinterface_range` (String) Per Border Dot1q Range For VRF Lite Connectivity
+- `subinterface_range` (String) Per Border Dot1q Range For VRF Lite Connectivity (Min:2, Max:4093)
 
 ### Read-Only
 
-- `deployment_status` (String) This fields shows the actual status of the deployment. It can be one of the following: Deployment pending Deployment successful
+- `allow_nxc_prev` (Boolean) Previous state of Allow onboarding of this fabric to Nexus Cloud
+- `bootstrap_multisubnet_internal` (String) Internal Bootstrap Multi Subnet Scope
+- `dhcp_end_internal` (String) Internal DHCP End Address
+- `dhcp_ipv6_enable_internal` (String) Internal DHCP IPv6 Enable
+- `dhcp_start_internal` (String) Internal DHCP Start Address
+- `domain_name_internal` (String) Internal Domain Name
+- `enable_netflow_prev` (Boolean) Previous state of Enable Netflow on VTEPs
+- `fabric_type` (String) Fabric Type
+- `feature_ptp_internal` (Boolean) Internal Feature PTP
 - `id` (String) Terraform unique Id for the fabric resource
+- `inband_enable_prev` (Boolean) Previous state of Enable POAP over Inband Interface
+- `inband_mgmt_prev` (Boolean) Previous state of Inband Management
+- `mgmt_gw_internal` (String) Internal Management Gateway
+- `mgmt_prefix_internal` (Number) Internal Management Prefix
+- `mgmt_v6prefix_internal` (Number) Internal Management IPv6 Prefix
+- `mso_connectivity_deployed` (String) MSO Connectivity Deployed
+- `mso_controler_id` (String) MSO Controller ID
+- `mso_site_group_name` (String) MSO Site Group Name
+- `mso_site_id` (String) MSO Site ID
+- `pm_enable_prev` (Boolean) Previous state of Enable Performance Monitoring
+- `pnp_enable_internal` (Boolean) Internal PnP Enable
+- `premso_parent_fabric` (String) Pre-MSO Parent Fabric

--- a/docs/resources/fabric_vxlan_msd.md
+++ b/docs/resources/fabric_vxlan_msd.md
@@ -3,12 +3,12 @@
 page_title: "ndfc_fabric_vxlan_msd Resource - terraform-provider-ndfc"
 subcategory: ""
 description: |-
-  Resource to configure and manage a VXLAN MSD Fabric
+  Resource to configure and manage a VXLAN MSD Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.
 ---
 
 # ndfc_fabric_vxlan_msd (Resource)
 
-Resource to configure and manage a VXLAN MSD Fabric
+Resource to configure and manage a VXLAN MSD Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.
 
 ## Example Usage
 
@@ -44,47 +44,77 @@ resource "ndfc_fabric_vxlan_msd" "test_resource_fabric_vxlan_msd_1" {
 ### Required
 
 - `deploy` (Boolean) This flag does configuration save and deploy
-- `fabric_name` (String) Fabric name to be created, updated or deleted (Max Size 64).
+- `fabric_name` (String) Fabric name to be created, updated or deleted.
 
 ### Optional
 
-- `anycast_gw_mac` (String) Shared MAC address for all leaves
-- `bgp_rp_asn` (String) 1-4294967295 | 1-65535.0-65535, e.g. 65000, 65001
+- `anycast_gw_mac` (String) Shared MAC address for all leafs
+- `bgp_rp_asn` (String) 1-4294967295 | 1-65535[.0-65535], e.g. 65000, 65001
 - `bgw_routing_tag` (Number) Routing tag associated with IP address of loopback and DCI interfaces
 - `border_gwy_connections` (String) Manual, Auto Overlay EVPN Peering to Route Servers, Auto Overlay EVPN Direct Peering to Border Gateways
-- `cloudsec_algorithm` (String) AES_128_CMAC or AES_256_CMAC
+- `cloudsec_algorithm` (String) CloudSec Cryptographic Algorithm
 - `cloudsec_autoconfig` (Boolean) Auto Config CloudSec on Border Gateways
-- `cloudsec_enforcement` (String) If set to strict, data across site must be encrypted.
+- `cloudsec_enforcement` (String) If set to 'strict', data across site must be encrypted.
 - `cloudsec_key_string` (String) Cisco Type 7 Encrypted Octet String
 - `cloudsec_report_timer` (Number) CloudSec Operational Status periodic report timer in minutes
 - `dci_subnet_range` (String) Address range to assign P2P DCI Links
-- `dci_subnet_target_mask` (Number) Target Mask for Subnet Range
+- `dci_subnet_target_mask` (Number) Target Mask for Subnet Range (Min:8, Max:31)
 - `default_network` (String) Default Overlay Network Template For Leafs
 - `default_pvlan_sec_network` (String) Default PVLAN Secondary Network Template
 - `default_vrf` (String) Default Overlay VRF Template For Leafs
 - `delay_restore` (Number) Multi-Site underlay and overlay control plane convergence time in seconds
-- `enable_bgp_bfd` (Boolean) For auto-created Multi-Site Underlay IFCs
-- `enable_bgp_log_neighbor_change` (Boolean) For auto-created Multi-Site Underlay IFCs
-- `enable_bgp_send_comm` (Boolean) For auto-created Multi-Site Underlay IFCs
+- `enable_bgp_bfd` (Boolean) BGP BFD on Multi-Site Underlay IFCs
+- `enable_bgp_log_neighbor_change` (Boolean) BGP log neighbor change on Multi-Site Underlay IFCs
+- `enable_bgp_send_comm` (Boolean) BGP Send-community on Multi-Site Underlay IFCs
 - `enable_pvlan` (Boolean) Enable PVLAN on MSD and its child fabrics
 - `enable_rs_redist_direct` (Boolean) For auto-created Multi-Site overlay IFCs in Route Servers. Applicable only when Multi-Site Overlay IFC Deployment Method is Centralized_To_Route_Server.
 - `enable_scheduled_backup` (Boolean) Backup at the specified time. Note: Fabric Backup/Restore functionality is being deprecated for MSD fabrics. Recommendation is to use NDFC Backup & Restore
+- `enable_sgt` (String) Enable Security Groups
+- `enable_trm_trmv6` (Boolean) Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites
+- `ext_fabric_type` (String) External Fabric Type
+- `ff` (String) Template Family
 - `l2_segment_id_range` (String) Overlay Network Identifier Range
 - `l3_partition_id_range` (String) Overlay VRF Identifier Range
-- `loopback100_ip_range` (String) Typically Loopback100 IP Address Range
+- `loopback100_ip_range` (String) Multi-Site VTEP VIP Loopback IP Range
+- `loopback100_ipv6_range` (String) Multi-Site VTEP VIP Loopback IPv6 Range
 - `ms_ifc_bgp_auth_key_type` (Number) BGP Key Encryption Type: 3 - 3DES, 7 - Cisco
 - `ms_ifc_bgp_password` (String) Encrypted eBGP Password Hex String
-- `ms_ifc_bgp_password_enable` (Boolean) eBGP password for Multi-Site underlay/overlay IFCs
-- `ms_loopback_id` (Number) No description available
-- `ms_underlay_autoconfig` (Boolean) No description available
+- `ms_ifc_bgp_password_enable` (Boolean) Enable Multi-Site eBGP Password
+- `ms_loopback_id` (Number) Multi-Site VTEP VIP Loopback ID
+- `ms_underlay_autoconfig` (Boolean) Multi-Site Underlay IFC Auto Deployment Flag
 - `network_extension_template` (String) Default Overlay Network Template For Borders
 - `rp_server_ip` (String) Multi-Site Route-Server peer list (typically loopback IP address on Route-Server for Multi-Site EVPN peering with BGWs), e.g. 128.89.0.1, 128.89.0.2
 - `rs_routing_tag` (Number) Routing tag associated with Route Server IP for redistribute direct. This is the IP used in eBGP EVPN peering.
 - `scheduled_time` (String) Time (UTC) in 24hr format. (00:00 to 23:59)
+- `sgt_id_range` (String) Security Group Tag (SGT) ID Range
+- `sgt_name_prefix` (String) Prefix to be used when a new Security Group is created.
+- `sgt_preprovision` (Boolean) Generate security groups configuration for non-enforced VRFs
 - `tor_auto_deploy` (Boolean) Enables Overlay VLANs on uplink between ToRs and Leafs
+- `v6_dci_subnet_range` (String) Address range to assign P2P DCI Links
+- `v6_dci_subnet_target_mask` (Number) Target IPv6 Mask for Subnet Range (Min:120, Max:127)
 - `vrf_extension_template` (String) Default Overlay VRF Template For Borders
+- `vxlan_underlay_is_v6` (Boolean) If not enabled, IPv4 underlay is used in child VXLAN fabric
 
 ### Read-Only
 
+- `bgw_routing_tag_prev` (String) Previous state of Border Gateway Routing Tag
+- `dcnm_id` (String) DCNM ID
 - `deployment_status` (String) This fields shows the actual status of the deployment. It can be one of the following: Deployment pending Deployment successful
+- `enable_pvlan_prev` (Boolean) Previous state of Enable PVLAN
+- `enable_sgt_prev` (String) Previous state of Enable Security Groups
+- `enable_trm_trmv6_prev` (Boolean) Previous state of Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites
+- `fabric_type` (String) Fabric Type
 - `id` (String) Terraform unique Id for the fabric resource
+- `ms_ifc_bgp_auth_key_type_prev` (Number) BGP Key Encryption Type: 3 - 3DES, 7 - Cisco
+- `ms_ifc_bgp_password_enable_prev` (Boolean) Previous state of Enable Multi-Site eBGP Password
+- `ms_ifc_bgp_password_prev` (String) Previous state of eBGP Password
+- `mso_controler_id` (String) MSO Controller ID
+- `mso_site_group_name` (String) MSO Site Group Name
+- `parent_onemanage_fabric` (String) Parent OneManage Fabric
+- `premso_parent_fabric` (String) Pre-MSO Parent Fabric
+- `sgt_id_range_prev` (String) Previous state of Security Group Tag (SGT) ID Range
+- `sgt_name_prefix_prev` (String) Previous state of Security Group Name Prefix
+- `sgt_oper_status` (String) Operational status for Security Groups
+- `sgt_preprov_recalc_status` (String) Recalculation status for Security Groups Pre-provision
+- `sgt_preprovision_prev` (Boolean) Previous state of Security Groups Pre-provision
+- `sgt_recalc_status` (String) Recalculation status for Security Groups

--- a/examples/resources/ndfc_fabric_ipfm/resource.tf
+++ b/examples/resources/ndfc_fabric_ipfm/resource.tf
@@ -9,7 +9,6 @@ resource "ndfc_fabric_ipfm" "test_resource_fabric_ipfm_1" {
   enable_aaa               = false
   enable_asm               = false
   enable_nbm_passive       = false
-  fabric_interface_type    = "p2p"
   fabric_mtu               = 9216
   feature_ptp              = false
   isis_auth_enable         = false

--- a/generator/defs/fabric_common.yaml
+++ b/generator/defs/fabric_common.yaml
@@ -21,7 +21,8 @@ resource:
 
         - model_name: AAA_REMOTE_IP_ENABLED
           tf_name: aaa_remote_ip_enabled
-          description: Enable only, when IP Authorization is enabled in the AAA Server
+          description: >-
+            Enable only, when IP Authorization is enabled in the AAA Server
           computed: true
           optional: true
           type: Bool
@@ -33,13 +34,16 @@ resource:
 
         - model_name: ASM_GROUP_RANGES
           tf_name: asm_group_ranges
-          description: 'ASM group ranges with prefixes (len:4-32) example: 239.1.1.0/25,
-            max 20 ranges. Enabling SPT-Threshold Infinity to prevent switchover to source-tree.'
+          description: >-
+            ASM group ranges with prefixes (len:4-32) example: 239.1.1.0/25,
+            max 20 ranges. Enabling SPT-Threshold Infinity to prevent
+            switchover to source-tree.
           type: String
 
         - model_name: BOOTSTRAP_CONF
           tf_name: bootstrap_conf
-          description: Additional CLIs required during device bootup/login e.g. AAA/Radius
+          description: Additional CLIs required during device bootup/login e.g.
+            AAA/Radius
           type: String
 
         - model_name: BOOTSTRAP_ENABLE
@@ -93,20 +97,15 @@ resource:
 
         - model_name: DNS_SERVER_VRF
           tf_name: dns_server_vrf
-          description: One VRF for all DNS servers or a comma separated list of VRFs, one
+          description: >-
+            One VRF for all DNS servers or a comma separated list of VRFs, one
             per DNS server
           type: String
 
         - model_name: ENABLE_AAA
           tf_name: enable_aaa
-          description: Include AAA configs from Manageability tab during device bootup
-          computed: true
-          optional: true
-          type: Bool
-
-        - model_name: ENABLE_ASM
-          tf_name: enable_asm
-          description: Enable groups with receivers sending (*,G) joins
+          description: Include AAA configs from Manageability tab during device
+            bootup
           computed: true
           optional: true
           type: Bool
@@ -131,13 +130,16 @@ resource:
 
         - model_name: EXTRA_CONF_LEAF
           tf_name: extra_conf_leaf
-          description: Additional CLIs For All Leafs and Tier2 Leafs As Captured From Show
+          description: >-
+            Additional CLIs For All Leafs and Tier2 Leafs As Captured From Show
             Running Configuration
           type: String
 
         - model_name: EXTRA_CONF_SPINE
           tf_name: extra_conf_spine
-          description: Additional CLIs For All Spines As Captured From Show Running Configuration
+          description: >-
+            Additional CLIs For All Spines As Captured From Show Running
+            Configuration
           type: String
 
         - model_name: FABRIC_INTERFACE_TYPE
@@ -196,7 +198,8 @@ resource:
 
         - model_name: ISIS_P2P_ENABLE
           tf_name: isis_p2p_enable
-          description: This will enable network point-to-point on fabric interfaces which
+          description: >-
+            This will enable network point-to-point on fabric interfaces which
             are numbered
           type: Bool
 
@@ -248,7 +251,8 @@ resource:
 
         - model_name: NTP_SERVER_VRF
           tf_name: ntp_server_vrf
-          description: One VRF for all NTP servers or a comma separated list of VRFs, one
+          description: >-
+            One VRF for all NTP servers or a comma separated list of VRFs, one
             per NTP server
           type: String
 
@@ -314,7 +318,8 @@ resource:
 
         - model_name: PTP_DOMAIN_ID
           tf_name: ptp_domain_id
-          description: Multiple Independent PTP Clocking Subdomains on a Single Network
+          description: >-
+            Multiple Independent PTP Clocking Subdomains on a Single Network
           type: Int64
           handle_empty: true
 
@@ -358,7 +363,8 @@ resource:
 
         - model_name: STATIC_UNDERLAY_IP_ALLOC
           tf_name: static_underlay_ip_alloc
-          description: Checking this will disable Dynamic Fabric IP Address Allocations
+          description: Checking this will disable Dynamic Fabric IP Address
+            Allocations
           computed: true
           optional: true
           type: Bool
@@ -386,25 +392,30 @@ resource:
 
         - model_name: SYSLOG_SERVER_VRF
           tf_name: syslog_server_vrf
-          description: One VRF for all Syslog servers or a comma separated list of VRFs,
+          description: >-
+            One VRF for all Syslog servers or a comma separated list of VRFs,
             one per Syslog server
           type: String
 
         - model_name: SYSLOG_SEV
           tf_name: syslog_sev
-          description: Comma separated list of Syslog severity values, one per Syslog server
+          description: >-
+            Comma separated list of Syslog severity values, one per Syslog
+            server
           type: String
 
         - model_name: BGP_AS
           tf_name: bgp_as
-          description: 1-4294967295 | 1-65535.0-65535 It is a good practice to have a unique
-            ASN for each Fabric.
+          description: >-
+            1-4294967295 | 1-65535.0-65535. It is a good practice to have a
+            unique ASN for each Fabric.
           type: String
           mandatory: true
 
         - model_name: BOOTSTRAP_CONF_XE
           tf_name: bootstrap_conf_xe
-          description: Additional CLIs required during device bootup/login e.g. AAA/Radius
+          description: Additional CLIs required during device bootup/login e.g.
+            AAA/Radius
           type: String
 
         - model_name: DOMAIN_NAME
@@ -435,21 +446,25 @@ resource:
 
         - model_name: ENABLE_RT_INTF_STATS
           tf_name: enable_rt_intf_stats
-          description: Enable Real Time Interface Statistics Collection - Valid for NX-OS only
+          description: >-
+            Enable Real Time Interface Statistics Collection - Valid for NX-OS
+            only
           type: Bool
           computed: true
           optional: true
 
         - model_name: FABRIC_FREEFORM
           tf_name: fabric_freeform
-          description: Additional supported CLIs for all same OS (e.g. all NxOS or IOS-XE,
+          description: >-
+            Additional supported CLIs for all same OS (e.g. all NxOS or IOS-XE,
             etc) switches
           type: String
 
         - model_name: INBAND_ENABLE
           tf_name: inband_enable
-          description: 'Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should
-            be Enabled)'
+          description: >-
+            Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should
+            be Enabled)
           type: Bool
 
         - model_name: INBAND_MGMT
@@ -467,7 +482,9 @@ resource:
 
         - model_name: IS_READ_ONLY
           tf_name: is_read_only
-          description: If enabled, fabric is only monitored. No configuration will be deployed
+          description: >-
+            If enabled, fabric is only monitored. No configuration will be
+            deployed
           computed: true
           optional: true
           type: Bool
@@ -534,7 +551,8 @@ resource:
 
         - model_name: PNP_ENABLE
           tf_name: pnp_enable
-          description: Enable Plug n Play (Automatic IP Assignment) for Cat9K switches
+          description: Enable Plug n Play (Automatic IP Assignment) for Cat9K
+            switches
           type: Bool
 
         - model_name: SUBINTERFACE_RANGE
@@ -546,7 +564,9 @@ resource:
 
         - model_name: enableRealTimeBackup
           tf_name: enable_real_time_backup
-          description: Backup hourly only if there is any config deployment since last backup
+          description: >-
+            Backup hourly only if there is any config deployment since last
+            backup
           type: Bool
 
         - model_name: enableScheduledBackup
@@ -561,22 +581,25 @@ resource:
 
         - model_name: ADVERTISE_PIP_BGP
           tf_name: advertise_pip_bgp
-          description: For Primary VTEP IP Advertisement As Next-Hop Of Prefix Routes
+          description: For Primary VTEP IP Advertisement As Next-Hop Of Prefix
+            Routes
           computed: true
           optional: true
           type: Bool
 
         - model_name: ADVERTISE_PIP_ON_BORDER
           tf_name: advertise_pip_on_border
-          description: Enable advertise-pip on vPC borders and border gateways only. Applicable
-            only when vPC advertise-pip is not enabled
+          description: >-
+            Enable advertise-pip on vPC borders and border gateways only.
+            Applicable only when vPC advertise-pip is not enabled
           computed: true
           optional: true
           type: Bool
 
         - model_name: ANYCAST_BGW_ADVERTISE_PIP
           tf_name: anycast_bgw_advertise_pip
-          description: To advertise Anycast Border Gateway PIP as VTEP. Effective on MSD
+          description: >-
+            To advertise Anycast Border Gateway PIP as VTEP. Effective on MSD
             fabric Recalculate Config
           computed: true
           optional: true
@@ -604,44 +627,49 @@ resource:
 
         - model_name: AUTO_SYMMETRIC_DEFAULT_VRF
           tf_name: auto_symmetric_default_vrf
-          description: Whether to auto generate Default VRF interface and BGP peering configuration
-            on managed neighbor devices. If set, auto created VRF Lite IFC links will have
-            Auto Deploy Default VRF for Peer enabled.
+          description: >-
+            Whether to auto generate Default VRF interface and BGP peering
+            configuration on managed neighbor devices. If set, auto created VRF
+            Lite IFC links will have Auto Deploy Default VRF for Peer enabled.
           computed: true
           optional: true
           type: Bool
 
         - model_name: AUTO_SYMMETRIC_VRF_LITE
           tf_name: auto_symmetric_vrf_lite
-          description: Whether to auto generate VRF LITE sub-interface and BGP peering configuration
-            on managed neighbor devices. If set, auto created VRF Lite IFC links will have
-            Auto Deploy for Peer enabled.
+          description: >-
+            Whether to auto generate VRF LITE sub-interface and BGP peering
+            configuration on managed neighbor devices. If set, auto created VRF
+            Lite IFC links will have Auto Deploy for Peer enabled.
           computed: true
           optional: true
           type: Bool
 
         - model_name: AUTO_UNIQUE_VRF_LITE_IP_PREFIX
           tf_name: auto_unique_vrf_lite_ip_prefix
-          description: When enabled, IP prefix allocated to the VRF LITE IFC is not reused
-            on VRF extension over VRF LITE IFC. Instead, unique IP Subnet is allocated for
-            each VRF extension over VRF LITE IFC.
+          description: >-
+            When enabled, IP prefix allocated to the VRF LITE IFC is not reused
+            on VRF extension over VRF LITE IFC. Instead, unique IP Subnet is
+            allocated for each VRF extension over VRF LITE IFC.
           computed: true
           optional: true
           type: Bool
 
         - model_name: AUTO_VRFLITE_IFC_DEFAULT_VRF
           tf_name: auto_vrflite_ifc_default_vrf
-          description: Whether to auto generate Default VRF interface and BGP peering configuration
-            on VRF LITE IFC auto deployment. If set, auto created VRF Lite IFC links will
-            have Auto Deploy Default VRF enabled.
+          description: >-
+            Whether to auto generate Default VRF interface and BGP peering
+            configuration on VRF LITE IFC auto deployment. If set, auto created
+            VRF Lite IFC links will have Auto Deploy Default VRF enabled.
           computed: true
           optional: true
           type: Bool
 
         - model_name: BANNER
           tf_name: banner
-          description: Message of the Day (motd) banner. Delimiter char (very first char
-            is delimiter char) followed by message ending with delimiter)
+          description: >-
+            Message of the Day (motd) banner. Delimiter char (very first char is
+            delimiter char) followed by message ending with delimiter)
           type: String
 
         - model_name: BFD_AUTH_ENABLE
@@ -760,10 +788,10 @@ resource:
         - model_name: DCI_SUBNET_TARGET_MASK
           tf_name: dci_subnet_target_mask
           description: No description available
-          computed: true
-          optional: true
           type: Int64
           handle_empty: true
+          computed: true
+          optional: true
 
         - model_name: DEAFULT_QUEUING_POLICY_CLOUDSCALE
           tf_name: default_queuing_policy_cloudscale
@@ -1353,14 +1381,6 @@ resource:
           description: 1-4294967295 | 1-65535.0-65535, e.g. 65000, 65001
           type: String
 
-        - model_name: BGW_ROUTING_TAG
-          tf_name: bgw_routing_tag
-          description: Routing tag associated with IP address of loopback and DCI interfaces
-          computed: true
-          optional: true
-          type: Int64
-          handle_empty: true
-
         - model_name: BORDER_GWY_CONNECTIONS
           tf_name: border_gwy_connections
           description: Manual, Auto Overlay EVPN Peering to Route Servers, Auto Overlay
@@ -1843,7 +1863,6 @@ resource:
           type: String
           example: Easy_Fabric
           computed: true
-          optional: true
 
         - model_name: BGP_AS_PREV
           tf_name: bgp_as_prev
@@ -2369,2052 +2388,2394 @@ resource:
           type: Bool
           computed: true
 
-    datasource:
-        name: fabric
-        doc_category: Fabric
-        generate_tf_resource: true
-        description: Basic data source attribute for all fabric types
-        attributes:
-            - model_name: FABRIC_NAME
-              tf_name: fabric_name
-              type: String
-              description: 'Fabric name'
-              mandatory: true
-              example: 'CML'
-
-            - model_name: AAA_REMOTE_IP_ENABLED
-              tf_name: aaa_remote_ip_enabled
-              type: Bool
-              description: 'Enable only, when IP Authorization is enabled in the AAA Server'
-              computed: true
-
-            - model_name: AAA_SERVER_CONF
-              tf_name: aaa_server_conf
-              type: String
-              description: AAA Configurations
-              computed: true
-
-            - model_name: ADVERTISE_PIP_BGP
-              tf_name: advertise_pip_bgp
-              type: Bool
-              description: For Primary VTEP IP Advertisement As Next-Hop Of Prefix Routes
-              computed: true
-
-            - model_name: ADVERTISE_PIP_ON_BORDER
-              tf_name: advertise_pip_on_border
-              type: Bool
-              description: >-
-                Enable advertise-pip on vPC borders and border gateways only. Applicable
-                only when vPC advertise-pip is not enabled
-              computed: true
-
-            - model_name: ANYCAST_BGW_ADVERTISE_PIP
-              tf_name: anycast_bgw_advertise_pip
-              type: Bool
-              description: >-
-                To advertise Anycast Border Gateway PIP as VTEP. Effective on MSD fabric
-                Recalculate Config
-              computed: true
-
-            - model_name: ANYCAST_GW_MAC
-              tf_name: anycast_gw_mac
-              type: String
-              description: Shared MAC address for all leafs (xxxx.xxxx.xxxx)
-              computed: true
-
-            - model_name: ANYCAST_LB_ID
-              tf_name: anycast_lb_id
-              type: Int64
-              handle_empty: true
-              description: Used for vPC Peering in VXLANv6 Fabrics
-              computed: true
-
-            - model_name: ANYCAST_RP_IP_RANGE
-              tf_name: anycast_rp_ip_range
-              type: String
-              description: Anycast or Phantom RP IP Address Range
-              computed: true
-
-            - model_name: AUTO_SYMMETRIC_DEFAULT_VRF
-              tf_name: auto_symmetric_default_vrf
-              type: Bool
-              description: >-
-                Whether to auto generate Default VRF interface and BGP peering
-                configuration on managed neighbor devices. If set, auto created VRF Lite
-                IFC links will have Auto Deploy Default VRF for Peer enabled.
-              computed: true
-
-            - model_name: AUTO_SYMMETRIC_VRF_LITE
-              tf_name: auto_symmetric_vrf_lite
-              type: Bool
-              description: >-
-                Whether to auto generate VRF LITE sub-interface and BGP peering
-                configuration on managed neighbor devices. If set, auto created VRF Lite
-                IFC links will have Auto Deploy for Peer enabled.
-              computed: true
-
-            - model_name: AUTO_UNIQUE_VRF_LITE_IP_PREFIX
-              tf_name: auto_unique_vrf_lite_ip_prefix
-              type: Bool
-              description: >-
-                When enabled, IP prefix allocated to the VRF LITE IFC is not reused on
-                VRF extension over VRF LITE IFC. Instead, unique IP Subnet is allocated
-                for each VRF extension over VRF LITE IFC.
-              computed: true
-
-            - model_name: AUTO_VRFLITE_IFC_DEFAULT_VRF
-              tf_name: auto_vrflite_ifc_default_vrf
-              type: Bool
-              description: >-
-                Whether to auto generate Default VRF interface and BGP peering
-                configuration on VRF LITE IFC auto deployment. If set, auto created VRF
-                Lite IFC links will have Auto Deploy Default VRF enabled.
-              computed: true
-
-            - model_name: BANNER
-              tf_name: banner
-              type: String
-              description: >-
-                Message of the Day (motd) banner. Delimiter char (very first char is
-                delimiter char) followed by message ending with delimiter)
-              computed: true
-
-            - model_name: BFD_AUTH_ENABLE
-              tf_name: bfd_auth_enable
-              type: Bool
-              description: Valid for P2P Interfaces only
-              computed: true
-
-            - model_name: BFD_AUTH_KEY
-              tf_name: bfd_auth_key
-              type: String
-              description: Encrypted SHA1 secret value
-              computed: true
-
-            - model_name: BFD_AUTH_KEY_ID
-              tf_name: bfd_auth_key_id
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: BFD_ENABLE
-              tf_name: bfd_enable
-              type: Bool
-              description: Valid for IPv4 Underlay only
-              computed: true
-
-            - model_name: BFD_IBGP_ENABLE
-              tf_name: bfd_ibgp_enable
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: BFD_ISIS_ENABLE
-              tf_name: bfd_isis_enable
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: BFD_OSPF_ENABLE
-              tf_name: bfd_ospf_enable
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: BFD_PIM_ENABLE
-              tf_name: bfd_pim_enable
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: BGP_AS
-              tf_name: bgp_as
-              type: String
-              description: >-
-                1-4294967295 | 1-65535.0-65535 It is a good practice to have a unique
-                ASN for each Fabric.
-              computed: true
-
-            - model_name: BGP_AUTH_ENABLE
-              tf_name: bgp_auth_enable
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: BGP_AUTH_KEY
-              tf_name: bgp_auth_key
-              type: String
-              description: Encrypted BGP Authentication Key based on type
-              computed: true
-
-            - model_name: BGP_AUTH_KEY_TYPE
-              tf_name: bgp_auth_key_type
-              type: Int64
-              handle_empty: true
-              description: 'BGP Key Encryption Type: 3 - 3DES, 7 - Cisco'
-              computed: true
-
-            - model_name: BGP_LB_ID
-              tf_name: bgp_lb_id
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: BOOTSTRAP_CONF
-              tf_name: bootstrap_conf
-              type: String
-              description: Additional CLIs required during device bootup/login e.g. AAA/Radius
-              computed: true
-
-            - model_name: BOOTSTRAP_ENABLE
-              tf_name: bootstrap_enable
-              type: Bool
-              description: Automatic IP Assignment For POAP
-              computed: true
-
-            - model_name: BOOTSTRAP_MULTISUBNET
-              tf_name: bootstrap_multisubnet
-              type: String
-              description: '''lines with # prefix are ignored here'''
-              computed: true
-
-            - model_name: BROWNFIELD_NETWORK_NAME_FORMAT
-              tf_name: brownfield_network_name_format
-              type: String
-              description: Generated network name should be < 64 characters
-              computed: true
-
-            - model_name: BROWNFIELD_SKIP_OVERLAY_NETWORK_ATTACHMENTS
-              tf_name: brownfield_skip_overlay_network_attachments
-              type: Bool
-              description: >-
-                Enable to skip overlay network interface attachments for Brownfield and
-                Host Port Resync cases
-              computed: true
-
-            - model_name: CDP_ENABLE
-              tf_name: cdp_enable
-              type: Bool
-              description: Enable CDP on management interface
-              computed: true
-
-            - model_name: COPP_POLICY
-              tf_name: copp_policy
-              type: String
-              description: >-
-                Fabric Wide CoPP Policy. Customized CoPP policy should be provided when
-                manual is selected
-              computed: true
-
-            - model_name: DCI_SUBNET_RANGE
-              tf_name: dci_subnet_range
-              type: String
-              description: Address range to assign P2P Interfabric Connections
-              computed: true
-
-            - model_name: DCI_SUBNET_TARGET_MASK
-              tf_name: dci_subnet_target_mask
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: DEAFULT_QUEUING_POLICY_CLOUDSCALE
-              tf_name: default_queuing_policy_cloudscale
-              type: String
-              description: >-
-                Queuing Policy for all 92xx, -EX, -FX, -FX2, -FX3, -GX series switches
-                in the fabric
-              computed: true
-
-            - model_name: DEAFULT_QUEUING_POLICY_OTHER
-              tf_name: default_queuing_policy_other
-              type: String
-              description: Queuing Policy for all other switches in the fabric
-              computed: true
-
-            - model_name: DEAFULT_QUEUING_POLICY_R_SERIES
-              tf_name: default_queuing_policy_r_series
-              type: String
-              description: Queuing Policy for all R-Series switches in the fabric
-              computed: true
-
-            - model_name: DEFAULT_VRF_REDIS_BGP_RMAP
-              tf_name: default_vrf_redis_bgp_rmap
-              type: String
-              description: >-
-                Route Map used to redistribute BGP routes to IGP in default vrf in auto
-                created VRF Lite IFC links
-              computed: true
-
-            - model_name: DHCP_ENABLE
-              tf_name: dhcp_enable
-              type: Bool
-              description: Automatic IP Assignment For POAP From Local DHCP Server
-              computed: true
-
-            - model_name: DHCP_END
-              tf_name: dhcp_end
-              type: String
-              description: End Address For Switch POAP
-              computed: true
-
-            - model_name: DHCP_IPV6_ENABLE
-              tf_name: dhcp_ipv6_enable
-              type: String
-              description: No description available
-              computed: true
-
-            - model_name: DHCP_START
-              tf_name: dhcp_start
-              type: String
-              description: Start Address For Switch POAP
-              computed: true
-
-            - model_name: DNS_SERVER_IP_LIST
-              tf_name: dns_server_ip_list
-              type: String
-              description: Comma separated list of IP Addresses(v4/v6)
-              computed: true
-
-            - model_name: DNS_SERVER_VRF
-              tf_name: dns_server_vrf
-              type: String
-              description: >-
-                One VRF for all DNS servers or a comma separated list of VRFs, one per
-                DNS server
-              computed: true
-
-            - model_name: ENABLE_AAA
-              tf_name: enable_aaa
-              type: Bool
-              description: Include AAA configs from Manageability tab during device bootup
-              computed: true
-
-            - model_name: ENABLE_DEFAULT_QUEUING_POLICY
-              tf_name: enable_default_queuing_policy
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: ENABLE_FABRIC_VPC_DOMAIN_ID
-              tf_name: enable_fabric_vpc_domain_id
-              type: Bool
-              description: (Not Recommended)
-              computed: true
-
-            - model_name: ENABLE_MACSEC
-              tf_name: enable_macsec
-              type: Bool
-              description: Enable MACsec in the fabric
-              computed: true
-
-            - model_name: ENABLE_NETFLOW
-              tf_name: enable_netflow
-              type: Bool
-              description: Enable Netflow on VTEPs
-              computed: true
-
-            - model_name: ENABLE_NGOAM
-              tf_name: enable_ngoam
-              type: Bool
-              description: >-
-                Enable the Next Generation (NG) OAM feature for all switches in the
-                fabric to aid in trouble-shooting VXLAN EVPN fabrics
-              computed: true
-
-            - model_name: ENABLE_NXAPI
-              tf_name: enable_nxapi
-              type: Bool
-              description: Enable HTTPS NX-API
-              computed: true
-
-            - model_name: ENABLE_NXAPI_HTTP
-              tf_name: enable_nxapi_http
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: ENABLE_PBR
-              tf_name: enable_pbr
-              type: Bool
-              description: >-
-                When ESR option is ePBR, enable ePBR will enable pbr, sla sender and
-                epbr features on the switch
-              computed: true
-
-            - model_name: ENABLE_PVLAN
-              tf_name: enable_pvlan
-              type: Bool
-              description: Enable PVLAN on switches except spines and super spines
-              computed: true
-
-            - model_name: ENABLE_TENANT_DHCP
-              tf_name: enable_tenant_dhcp
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: ENABLE_TRM
-              tf_name: enable_trm
-              type: Bool
-              description: For Overlay Multicast Support In VXLAN Fabrics
-              computed: true
-
-            - model_name: ENABLE_VPC_PEER_LINK_NATIVE_VLAN
-              tf_name: enable_vpc_peer_link_native_vlan
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: EXTRA_CONF_INTRA_LINKS
-              tf_name: extra_conf_intra_links
-              type: String
-              description: Additional CLIs For All Intra-Fabric Links
-              computed: true
-
-            - model_name: EXTRA_CONF_LEAF
-              tf_name: extra_conf_leaf
-              type: String
-              description: >-
-                Additional CLIs For All Leafs As Captured From Show Running
-                Configuration
-              computed: true
-
-            - model_name: EXTRA_CONF_SPINE
-              tf_name: extra_conf_spine
-              type: String
-              description: >-
-                Additional CLIs For All Spines As Captured From Show Running
-                Configuration
-              computed: true
-
-            - model_name: EXTRA_CONF_TOR
-              tf_name: extra_conf_tor
-              type: String
-              description: Additional CLIs For All ToRs As Captured From Show Running Configuration
-              computed: true
-
-            - model_name: FABRIC_INTERFACE_TYPE
-              tf_name: fabric_interface_type
-              type: String
-              description: Numbered(Point-to-Point) or Unnumbered
-              computed: true
-
-            - model_name: FABRIC_MTU
-              tf_name: fabric_mtu
-              type: Int64
-              handle_empty: true
-              description: Must be an even number
-              computed: true
-
-            - model_name: FABRIC_VPC_DOMAIN_ID
-              tf_name: fabric_vpc_domain_id
-              type: Int64
-              handle_empty: true
-              description: vPC Domain Id to be used on all vPC pairs
-              computed: true
-
-            - model_name: FABRIC_VPC_QOS
-              tf_name: fabric_vpc_qos
-              type: Bool
-              description: >-
-                Qos on spines for guaranteed delivery of vPC Fabric Peering
-                communication
-              computed: true
-
-            - model_name: FABRIC_VPC_QOS_POLICY_NAME
-              tf_name: fabric_vpc_qos_policy_name
-              type: String
-              description: Qos Policy name should be same on all spines
-              computed: true
-
-            - model_name: FEATURE_PTP
-              tf_name: feature_ptp
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: GRFIELD_DEBUG_FLAG
-              tf_name: grfield_debug_flag
-              type: String
-              description: >-
-                Enable to clean switch configuration without reload when
-                PreserveConfig=no
-              computed: true
-
-            - model_name: HD_TIME
-              tf_name: hd_time
-              type: Int64
-              handle_empty: true
-              description: NVE Source Inteface HoldDown Time in seconds
-              computed: true
-
-            - model_name: HOST_INTF_ADMIN_STATE
-              tf_name: host_intf_admin_state
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: IBGP_PEER_TEMPLATE
-              tf_name: ibgp_peer_template
-              type: String
-              description: >-
-                Speficies the iBGP Peer-Template config used for RR and spines with
-                border role.
-              computed: true
-
-            - model_name: IBGP_PEER_TEMPLATE_LEAF
-              tf_name: ibgp_peer_template_leaf
-              type: String
-              description: >-
-                Specifies the config used for leaf, border or border gateway. If this
-                field is empty, the peer template defined in iBGP Peer-Template Config
-                is used on all BGP enabled devices (RRs,leafs, border or border gateway
-                roles.
-              computed: true
-
-            - model_name: INBAND_DHCP_SERVERS
-              tf_name: inband_dhcp_servers
-              type: String
-              description: Comma separated list of IPv4 Addresses (Max 3)
-              computed: true
-
-            - model_name: INBAND_MGMT
-              tf_name: inband_mgmt
-              type: Bool
-              description: Manage switches with only Inband connectivity
-              computed: true
-
-            - model_name: ISIS_AUTH_ENABLE
-              tf_name: isis_auth_enable
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: ISIS_AUTH_KEY
-              tf_name: isis_auth_key
-              type: String
-              description: Cisco Type 7 Encrypted
-              computed: true
-
-            - model_name: ISIS_AUTH_KEYCHAIN_KEY_ID
-              tf_name: isis_auth_keychain_key_id
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: ISIS_AUTH_KEYCHAIN_NAME
-              tf_name: isis_auth_keychain_name
-              type: String
-              description: No description available
-              computed: true
-
-            - model_name: ISIS_LEVEL
-              tf_name: isis_level
-              type: String
-              description: 'Supported IS types: level-1, level-2'
-              computed: true
-
-            - model_name: ISIS_OVERLOAD_ELAPSE_TIME
-              tf_name: isis_overload_elapse_time
-              type: Int64
-              handle_empty: true
-              description: Clear the overload bit after an elapsed time in seconds
-              computed: true
-
-            - model_name: ISIS_OVERLOAD_ENABLE
-              tf_name: isis_overload_enable
-              type: Bool
-              description: 'When enabled, set the overload bit for an elapsed time after a reload'
-              computed: true
-
-            - model_name: ISIS_P2P_ENABLE
-              tf_name: isis_p2p_enable
-              type: Bool
-              description: >-
-                This will enable network point-to-point on fabric interfaces which are
-                numbered
-              computed: true
-
-            - model_name: L2_HOST_INTF_MTU
-              tf_name: l2_host_intf_mtu
-              type: Int64
-              handle_empty: true
-              description: Must be an even number
-              computed: true
-
-            - model_name: L2_SEGMENT_ID_RANGE
-              tf_name: l2_segment_id_range
-              type: String
-              description: Overlay Network Identifier Range
-              computed: true
-
-            - model_name: L3VNI_MCAST_GROUP
-              tf_name: l3vni_mcast_group
-              type: String
-              description: Default Underlay Multicast group IP assigned for every overlay VRF.
-              computed: true
-
-            - model_name: L3_PARTITION_ID_RANGE
-              tf_name: l3_partition_id_range
-              type: String
-              description: Overlay VRF Identifier Range
-              computed: true
-
-            - model_name: LINK_STATE_ROUTING
-              tf_name: link_state_routing
-              type: String
-              description: Used for Spine-Leaf Connectivity
-              computed: true
-
-            - model_name: LINK_STATE_ROUTING_TAG
-              tf_name: link_state_routing_tag
-              type: String
-              description: Underlay Routing Process Tag
-              computed: true
-
-            - model_name: LOOPBACK0_IPV6_RANGE
-              tf_name: loopback0_ipv6_range
-              type: String
-              description: Typically Loopback0 IPv6 Address Range
-              computed: true
-
-            - model_name: LOOPBACK0_IP_RANGE
-              tf_name: loopback0_ip_range
-              type: String
-              description: Typically Loopback0 IP Address Range
-              computed: true
-
-            - model_name: LOOPBACK1_IPV6_RANGE
-              tf_name: loopback1_ipv6_range
-              type: String
-              description: Typically Loopback1 and Anycast Loopback IPv6 Address Range
-              computed: true
-
-            - model_name: LOOPBACK1_IP_RANGE
-              tf_name: loopback1_ip_range
-              type: String
-              description: Typically Loopback1 IP Address Range
-              computed: true
-
-            - model_name: MACSEC_ALGORITHM
-              tf_name: macsec_algorithm
-              type: String
-              description: AES_128_CMAC or AES_256_CMAC
-              computed: true
-
-            - model_name: MACSEC_CIPHER_SUITE
-              tf_name: macsec_cipher_suite
-              type: String
-              description: Configure Cipher Suite
-              computed: true
-
-            - model_name: MACSEC_FALLBACK_ALGORITHM
-              tf_name: macsec_fallback_algorithm
-              type: String
-              description: AES_128_CMAC or AES_256_CMAC
-              computed: true
-
-            - model_name: MACSEC_FALLBACK_KEY_STRING
-              tf_name: macsec_fallback_key_string
-              type: String
-              description: Cisco Type 7 Encrypted Octet String
-              computed: true
-
-            - model_name: MACSEC_KEY_STRING
-              tf_name: macsec_key_string
-              type: String
-              description: Cisco Type 7 Encrypted Octet String
-              computed: true
-
-            - model_name: MACSEC_REPORT_TIMER
-              tf_name: macsec_report_timer
-              type: Int64
-              handle_empty: true
-              description: MACsec Operational Status periodic report timer in minutes
-              computed: true
-
-            - model_name: MGMT_GW
-              tf_name: mgmt_gw
-              type: String
-              description: Default Gateway For Management VRF On The Switch
-              computed: true
-
-            - model_name: MGMT_PREFIX
-              tf_name: mgmt_prefix
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: MGMT_V6PREFIX
-              tf_name: mgmt_v6prefix
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: MPLS_HANDOFF
-              tf_name: mpls_handoff
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: MPLS_LB_ID
-              tf_name: mpls_lb_id
-              type: Int64
-              handle_empty: true
-              description: Used for VXLAN to MPLS SR/LDP Handoff
-              computed: true
-
-            - model_name: MPLS_LOOPBACK_IP_RANGE
-              tf_name: mpls_loopback_ip_range
-              type: String
-              description: Used for VXLAN to MPLS SR/LDP Handoff
-              computed: true
-
-            - model_name: MST_INSTANCE_RANGE
-              tf_name: mst_instance_range
-              type: String
-              description: 'MST instance range, Example: 0-3,5,7-9, Default is 0'
-              computed: true
-
-            - model_name: MULTICAST_GROUP_SUBNET
-              tf_name: multicast_group_subnet
-              type: String
-              description: >-
-                Multicast pool prefix between 8 to 30. A multicast group IP from this
-                pool is used for BUM traffic for each overlay network.
-              computed: true
-
-            - model_name: NETFLOW_EXPORTER_LIST
-              tf_name: netflow_exporter_list
-              type: String
-              description: One or Multiple Netflow Exporters
-              computed: true
-
-            - model_name: NETFLOW_MONITOR_LIST
-              tf_name: netflow_monitor_list
-              type: String
-              description: One or Multiple Netflow Monitors
-              computed: true
-
-            - model_name: NETFLOW_RECORD_LIST
-              tf_name: netflow_record_list
-              type: String
-              description: One or Multiple Netflow Records
-              computed: true
-
-            - model_name: NETWORK_VLAN_RANGE
-              tf_name: network_vlan_range
-              type: String
-              description: Per Switch Overlay Network VLAN Range
-              computed: true
-
-            - model_name: NTP_SERVER_IP_LIST
-              tf_name: ntp_server_ip_list
-              type: String
-              description: Comma separated list of IP Addresses(v4/v6)
-              computed: true
-
-            - model_name: NTP_SERVER_VRF
-              tf_name: ntp_server_vrf
-              type: String
-              description: >-
-                One VRF for all NTP servers or a comma separated list of VRFs, one per
-                NTP server
-              computed: true
-
-            - model_name: NVE_LB_ID
-              tf_name: nve_lb_id
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: NXAPI_HTTPS_PORT
-              tf_name: nxapi_https_port
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: NXAPI_HTTP_PORT
-              tf_name: nxapi_http_port
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: OBJECT_TRACKING_NUMBER_RANGE
-              tf_name: object_tracking_number_range
-              type: String
-              description: Per switch tracked object ID Range
-              computed: true
-
-            - model_name: OSPF_AREA_ID
-              tf_name: ospf_area_id
-              type: String
-              description: OSPF Area Id in IP address format
-              computed: true
-
-            - model_name: OSPF_AUTH_ENABLE
-              tf_name: ospf_auth_enable
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: OSPF_AUTH_KEY
-              tf_name: ospf_auth_key
-              type: String
-              description: 3DES Encrypted
-              computed: true
-
-            - model_name: OSPF_AUTH_KEY_ID
-              tf_name: ospf_auth_key_id
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: OVERLAY_MODE
-              tf_name: overlay_mode
-              type: String
-              description: VRF/Network configuration using config-profile or CLI
-              computed: true
-
-            - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION
-              tf_name: per_vrf_loopback_auto_provision
-              type: Bool
-              description: Auto provision a loopback on a VTEP on VRF attachment
-              computed: true
-
-            - model_name: PER_VRF_LOOPBACK_IP_RANGE
-              tf_name: per_vrf_loopback_ip_range
-              type: String
-              description: >-
-                Prefix pool to assign IP addresses to loopbacks on VTEPs on a per VRF
-                basis
-              computed: true
-
-            - model_name: PHANTOM_RP_LB_ID1
-              tf_name: phantom_rp_lb_id1
-              type: Int64
-              handle_empty: true
-              description: Used for Bidir-PIM Phantom RP
-              computed: true
-
-            - model_name: PHANTOM_RP_LB_ID2
-              tf_name: phantom_rp_lb_id2
-              type: Int64
-              handle_empty: true
-              description: Used for Fallback Bidir-PIM Phantom RP
-              computed: true
-
-            - model_name: PHANTOM_RP_LB_ID3
-              tf_name: phantom_rp_lb_id3
-              type: Int64
-              handle_empty: true
-              description: Used for second Fallback Bidir-PIM Phantom RP
-              computed: true
-
-            - model_name: PHANTOM_RP_LB_ID4
-              tf_name: phantom_rp_lb_id4
-              type: Int64
-              handle_empty: true
-              description: Used for third Fallback Bidir-PIM Phantom RP
-              computed: true
-
-            - model_name: PIM_HELLO_AUTH_ENABLE
-              tf_name: pim_hello_auth_enable
-              type: Bool
-              description: Valid for IPv4 Underlay only
-              computed: true
-
-            - model_name: PIM_HELLO_AUTH_KEY
-              tf_name: pim_hello_auth_key
-              type: String
-              description: 3DES Encrypted
-              computed: true
-
-            - model_name: PM_ENABLE
-              tf_name: pm_enable
-              type: Bool
-              description: No description available
-              computed: true
-
-            - model_name: POWER_REDUNDANCY_MODE
-              tf_name: power_redundancy_mode
-              type: String
-              description: Default Power Supply Mode For The Fabric
-              computed: true
-
-            - model_name: PTP_DOMAIN_ID
-              tf_name: ptp_domain_id
-              type: Int64
-              handle_empty: true
-              description: Multiple Independent PTP Clocking Subdomains on a Single Network
-              computed: true
-
-            - model_name: PTP_LB_ID
-              tf_name: ptp_lb_id
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: REPLICATION_MODE
-              tf_name: replication_mode
-              type: String
-              description: Replication Mode for BUM Traffic
-              computed: true
-
-            - model_name: ROUTER_ID_RANGE
-              tf_name: router_id_range
-              type: String
-              description: No description available
-              computed: true
-
-            - model_name: ROUTE_MAP_SEQUENCE_NUMBER_RANGE
-              tf_name: route_map_sequence_number_range
-              type: String
-              description: No description available
-              computed: true
-
-            - model_name: RP_COUNT
-              tf_name: rp_count
-              type: Int64
-              handle_empty: true
-              description: Number of spines acting as Rendezvous-Point (RP)
-              computed: true
-
-            - model_name: RP_LB_ID
-              tf_name: rp_lb_id
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: RP_MODE
-              tf_name: rp_mode
-              type: String
-              description: Multicast RP Mode
-              computed: true
-
-            - model_name: RR_COUNT
-              tf_name: rr_count
-              type: Int64
-              handle_empty: true
-              description: Number of spines acting as Route-Reflectors
-              computed: true
-
-            - model_name: SEED_SWITCH_CORE_INTERFACES
-              tf_name: seed_switch_core_interfaces
-              type: String
-              description: 'Core-facing Interface list on Seed Switch (e.g. e1/1-30,e1/32)'
-              computed: true
-
-            - model_name: SERVICE_NETWORK_VLAN_RANGE
-              tf_name: service_network_vlan_range
-              type: String
-              description: Per Switch Overlay Service Network VLAN Range
-              computed: true
-
-            - model_name: SITE_ID
-              tf_name: site_id
-              type: String
-              description: For EVPN Multi-Site Support . Defaults to Fabric ASN
-              computed: true
-
-            - model_name: SLA_ID_RANGE
-              tf_name: sla_id_range
-              type: String
-              description: Per switch SLA ID Range
-              computed: true
-
-            - model_name: SNMP_SERVER_HOST_TRAP
-              tf_name: snmp_server_host_trap
-              type: Bool
-              description: Configure NDFC as a receiver for SNMP traps
-              computed: true
-
-            - model_name: SPINE_SWITCH_CORE_INTERFACES
-              tf_name: spine_switch_core_interfaces
-              type: String
-              description: 'Core-facing Interface list on all Spines (e.g. e1/1-30,e1/32)'
-              computed: true
-
-            - model_name: STATIC_UNDERLAY_IP_ALLOC
-              tf_name: static_underlay_ip_alloc
-              type: Bool
-              description: Checking this will disable Dynamic Underlay IP Address Allocations
-              computed: true
-
-            - model_name: STP_BRIDGE_PRIORITY
-              tf_name: stp_bridge_priority
-              type: Int64
-              handle_empty: true
-              description: Bridge priority for the spanning tree in increments of 4096
-              computed: true
-
-            - model_name: STP_ROOT_OPTION
-              tf_name: stp_root_option
-              type: String
-              description: >-
-                Which protocol to use for configuring root bridge? rpvst+: Rapid
-                Per-VLAN Spanning Tree, mst: Multiple Spanning Tree, unmanaged
-                (default): STP Root not managed by NDFC
-              computed: true
-
-            - model_name: STP_VLAN_RANGE
-              tf_name: stp_vlan_range
-              type: String
-              description: 'Vlan range, Example: 1,3-5,7,9-11, Default is 1-3967'
-              computed: true
-
-            - model_name: STRICT_CC_MODE
-              tf_name: strict_cc_mode
-              type: Bool
-              description: >-
-                Enable bi-directional compliance checks to flag additional configs in
-                the running config that are not in the intent/expected config
-              computed: true
-
-            - model_name: SUBINTERFACE_RANGE
-              tf_name: subinterface_range
-              type: String
-              description: Per Border Dot1q Range For VRF Lite Connectivity
-              computed: true
-
-            - model_name: SUBNET_RANGE
-              tf_name: subnet_range
-              type: String
-              description: Address range to assign Numbered and Peer Link SVI IPs
-              computed: true
-
-            - model_name: SUBNET_TARGET_MASK
-              tf_name: subnet_target_mask
-              type: Int64
-              handle_empty: true
-              description: Mask for Underlay Subnet IP Range
-              computed: true
-
-            - model_name: SYSLOG_SERVER_IP_LIST
-              tf_name: syslog_server_ip_list
-              type: String
-              description: Comma separated list of IP Addresses(v4/v6)
-              computed: true
-
-            - model_name: SYSLOG_SERVER_VRF
-              tf_name: syslog_server_vrf
-              type: String
-              description: >-
-                One VRF for all Syslog servers or a comma separated list of VRFs, one
-                per Syslog server
-              computed: true
-
-            - model_name: SYSLOG_SEV
-              tf_name: syslog_sev
-              type: String
-              description: 'Comma separated list of Syslog severity values, one per Syslog server'
-              computed: true
-
-            - model_name: TCAM_ALLOCATION
-              tf_name: tcam_allocation
-              type: Bool
-              description: >-
-                TCAM commands are automatically generated for VxLAN and vPC Fabric
-                Peering when Enabled
-              computed: true
-
-            - model_name: UNDERLAY_IS_V6
-              tf_name: underlay_is_v6
-              type: Bool
-              description: 'If not enabled, IPv4 underlay is used'
-              computed: true
-
-            - model_name: UNNUM_BOOTSTRAP_LB_ID
-              tf_name: unnum_bootstrap_lb_id
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: UNNUM_DHCP_END
-              tf_name: unnum_dhcp_end
-              type: String
-              description: Must be a subset of IGP/BGP Loopback Prefix Pool
-              computed: true
-
-            - model_name: UNNUM_DHCP_START
-              tf_name: unnum_dhcp_start
-              type: String
-              description: Must be a subset of IGP/BGP Loopback Prefix Pool
-              computed: true
-
-            - model_name: USE_LINK_LOCAL
-              tf_name: use_link_local
-              type: Bool
-              description: 'If not enabled, Spine-Leaf interfaces will use global IPv6 addresses'
-              computed: true
-
-            - model_name: V6_SUBNET_RANGE
-              tf_name: v6_subnet_range
-              type: String
-              description: IPv6 Address range to assign Numbered and Peer Link SVI IPs
-              computed: true
-
-            - model_name: V6_SUBNET_TARGET_MASK
-              tf_name: v6_subnet_target_mask
-              type: Int64
-              handle_empty: true
-              description: Mask for Underlay Subnet IPv6 Range
-              computed: true
-
-            - model_name: VPC_AUTO_RECOVERY_TIME
-              tf_name: vpc_auto_recovery_time
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: VPC_DELAY_RESTORE
-              tf_name: vpc_delay_restore
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: VPC_DOMAIN_ID_RANGE
-              tf_name: vpc_domain_id_range
-              type: String
-              description: vPC Domain id range to use for new pairings
-              computed: true
-
-            - model_name: VPC_ENABLE_IPv6_ND_SYNC
-              tf_name: vpc_enable_ipv6_nd_sync
-              type: Bool
-              description: Enable IPv6 ND synchronization between vPC peers
-              computed: true
-
-            - model_name: VPC_PEER_KEEP_ALIVE_OPTION
-              tf_name: vpc_peer_keep_alive_option
-              type: String
-              description: Use vPC Peer Keep Alive with Loopback or Management
-              computed: true
-
-            - model_name: VPC_PEER_LINK_PO
-              tf_name: vpc_peer_link_po
-              type: Int64
-              handle_empty: true
-              description: No description available
-              computed: true
-
-            - model_name: VPC_PEER_LINK_VLAN
-              tf_name: vpc_peer_link_vlan
-              type: Int64
-              handle_empty: true
-              description: VLAN range for vPC Peer Link SVI
-              computed: true
-
-            - model_name: VRF_LITE_AUTOCONFIG
-              tf_name: vrf_lite_autoconfig
-              type: String
-              description: >-
-                VRF Lite Inter-Fabric Connection Deployment Options. If
-                Back2Back&ToExternal is selected, VRF Lite IFCs are auto created between
-                border devices of two Easy Fabrics, and between border devices in Easy
-                Fabric and edge routers in External Fabric. The IP address is taken from
-                the VRF Lite Subnet IP Range pool.
-              computed: true
-
-            - model_name: VRF_VLAN_RANGE
-              tf_name: vrf_vlan_range
-              type: String
-              description: Per Switch Overlay VRF VLAN Range
-              computed: true
-
-            - model_name: default_network
-              tf_name: default_network
-              type: String
-              description: Default Overlay Network Template For Leafs
-              computed: true
-
-            - model_name: default_pvlan_sec_network
-              tf_name: default_pvlan_sec_network
-              type: String
-              description: Default PVLAN Secondary Network Template
-              computed: true
-
-            - model_name: default_vrf
-              tf_name: default_vrf
-              type: String
-              description: Default Overlay VRF Template For Leafs
-              computed: true
-
-            - model_name: enableRealTimeBackup
-              tf_name: enable_real_time_backup
-              type: Bool
-              description: Backup hourly only if there is any config deployment since last backup
-              computed: true
-
-            - model_name: enableScheduledBackup
-              tf_name: enable_scheduled_backup
-              type: Bool
-              description: Backup at the specified time
-              computed: true
-
-            - model_name: network_extension_template
-              tf_name: network_extension_template
-              type: String
-              description: Default Overlay Network Template For Borders
-              computed: true
-
-            - model_name: scheduledTime
-              tf_name: scheduled_time
-              type: String
-              description: 'Time (UTC) in 24hr format. (00:00 to 23:59)'
-              computed: true
-
-            - model_name: vrf_extension_template
-              tf_name: vrf_extension_template
-              type: String
-              description: Default Overlay VRF Template For Borders
-              computed: true
-
-            - model_name: deployment_status
-              tf_name: deployment_status
-              type: String
-              description: >-
-                This fields shows the actual status of the deployment. It can be one of the following:
-                Deployment successful
-              computed: true
-
-            - model_name: IPv6_MULTICAST_GROUP_SUBNET
-              tf_name: ipv6_multicast_group_subnet
-              description: IPv6 Multicast Group Subnet - IPv6 Multicast address with prefix 112 to 128
-              type: String
-              example: "ff1e::/121"
-              computed: true
-
-            - model_name: ENABLE_TRMv6
-              tf_name: enable_trmv6
-              description: For Overlay IPv6 Multicast Support In VXLAN Fabrics
-              type: Bool
-              computed: true
-
-            - model_name: L3VNI_IPv6_MCAST_GROUP
-              tf_name: l3vni_ipv6_mcast_group
-              description: Default MDT IPv6 Address for TRM VRFs - Default Underlay Multicast group IP6 address assigned for every overlay VRF
-              type: String
-              example: "ff1e::"
-              computed: true
-
-            - model_name: MVPN_VRI_ID_RANGE
-              tf_name: mvpn_vri_id_range
-              description: MVPN VRI ID for vPC, applicable when TRM is enabled with IPv6 underlay, or TRM is enabled with IPv4 underlay while fabric allows L3VNI without VLAN option
-              type: String
-              computed: true
-
-            - model_name: ENABLE_VRI_ID_REALLOC
-              tf_name: enable_vri_id_realloc
-              description: One time VRI ID re-allocation based on 'MVPN VRI ID Range'
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_AGG_ACC_ID_RANGE
-              tf_name: enable_agg_acc_id_range
-              description: Use specific vPC/Port-channel ID range for leaf-tor pairings
-              type: Bool
-              computed: true
-
-            - model_name: AGG_ACC_VPC_PO_ID_RANGE
-              tf_name: agg_acc_vpc_po_id_range
-              description: Specify one vPC/Port-Channel ID range, this range is used for auto-allocating vPC/Port-Channel IDs for leaf-tor pairings
-              type: String
-              example: 1-499
-              computed: true
-
-            - model_name: ISIS_AREA_NUM
-              tf_name: isis_area_num
-              description: IS-IS NET Area Number - NET in form of XX.<4-hex-digit Custom Area Number>.XXXX.XXXX.XXXX.00
-              type: String
-              example: 0001
-              computed: true
-
-            - model_name: ENABLE_SGT
-              tf_name: enable_sgt
-              description: Enable Security Groups - Security group can be enabled only with V4 underlay and CLI overlay mode
-              type: Bool
-              computed: true
-
-            - model_name: SGT_NAME_PREFIX
-              tf_name: sgt_name_prefix
-              description: Security Group Name Prefix - Prefix to be used when a new Security Group is created (Min:1, Max:10 characters)
-              type: String
-              example: SG_
-              computed: true
-
-            - model_name: SGT_ID_RANGE
-              tf_name: sgt_id_range
-              description: "Security Group Tag (SGT) ID Range - Min:16, Max:65535. Reserved Range: 0-15"
-              type: String
-              example: 10000-14000
-              computed: true
-
-            - model_name: SGT_PREPROVISION
-              tf_name: sgt_preprovision
-              description: Security Groups Pre-provision - Generate security groups configuration for non-enforced VRFs
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_DCI_MACSEC
-              tf_name: enable_dci_macsec
-              description: Enable DCI MACsec - Enable MACsec on DCI links. DCI MACsec fabric parameters are used for configuring MACsec on a DCI link if 'Use Link MACsec Setting' is disabled on the link.
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_QKD
-              tf_name: enable_qkd
-              description: Enable QKD - Enable DCI MACsec with QKD config
-              type: Bool
-              computed: true
-
-            - model_name: ALLOW_L3VNI_NO_VLAN
-              tf_name: allow_l3vni_no_vlan
-              description: Whether allows L3 VNI configuration without VLAN configuration
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_L3VNI_NO_VLAN
-              tf_name: enable_l3vni_no_vlan
-              description: L3 VNI configuration without VLAN configuration. This value is propagated on vrf creation as the default value of 'Enable L3VNI w/o VLAN' in vrf
-              type: Bool
-              computed: true
-
-            - model_name: MPLS_ISIS_AREA_NUM
-              tf_name: mpls_isis_area_num
-              description: IS-IS NET Area Number for MPLS Handoff - NET in form of XX.<4-hex-digit Custom Area Number>.XXXX.XXXX.XXXX.00
-              type: String
-              example: 0001
-              computed: true
-
-            - model_name: ENABLE_AI_ML_QOS_POLICY
-              tf_name: enable_ai_ml_qos_policy
-              description: Configures QoS and Queuing Policies specific to N9K Cloud Scale switch fabric for AI/ML network loads
-              type: Bool
-              computed: true
-
-            - model_name: AI_ML_QOS_POLICY
-              tf_name: ai_ml_qos_policy
-              description: "Queuing Policy based on predominant fabric link speed: 400G / 100G / 25G"
-              type: String
-              example: AI_Fabric_QOS_400G
-              computed: true
-
-            - model_name: PFC_WATCH_INT
-              tf_name: pfc_watch_int
-              description: Priority flow control watch-dog interval - Acceptable values from 101 to 1000 (milliseconds). Leave blank for system default (100ms).
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: ENABLE_RT_INTF_STATS
-              tf_name: enable_rt_intf_stats
-              description: Enable Real Time Interface Statistics Collection - Valid for NX-OS only
-              type: Bool
-              computed: true
-
-            - model_name: IPv6_ANYCAST_RP_IP_RANGE
-              tf_name: ipv6_anycast_rp_ip_range
-              description: Anycast RP IPv6 Address Range
-              type: String
-              example: fd00::254:254:0/118
-              computed: true
-
-            - model_name: KME_SERVER_IP
-              tf_name: kme_server_ip
-              description: Key Management Entity server IPv4 address
-              type: String
-              computed: true
-
-            - model_name: KME_SERVER_PORT
-              tf_name: kme_server_port
-              description: Key Management Entity server port number
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: TRUSTPOINT_LABEL
-              tf_name: trustpoint_label
-              description: Tls authentication type trustpoint label (Max Size 64)
-              type: String
-              computed: true
-
-            - model_name: IGNORE_CERT
-              tf_name: ignore_cert
-              description: Skip verification of incoming certificate
-              type: Bool
-              computed: true
-
-            - model_name: DEPLOYMENT_FREEZE
-              tf_name: deployment_freeze
-              description: Disable all deployments in this fabric
-              type: Bool
-              computed: true
-
-            - model_name: QKD_PROFILE_NAME
-              tf_name: qkd_profile_name
-              description: Name of crypto profile (Max Size 63)
-              type: String
-              computed: true
-
-            - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION_V6
-              tf_name: per_vrf_loopback_auto_provision_v6
-              description: Auto provision a loopback IPv6 on a VTEP on VRF attachment
-              type: Bool
-              computed: true
-
-            - model_name: PER_VRF_LOOPBACK_IP_RANGE_V6
-              tf_name: per_vrf_loopback_ip_range_v6
-              description: Prefix pool to assign IPv6 addresses to loopbacks on VTEPs on a per VRF basis
-              type: String
-              example: fd00::a05:0/112
-              computed: true
-
-            - model_name: ESR_OPTION
-              tf_name: esr_option
-              description: Policy-Based Routing (PBR) or Enhanced PBR (ePBR)
-              type: String
-              computed: true
-              validator: 'OneOf("PBR", "ePBR")'
-
-            - model_name: PTP_VLAN_ID
-              tf_name: ptp_vlan_id
-              description: (Min:2, Max:3967) SVI used for PTP source on ToRs
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: ALLOW_NXC
-              tf_name: allow_nxc
-              description: Allow onboarding of this fabric to Nexus Cloud
-              type: Bool
-              computed: true
-
-            - model_name: OVERWRITE_GLOBAL_NXC
-              tf_name: overwrite_global_nxc
-              description: If enabled, Fabric NxCloud Settings will be used
-              type: Bool
-              computed: true
-
-            - model_name: NXC_DEST_VRF
-              tf_name: nxc_dest_vrf
-              description: VRF to be used to reach Nexus Cloud, enter 'management' for management VRF and 'default' for default VRF
-              type: String
-              example: management
-              computed: true
-
-            - model_name: NXC_SRC_INTF
-              tf_name: nxc_src_intf
-              description: "Source interface for communication to Nexus Cloud, mandatory if Destination VRF is not management, supported interfaces: loopback, port-channel, vlan"
-              type: String
-              computed: true
-
-            - model_name: NXC_PROXY_SERVER
-              tf_name: nxc_proxy_server
-              description: IPv4 or IPv6 address, or DNS name of the proxy server
-              type: String
-              computed: true
-
-            - model_name: NXC_PROXY_PORT
-              tf_name: nxc_proxy_port
-              description: Proxy port number, default is 8080
-              type: Int64
-              handle_empty: true
-              example: 8080
-              computed: true
-
-            - model_name: VPC_DELAY_RESTORE_TIME
-              tf_name: vpc_delay_restore_time
-              description: vPC Delay Restore Time For vPC links in seconds (Min:1, Max:3600)
-              type: Int64
-              handle_empty: true
-              example: 60
-              computed: true
-
-            - model_name: FABRIC_TYPE
-              tf_name: fabric_type
-              description: Fabric Type
-              type: String
-              example: Switch_Fabric
-              computed: true
-
-            - model_name: EXT_FABRIC_TYPE
-              tf_name: ext_fabric_type
-              description: External Fabric Type
-              type: String
-              computed: true
-
-            - model_name: ENABLE_AGENT
-              tf_name: enable_agent
-              description: Enable Agnet (development purpose only)
-              type: Bool
-              computed: true
-
-            - model_name: AGENT_INTF
-              tf_name: agent_intf
-              description: Interface to connect to Agent
-              type: String
-              example: eth0
-              computed: true
-
-            - model_name: SSPINE_ADD_DEL_DEBUG_FLAG
-              tf_name: sspine_add_del_debug_flag
-              description: Allow First Super Spine Add or Last Super Spine Delete From Topology
-              type: String
-              example: Disable
-              computed: true
-
-            - model_name: BRFIELD_DEBUG_FLAG
-              tf_name: brfield_debug_flag
-              description: "!!! Only for brf debugging purpose !!!"
-              type: String
-              example: Disable
-              computed: true
-
-            - model_name: ACTIVE_MIGRATION
-              tf_name: active_migration
-              description: Active Migration
-              type: Bool
-              computed: true
-
-            - model_name: FF
-              tf_name: ff
-              description: Template Family
-              type: String
-              example: Easy_Fabric
-              computed: true
-
-            - model_name: BGP_AS_PREV
-              tf_name: bgp_as_prev
-              description: Previous BGP AS value
-              type: String
-              computed: true
-
-            - model_name: UNDERLAY_IS_V6_PREV
-              tf_name: underlay_is_v6_prev
-              description: Previous state of UNDERLAY_IS_V6
-              type: Bool
-              computed: true
-
-            - model_name: PM_ENABLE_PREV
-              tf_name: pm_enable_prev
-              description: Previous state of Performance Monitoring Enable
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_FABRIC_VPC_DOMAIN_ID_PREV
-              tf_name: enable_fabric_vpc_domain_id_prev
-              description: Previous state of Enable Fabric VPC Domain ID
-              type: Bool
-              computed: true
-
-            - model_name: OVERLAY_MODE_PREV
-              tf_name: overlay_mode_prev
-              description: Previous Overlay Mode value
-              type: String
-              computed: true
-
-            - model_name: ALLOW_L3VNI_NO_VLAN_PREV
-              tf_name: allow_l3vni_no_vlan_prev
-              description: Previous state of Allow L3VNI without VLAN
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_PVLAN_PREV
-              tf_name: enable_pvlan_prev
-              description: Previous state of Enable Private VLAN
-              type: Bool
-              computed: true
-
-            - model_name: AUTO_UNIQUE_VRF_LITE_IP_PREFIX_PREV
-              tf_name: auto_unique_vrf_lite_ip_prefix_prev
-              description: Previous state of Auto Unique VRF Lite IP Prefix
-              type: Bool
-              computed: true
-
-            - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION_PREV
-              tf_name: per_vrf_loopback_auto_provision_prev
-              description: Previous state of Per VRF Loopback Auto Provisioning
-              type: Bool
-              computed: true
-
-            - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION_V6_PREV
-              tf_name: per_vrf_loopback_auto_provision_v6_prev
-              description: Previous state of Per VRF Loopback IPv6 Auto Provisioning
-              type: Bool
-              computed: true
-
-            - model_name: MSO_SITE_ID
-              tf_name: mso_site_id
-              description: MSO Site ID
-              type: String
-              computed: true
-
-            - model_name: MSO_CONTROLER_ID
-              tf_name: mso_controler_id
-              description: MSO Controller ID
-              type: String
-              computed: true
-
-            - model_name: MSO_SITE_GROUP_NAME
-              tf_name: mso_site_group_name
-              description: MSO Site Group Name
-              type: String
-              computed: true
-
-            - model_name: PREMSO_PARENT_FABRIC
-              tf_name: premso_parent_fabric
-              description: Pre-MSO Parent Fabric
-              type: String
-              computed: true
-
-            - model_name: MSO_CONNECTIVITY_DEPLOYED
-              tf_name: mso_connectivity_deployed
-              description: MSO Connectivity Deployed
-              type: String
-              computed: true
-
-            - model_name: ANYCAST_RP_IP_RANGE_INTERNAL
-              tf_name: anycast_rp_ip_range_internal
-              description: Internal Anycast RP IP Range
-              type: String
-              computed: true
-
-            - model_name: IPv6_ANYCAST_RP_IP_RANGE_INTERNAL
-              tf_name: ipv6_anycast_rp_ip_range_internal
-              description: Internal IPv6 Anycast RP IP Range
-              type: String
-              computed: true
-
-            - model_name: DHCP_START_INTERNAL
-              tf_name: dhcp_start_internal
-              description: Internal DHCP Scope Start Address
-              type: String
-              computed: true
-
-            - model_name: DHCP_END_INTERNAL
-              tf_name: dhcp_end_internal
-              description: Internal DHCP Scope End Address
-              type: String
-              computed: true
-
-            - model_name: MGMT_GW_INTERNAL
-              tf_name: mgmt_gw_internal
-              description: Internal Management Gateway
-              type: String
-              computed: true
-
-            - model_name: MGMT_PREFIX_INTERNAL
-              tf_name: mgmt_prefix_internal
-              description: Internal Management Subnet Prefix
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: BOOTSTRAP_MULTISUBNET_INTERNAL
-              tf_name: bootstrap_multisubnet_internal
-              description: Internal Bootstrap Multi Subnet Scope
-              type: String
-              computed: true
-
-            - model_name: MGMT_V6PREFIX_INTERNAL
-              tf_name: mgmt_v6prefix_internal
-              description: Internal Management IPv6 Subnet Prefix
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: DHCP_IPV6_ENABLE_INTERNAL
-              tf_name: dhcp_ipv6_enable_internal
-              description: Internal DHCP IPv6 Enable Flag
-              type: String
-              computed: true
-
-            - model_name: UNNUM_DHCP_START_INTERNAL
-              tf_name: unnum_dhcp_start_internal
-              description: Internal Unnumbered DHCP Start Address
-              type: String
-              computed: true
-
-            - model_name: UNNUM_DHCP_END_INTERNAL
-              tf_name: unnum_dhcp_end_internal
-              description: Internal Unnumbered DHCP End Address
-              type: String
-              computed: true
-
-            - model_name: ENABLE_EVPN
-              tf_name: enable_evpn
-              description: Enable EVPN
-              type: Bool
-              computed: true
-
-            - model_name: FEATURE_PTP_INTERNAL
-              tf_name: feature_ptp_internal
-              description: Internal PTP Feature Enable Flag
-              type: Bool
-              computed: true
-
-            - model_name: SSPINE_COUNT
-              tf_name: sspine_count
-              description: Super Spine Count
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: SPINE_COUNT
-              tf_name: spine_count
-              description: Spine Count
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: abstract_feature_leaf
-              tf_name: abstract_feature_leaf
-              description: Feature Configuration for Leaf
-              type: String
-              computed: true
-
-            - model_name: abstract_feature_spine
-              tf_name: abstract_feature_spine
-              description: Feature Configuration for Spine
-              type: String
-              computed: true
-
-            - model_name: abstract_dhcp
-              tf_name: abstract_dhcp
-              description: DHCP Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_multicast
-              tf_name: abstract_multicast
-              description: Multicast Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_anycast_rp
-              tf_name: abstract_anycast_rp
-              description: Anycast RP Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_loopback_interface
-              tf_name: abstract_loopback_interface
-              description: Primary Loopback Interface Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_isis
-              tf_name: abstract_isis
-              description: ISIS Network Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_ospf
-              tf_name: abstract_ospf
-              description: OSPF Network Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_vpc_domain
-              tf_name: abstract_vpc_domain
-              description: vPC Domain Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_vlan_interface
-              tf_name: abstract_vlan_interface
-              description: VLAN Interface Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_isis_interface
-              tf_name: abstract_isis_interface
-              description: ISIS Interface Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_ospf_interface
-              tf_name: abstract_ospf_interface
-              description: OSPF Interface Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_pim_interface
-              tf_name: abstract_pim_interface
-              description: PIM Interface Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_route_map
-              tf_name: abstract_route_map
-              description: Route-Map Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_bgp
-              tf_name: abstract_bgp
-              description: BGP Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_bgp_rr
-              tf_name: abstract_bgp_rr
-              description: BGP RR Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_bgp_neighbor
-              tf_name: abstract_bgp_neighbor
-              description: BGP Neighbor Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_extra_config_leaf
-              tf_name: abstract_extra_config_leaf
-              description: Add Extra Configuration for Leaf
-              type: String
-              computed: true
-
-            - model_name: abstract_extra_config_spine
-              tf_name: abstract_extra_config_spine
-              description: Add Extra Configuration for Spine
-              type: String
-              computed: true
-
-            - model_name: abstract_extra_config_tor
-              tf_name: abstract_extra_config_tor
-              description: Add Extra Configuration for ToR
-              type: String
-              computed: true
-
-            - model_name: abstract_extra_config_bootstrap
-              tf_name: abstract_extra_config_bootstrap
-              description: Add Extra Configuration for Bootstrap
-              type: String
-              computed: true
-
-            - model_name: temp_anycast_gateway
-              tf_name: temp_anycast_gateway
-              description: Anycast Gateway MAC Configuration
-              type: String
-              computed: true
-
-            - model_name: temp_vpc_domain_mgmt
-              tf_name: temp_vpc_domain_mgmt
-              description: vPC Keep-alive Configuration using Management VRF
-              type: String
-              computed: true
-
-            - model_name: temp_vpc_peer_link
-              tf_name: temp_vpc_peer_link
-              description: vPC Peer-Link Configuration
-              type: String
-              computed: true
-
-            - model_name: abstract_routed_host
-              tf_name: abstract_routed_host
-              description: Routed Host Port Configuration
-              type: String
-              computed: true
-
-            - model_name: UPGRADE_FROM_VERSION
-              tf_name: upgrade_from_version
-              description: Upgrade from Version
-              type: String
-              computed: true
-
-            - model_name: TOPDOWN_CONFIG_RM_TRACKING
-              tf_name: topdown_config_rm_tracking
-              description: Top-Down Config RM Tracking
-              type: String
-              computed: true
-
-            - model_name: SITE_ID_POLICY_ID
-              tf_name: site_id_policy_id
-              description: Site ID Policy ID
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: FABRIC_VPC_DOMAIN_ID_PREV
-              tf_name: fabric_vpc_domain_id_prev
-              description: Internal Fabric Wide vPC Domain ID
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: LINK_STATE_ROUTING_TAG_PREV
-              tf_name: link_state_routing_tag_prev
-              description: Previous Link State Routing Tag
-              type: String
-              computed: true
-
-            - model_name: BFD_ENABLE_PREV
-              tf_name: bfd_enable_prev
-              description: Previous state of BFD Enable
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_SGT_PREV
-              tf_name: enable_sgt_prev
-              description: Previous state of Enable Security Groups
-              type: Bool
-              computed: true
-
-            - model_name: SGT_PREPROVISION_PREV
-              tf_name: sgt_preprovision_prev
-              description: Previous state of Security Group Tag Preprovision
-              type: Bool
-              computed: true
-
-            - model_name: SGT_PREPROV_RECALC_STATUS
-              tf_name: sgt_preprov_recalc_status
-              description: Recalculation status for Security Group pre-provisioning
-              type: String
-              computed: true
-              enum_values: ['start', 'empty', 'completed']
-
-            - model_name: SGT_RECALC_STATUS
-              tf_name: sgt_recalc_status
-              description: Recalculation status for Security Group
-              type: String
-              computed: true
-              enum_values: ['start', 'empty', 'completed']
-
-            - model_name: SGT_OPER_STATUS
-              tf_name: sgt_oper_status
-              description: Operational status for Security Group
-              type: String
-              computed: true
-              enum_values: ['on', 'off']
-
-            - model_name: ENABLE_MACSEC_PREV
-              tf_name: enable_macsec_prev
-              description: Previous state of Enable MACsec
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_DCI_MACSEC_PREV
-              tf_name: enable_dci_macsec_prev
-              description: Previous state of Enable DCI MACsec
-              type: Bool
-              computed: true
-
-            - model_name: DCI_MACSEC_FALLBACK_KEY_STRING
-              tf_name: dci_macsec_fallback_key_string
-              description: Cisco Type 7 Encrypted Octet String. This parameter is used when DCI link has QKD disabled.
-              type: String
-              computed: true
-
-            - model_name: DCI_MACSEC_FALLBACK_ALGORITHM
-              tf_name: dci_macsec_fallback_algorithm
-              description: AES_128_CMAC or AES_256_CMAC. This parameter is used when DCI link has QKD disabled.
-              type: String
-              computed: true
-              enum_values: ['AES_128_CMAC', 'AES_256_CMAC']
-
-            - model_name: DCI_MACSEC_ALGORITHM
-              tf_name: dci_macsec_algorithm
-              description: AES_128_CMAC or AES_256_CMAC
-              type: String
-              computed: true
-              enum_values: ['AES_128_CMAC', 'AES_256_CMAC']
-
-            - model_name: DCI_MACSEC_KEY_STRING
-              tf_name: dci_macsec_key_string
-              description: Cisco Type 7 Encrypted Octet String
-              type: String
-              computed: true
-
-            - model_name: DCI_MACSEC_CIPHER_SUITE
-              tf_name: dci_macsec_cipher_suite
-              description: Configure Cipher Suite
-              type: String
-              computed: true
-              enum_values: ['GCM-AES-128', 'GCM-AES-256', 'GCM-AES-XPN-128', 'GCM-AES-XPN-256']
-
-            - model_name: QKD_PROFILE_NAME_PREV
-              tf_name: qkd_profile_name_prev
-              description: Previous state of QKD Profile Name
-              type: Bool
-              computed: true
-
-            - model_name: FABRIC_MTU_PREV
-              tf_name: fabric_mtu_prev
-              description: Previous state of Fabric MTU
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: L2_HOST_INTF_MTU_PREV
-              tf_name: l2_host_intf_mtu_prev
-              description: Previous state of Layer 2 Host Interface MTU
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: MPLS_ISIS_AREA_NUM_PREV
-              tf_name: mpls_isis_area_num_prev
-              description: Previous state of MPLS IS-IS Area Number
-              type: String
-              computed: true
-
-            - model_name: ISIS_AREA_NUM_PREV
-              tf_name: isis_area_num_prev
-              description: Area Number last used for generating IS-IS NET
-              type: String
-              computed: true
-
-            - model_name: ENABLE_AI_ML_QOS_POLICY_FLAP
-              tf_name: enable_ai_ml_qos_policy_flap
-              description: Previous state of Enable AI/ML QoS Policy Flap
-              type: Bool
-              computed: true
-
-            - model_name: PFC_WATCH_INT_PREV
-              tf_name: pfc_watch_int_prev
-              description: Previous state of Priority Flow Control Watch Interval
-              type: Int64
-              handle_empty: true
-              computed: true
-
-            - model_name: INBAND_MGMT_PREV
-              tf_name: inband_mgmt_prev
-              description: Previous state of Inband Management
-              type: Bool
-              computed: true
-
-            - model_name: BOOTSTRAP_ENABLE_PREV
-              tf_name: bootstrap_enable_prev
-              description: Previous state of Bootstrap Enable
-              type: Bool
-              computed: true
-
-            - model_name: ENABLE_NETFLOW_PREV
-              tf_name: enable_netflow_prev
-              description: Previous state of Enable Netflow
-              type: Bool
-              computed: true
-
-            - model_name: ALLOW_NXC_PREV
-              tf_name: allow_nxc_prev
-              description: Previous state of Allow Nexus Cloud
-              type: Bool
-              computed: true
+        - model_name: ENABLE_NBM_PASSIVE_PREV
+          tf_name: enable_nbm_passive_prev
+          description: Previous state of Enable NBM Passive Mode
+          type: Bool
+          computed: true
+
+        - model_name: FABRIC_TECHNOLOGY
+          tf_name: fabric_technology
+          description: Fabric Technology
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_ETHERNET_DEFAULT_POLICY
+          tf_name: interface_ethernet_default_policy
+          description: Default policy for Ethernet interface of spine/leaf/tier2-leaf switches
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_LOOPBACK_DEFAULT_POLICY
+          tf_name: interface_loopback_default_policy
+          description: Loopback Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_PORT_CHANNEL_DEFAULT_POLICY
+          tf_name: interface_port_channel_default_policy
+          description: Port Channel Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_VLAN_DEFAULT_POLICY
+          tf_name: interface_vlan_default_policy
+          description: VLAN Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: RP_IP_RANGE_INTERNAL
+          tf_name: rp_ip_range_internal
+          description: Internal RP IP Range
+          type: String
+          computed: true
+
+        - model_name: INBAND_ENABLE_PREV
+          tf_name: inband_enable_prev
+          description: "Previous state of Enable POAP over Inband Interface"
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_ASM
+          tf_name: enable_asm
+          description: Enable groups with receivers sending (*,G) joins
+          type: Bool
+          example: false
+          optional: true
+          computed: true
+
+        - model_name: DOMAIN_NAME_INTERNAL
+          tf_name: domain_name_internal
+          description: Internal Domain Name
+          type: String
+          computed: true
+
+        - model_name: PNP_ENABLE_INTERNAL
+          tf_name: pnp_enable_internal
+          description: Internal PnP Enable
+          type: Bool
+          computed: true
+
+        - model_name: BGW_ROUTING_TAG
+          tf_name: bgw_routing_tag
+          description: Routing tag associated with IP address of loopback
+              and DCI interfaces
+          type: Int64
+          handle_empty: true
+          example: 54321
+          optional: true
+          computed: true
+
+        - model_name: DCNM_ID
+          tf_name: dcnm_id
+          description: DCNM ID
+          type: String
+          computed: true
+
+        - model_name: ENABLE_TRM_TRMv6
+          tf_name: enable_trm_trmv6
+          description: Enable IPv4 and/or IPv6 Tenant Routed Multicast
+              across sites
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_TRM_TRMv6_PREV
+          tf_name: enable_trm_trmv6_prev
+          description: Previous state of Enable IPv4 and/or IPv6 Tenant Routed
+              Multicast across sites
+          type: Bool
+          computed: true
+
+        - model_name: LOOPBACK100_IPV6_RANGE
+          tf_name: loopback100_ipv6_range
+          description: Multi-Site VTEP VIP Loopback IPv6 Range
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: BGW_ROUTING_TAG_PREV
+          tf_name: bgw_routing_tag_prev
+          description: Previous state of Border Gateway Routing Tag
+          type: String
+          computed: true
+
+        - model_name: MS_IFC_BGP_AUTH_KEY_TYPE_PREV
+          tf_name: ms_ifc_bgp_auth_key_type_prev
+          description: 'BGP Key Encryption Type: 3 - 3DES, 7 - Cisco'
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: MS_IFC_BGP_PASSWORD_ENABLE_PREV
+          tf_name: ms_ifc_bgp_password_enable_prev
+          description: Previous state of Enable Multi-Site eBGP Password
+          type: Bool
+          computed: true
+
+        - model_name: MS_IFC_BGP_PASSWORD_PREV
+          tf_name: ms_ifc_bgp_password_prev
+          description: Previous state of eBGP Password
+          type: String
+          computed: true
+
+        - model_name: PARENT_ONEMANAGE_FABRIC
+          tf_name: parent_onemanage_fabric
+          description: Parent OneManage Fabric
+          type: String
+          computed: true
+
+        - model_name: SGT_ID_RANGE_PREV
+          tf_name: sgt_id_range_prev
+          description: Previous state of Security Group Tag (SGT) ID Range
+          type: String
+          computed: true
+
+        - model_name: SGT_NAME_PREFIX_PREV
+          tf_name: sgt_name_prefix_prev
+          description: Previous state of Security Group Name Prefix
+          type: String
+          computed: true
+
+        - model_name: V6_DCI_SUBNET_RANGE
+          tf_name: v6_dci_subnet_range
+          description: Address range to assign P2P DCI Links
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: V6_DCI_SUBNET_TARGET_MASK
+          tf_name: v6_dci_subnet_target_mask
+          description: Target IPv6 Mask for Subnet Range (Min:120, Max:127)
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: VXLAN_UNDERLAY_IS_V6
+          tf_name: vxlan_underlay_is_v6
+          description: If not enabled, IPv4 underlay is used in child VXLAN
+              fabric
+          type: Bool
+          optional: true
+          computed: true
+
+datasource:
+    name: fabric
+    doc_category: Fabric
+    generate_tf_resource: true
+    description: Basic data source attribute for all fabric types
+    attributes:
+        - model_name: FABRIC_NAME
+          tf_name: fabric_name
+          type: String
+          description: 'Fabric name'
+          mandatory: true
+          example: 'CML'
+
+        - model_name: AAA_REMOTE_IP_ENABLED
+          tf_name: aaa_remote_ip_enabled
+          type: Bool
+          description: 'Enable only, when IP Authorization is enabled in the AAA Server'
+          computed: true
+
+        - model_name: AAA_SERVER_CONF
+          tf_name: aaa_server_conf
+          type: String
+          description: AAA Configurations
+          computed: true
+
+        - model_name: ADVERTISE_PIP_BGP
+          tf_name: advertise_pip_bgp
+          type: Bool
+          description: For Primary VTEP IP Advertisement As Next-Hop Of Prefix Routes
+          computed: true
+
+        - model_name: ADVERTISE_PIP_ON_BORDER
+          tf_name: advertise_pip_on_border
+          type: Bool
+          description: >-
+            Enable advertise-pip on vPC borders and border gateways only. Applicable
+            only when vPC advertise-pip is not enabled
+          computed: true
+
+        - model_name: ANYCAST_BGW_ADVERTISE_PIP
+          tf_name: anycast_bgw_advertise_pip
+          type: Bool
+          description: >-
+            To advertise Anycast Border Gateway PIP as VTEP. Effective on MSD fabric
+            Recalculate Config
+          computed: true
+
+        - model_name: ANYCAST_GW_MAC
+          tf_name: anycast_gw_mac
+          type: String
+          description: Shared MAC address for all leafs (xxxx.xxxx.xxxx)
+          computed: true
+
+        - model_name: ANYCAST_LB_ID
+          tf_name: anycast_lb_id
+          type: Int64
+          handle_empty: true
+          description: Used for vPC Peering in VXLANv6 Fabrics
+          computed: true
+
+        - model_name: ANYCAST_RP_IP_RANGE
+          tf_name: anycast_rp_ip_range
+          type: String
+          description: Anycast or Phantom RP IP Address Range
+          computed: true
+
+        - model_name: AUTO_SYMMETRIC_DEFAULT_VRF
+          tf_name: auto_symmetric_default_vrf
+          type: Bool
+          description: >-
+            Whether to auto generate Default VRF interface and BGP peering
+            configuration on managed neighbor devices. If set, auto created VRF Lite
+            IFC links will have Auto Deploy Default VRF for Peer enabled.
+          computed: true
+
+        - model_name: AUTO_SYMMETRIC_VRF_LITE
+          tf_name: auto_symmetric_vrf_lite
+          type: Bool
+          description: >-
+            Whether to auto generate VRF LITE sub-interface and BGP peering
+            configuration on managed neighbor devices. If set, auto created VRF Lite
+            IFC links will have Auto Deploy for Peer enabled.
+          computed: true
+
+        - model_name: AUTO_UNIQUE_VRF_LITE_IP_PREFIX
+          tf_name: auto_unique_vrf_lite_ip_prefix
+          type: Bool
+          description: >-
+            When enabled, IP prefix allocated to the VRF LITE IFC is not reused on
+            VRF extension over VRF LITE IFC. Instead, unique IP Subnet is allocated
+            for each VRF extension over VRF LITE IFC.
+          computed: true
+
+        - model_name: AUTO_VRFLITE_IFC_DEFAULT_VRF
+          tf_name: auto_vrflite_ifc_default_vrf
+          type: Bool
+          description: >-
+            Whether to auto generate Default VRF interface and BGP peering
+            configuration on VRF LITE IFC auto deployment. If set, auto created VRF
+            Lite IFC links will have Auto Deploy Default VRF enabled.
+          computed: true
+
+        - model_name: BANNER
+          tf_name: banner
+          type: String
+          description: >-
+            Message of the Day (motd) banner. Delimiter char (very first char is
+            delimiter char) followed by message ending with delimiter)
+          computed: true
+
+        - model_name: BFD_AUTH_ENABLE
+          tf_name: bfd_auth_enable
+          type: Bool
+          description: Valid for P2P Interfaces only
+          computed: true
+
+        - model_name: BFD_AUTH_KEY
+          tf_name: bfd_auth_key
+          type: String
+          description: Encrypted SHA1 secret value
+          computed: true
+
+        - model_name: BFD_AUTH_KEY_ID
+          tf_name: bfd_auth_key_id
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: BFD_ENABLE
+          tf_name: bfd_enable
+          type: Bool
+          description: Valid for IPv4 Underlay only
+          computed: true
+
+        - model_name: BFD_IBGP_ENABLE
+          tf_name: bfd_ibgp_enable
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: BFD_ISIS_ENABLE
+          tf_name: bfd_isis_enable
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: BFD_OSPF_ENABLE
+          tf_name: bfd_ospf_enable
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: BFD_PIM_ENABLE
+          tf_name: bfd_pim_enable
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: BGP_AS
+          tf_name: bgp_as
+          type: String
+          description: >-
+            1-4294967295 | 1-65535.0-65535 It is a good practice to have a unique
+            ASN for each Fabric.
+          computed: true
+
+        - model_name: BGP_AUTH_ENABLE
+          tf_name: bgp_auth_enable
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: BGP_AUTH_KEY
+          tf_name: bgp_auth_key
+          type: String
+          description: Encrypted BGP Authentication Key based on type
+          computed: true
+
+        - model_name: BGP_AUTH_KEY_TYPE
+          tf_name: bgp_auth_key_type
+          type: Int64
+          handle_empty: true
+          description: 'BGP Key Encryption Type: 3 - 3DES, 7 - Cisco'
+          computed: true
+
+        - model_name: BGP_LB_ID
+          tf_name: bgp_lb_id
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: BOOTSTRAP_CONF
+          tf_name: bootstrap_conf
+          type: String
+          description: Additional CLIs required during device bootup/login e.g. AAA/Radius
+          computed: true
+
+        - model_name: BOOTSTRAP_ENABLE
+          tf_name: bootstrap_enable
+          type: Bool
+          description: Automatic IP Assignment For POAP
+          computed: true
+
+        - model_name: BOOTSTRAP_MULTISUBNET
+          tf_name: bootstrap_multisubnet
+          type: String
+          description: '''lines with # prefix are ignored here'''
+          computed: true
+
+        - model_name: BROWNFIELD_NETWORK_NAME_FORMAT
+          tf_name: brownfield_network_name_format
+          type: String
+          description: Generated network name should be < 64 characters
+          computed: true
+
+        - model_name: BROWNFIELD_SKIP_OVERLAY_NETWORK_ATTACHMENTS
+          tf_name: brownfield_skip_overlay_network_attachments
+          type: Bool
+          description: >-
+            Enable to skip overlay network interface attachments for Brownfield and
+            Host Port Resync cases
+          computed: true
+
+        - model_name: CDP_ENABLE
+          tf_name: cdp_enable
+          type: Bool
+          description: Enable CDP on management interface
+          computed: true
+
+        - model_name: COPP_POLICY
+          tf_name: copp_policy
+          type: String
+          description: >-
+            Fabric Wide CoPP Policy. Customized CoPP policy should be provided when
+            manual is selected
+          computed: true
+
+        - model_name: DCI_SUBNET_RANGE
+          tf_name: dci_subnet_range
+          type: String
+          description: Address range to assign P2P Interfabric Connections
+          computed: true
+
+        - model_name: DCI_SUBNET_TARGET_MASK
+          tf_name: dci_subnet_target_mask
+          type: Int64
+          description: No description available
+          computed: true
+
+        - model_name: DEAFULT_QUEUING_POLICY_CLOUDSCALE
+          tf_name: default_queuing_policy_cloudscale
+          type: String
+          description: >-
+            Queuing Policy for all 92xx, -EX, -FX, -FX2, -FX3, -GX series switches
+            in the fabric
+          computed: true
+
+        - model_name: DEAFULT_QUEUING_POLICY_OTHER
+          tf_name: default_queuing_policy_other
+          type: String
+          description: Queuing Policy for all other switches in the fabric
+          computed: true
+
+        - model_name: DEAFULT_QUEUING_POLICY_R_SERIES
+          tf_name: default_queuing_policy_r_series
+          type: String
+          description: Queuing Policy for all R-Series switches in the fabric
+          computed: true
+
+        - model_name: DEFAULT_VRF_REDIS_BGP_RMAP
+          tf_name: default_vrf_redis_bgp_rmap
+          type: String
+          description: >-
+            Route Map used to redistribute BGP routes to IGP in default vrf in auto
+            created VRF Lite IFC links
+          computed: true
+
+        - model_name: DHCP_ENABLE
+          tf_name: dhcp_enable
+          type: Bool
+          description: Automatic IP Assignment For POAP From Local DHCP Server
+          computed: true
+
+        - model_name: DHCP_END
+          tf_name: dhcp_end
+          type: String
+          description: End Address For Switch POAP
+          computed: true
+
+        - model_name: DHCP_IPV6_ENABLE
+          tf_name: dhcp_ipv6_enable
+          type: String
+          description: No description available
+          computed: true
+
+        - model_name: DHCP_START
+          tf_name: dhcp_start
+          type: String
+          description: Start Address For Switch POAP
+          computed: true
+
+        - model_name: DNS_SERVER_IP_LIST
+          tf_name: dns_server_ip_list
+          type: String
+          description: Comma separated list of IP Addresses(v4/v6)
+          computed: true
+
+        - model_name: DNS_SERVER_VRF
+          tf_name: dns_server_vrf
+          type: String
+          description: >-
+            One VRF for all DNS servers or a comma separated list of VRFs, one per
+            DNS server
+          computed: true
+
+        - model_name: ENABLE_AAA
+          tf_name: enable_aaa
+          type: Bool
+          description: Include AAA configs from Manageability tab during device bootup
+          computed: true
+
+        - model_name: ENABLE_DEFAULT_QUEUING_POLICY
+          tf_name: enable_default_queuing_policy
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: ENABLE_FABRIC_VPC_DOMAIN_ID
+          tf_name: enable_fabric_vpc_domain_id
+          type: Bool
+          description: (Not Recommended)
+          computed: true
+
+        - model_name: ENABLE_MACSEC
+          tf_name: enable_macsec
+          type: Bool
+          description: Enable MACsec in the fabric
+          computed: true
+
+        - model_name: ENABLE_NETFLOW
+          tf_name: enable_netflow
+          type: Bool
+          description: Enable Netflow on VTEPs
+          computed: true
+
+        - model_name: ENABLE_NGOAM
+          tf_name: enable_ngoam
+          type: Bool
+          description: >-
+            Enable the Next Generation (NG) OAM feature for all switches in the
+            fabric to aid in trouble-shooting VXLAN EVPN fabrics
+          computed: true
+
+        - model_name: ENABLE_NXAPI
+          tf_name: enable_nxapi
+          type: Bool
+          description: Enable HTTPS NX-API
+          computed: true
+
+        - model_name: ENABLE_NXAPI_HTTP
+          tf_name: enable_nxapi_http
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: ENABLE_PBR
+          tf_name: enable_pbr
+          type: Bool
+          description: >-
+            When ESR option is ePBR, enable ePBR will enable pbr, sla sender and
+            epbr features on the switch
+          computed: true
+
+        - model_name: ENABLE_PVLAN
+          tf_name: enable_pvlan
+          type: Bool
+          description: Enable PVLAN on switches except spines and super spines
+          computed: true
+
+        - model_name: ENABLE_TENANT_DHCP
+          tf_name: enable_tenant_dhcp
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: ENABLE_TRM
+          tf_name: enable_trm
+          type: Bool
+          description: For Overlay Multicast Support In VXLAN Fabrics
+          computed: true
+
+        - model_name: ENABLE_VPC_PEER_LINK_NATIVE_VLAN
+          tf_name: enable_vpc_peer_link_native_vlan
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: EXTRA_CONF_INTRA_LINKS
+          tf_name: extra_conf_intra_links
+          type: String
+          description: Additional CLIs For All Intra-Fabric Links
+          computed: true
+
+        - model_name: EXTRA_CONF_LEAF
+          tf_name: extra_conf_leaf
+          type: String
+          description: >-
+            Additional CLIs For All Leafs As Captured From Show Running
+            Configuration
+          computed: true
+
+        - model_name: EXTRA_CONF_SPINE
+          tf_name: extra_conf_spine
+          type: String
+          description: >-
+            Additional CLIs For All Spines As Captured From Show Running
+            Configuration
+          computed: true
+
+        - model_name: EXTRA_CONF_TOR
+          tf_name: extra_conf_tor
+          type: String
+          description: Additional CLIs For All ToRs As Captured From Show Running Configuration
+          computed: true
+
+        - model_name: FABRIC_INTERFACE_TYPE
+          tf_name: fabric_interface_type
+          type: String
+          description: Numbered(Point-to-Point) or Unnumbered
+          computed: true
+
+        - model_name: FABRIC_MTU
+          tf_name: fabric_mtu
+          type: Int64
+          handle_empty: true
+          description: Must be an even number
+          computed: true
+
+        - model_name: FABRIC_VPC_DOMAIN_ID
+          tf_name: fabric_vpc_domain_id
+          type: Int64
+          handle_empty: true
+          description: vPC Domain Id to be used on all vPC pairs
+          computed: true
+
+        - model_name: FABRIC_VPC_QOS
+          tf_name: fabric_vpc_qos
+          type: Bool
+          description: >-
+            Qos on spines for guaranteed delivery of vPC Fabric Peering
+            communication
+          computed: true
+
+        - model_name: FABRIC_VPC_QOS_POLICY_NAME
+          tf_name: fabric_vpc_qos_policy_name
+          type: String
+          description: Qos Policy name should be same on all spines
+          computed: true
+
+        - model_name: FEATURE_PTP
+          tf_name: feature_ptp
+          type: Bool
+          example: false
+          description: No description available
+          computed: true
+
+        - model_name: GRFIELD_DEBUG_FLAG
+          tf_name: grfield_debug_flag
+          type: String
+          description: >-
+            Enable to clean switch configuration without reload when
+            PreserveConfig=no
+          computed: true
+
+        - model_name: HD_TIME
+          tf_name: hd_time
+          type: Int64
+          handle_empty: true
+          description: NVE Source Inteface HoldDown Time in seconds
+          computed: true
+
+        - model_name: HOST_INTF_ADMIN_STATE
+          tf_name: host_intf_admin_state
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: IBGP_PEER_TEMPLATE
+          tf_name: ibgp_peer_template
+          type: String
+          description: >-
+            Speficies the iBGP Peer-Template config used for RR and spines with
+            border role.
+          computed: true
+
+        - model_name: IBGP_PEER_TEMPLATE_LEAF
+          tf_name: ibgp_peer_template_leaf
+          type: String
+          description: >-
+            Specifies the config used for leaf, border or border gateway. If this
+            field is empty, the peer template defined in iBGP Peer-Template Config
+            is used on all BGP enabled devices (RRs,leafs, border or border gateway
+            roles.
+          computed: true
+
+        - model_name: INBAND_DHCP_SERVERS
+          tf_name: inband_dhcp_servers
+          type: String
+          description: Comma separated list of IPv4 Addresses (Max 3)
+          computed: true
+
+        - model_name: INBAND_MGMT
+          tf_name: inband_mgmt
+          type: Bool
+          description: Manage switches with only Inband connectivity
+          computed: true
+
+        - model_name: ISIS_AUTH_ENABLE
+          tf_name: isis_auth_enable
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: ISIS_AUTH_KEY
+          tf_name: isis_auth_key
+          type: String
+          description: Cisco Type 7 Encrypted
+          computed: true
+
+        - model_name: ISIS_AUTH_KEYCHAIN_KEY_ID
+          tf_name: isis_auth_keychain_key_id
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: ISIS_AUTH_KEYCHAIN_NAME
+          tf_name: isis_auth_keychain_name
+          type: String
+          description: No description available
+          computed: true
+
+        - model_name: ISIS_LEVEL
+          tf_name: isis_level
+          type: String
+          description: 'Supported IS types: level-1, level-2'
+          computed: true
+
+        - model_name: ISIS_OVERLOAD_ELAPSE_TIME
+          tf_name: isis_overload_elapse_time
+          type: Int64
+          handle_empty: true
+          description: Clear the overload bit after an elapsed time in seconds
+          computed: true
+
+        - model_name: ISIS_OVERLOAD_ENABLE
+          tf_name: isis_overload_enable
+          type: Bool
+          description: 'When enabled, set the overload bit for an elapsed time after a reload'
+          computed: true
+
+        - model_name: ISIS_P2P_ENABLE
+          tf_name: isis_p2p_enable
+          type: Bool
+          description: >-
+            This will enable network point-to-point on fabric interfaces which are
+            numbered
+          computed: true
+
+        - model_name: L2_HOST_INTF_MTU
+          tf_name: l2_host_intf_mtu
+          type: Int64
+          handle_empty: true
+          description: Must be an even number
+          computed: true
+
+        - model_name: L2_SEGMENT_ID_RANGE
+          tf_name: l2_segment_id_range
+          type: String
+          description: Overlay Network Identifier Range
+          computed: true
+
+        - model_name: L3VNI_MCAST_GROUP
+          tf_name: l3vni_mcast_group
+          type: String
+          description: Default Underlay Multicast group IP assigned for every overlay VRF.
+          computed: true
+
+        - model_name: L3_PARTITION_ID_RANGE
+          tf_name: l3_partition_id_range
+          type: String
+          description: Overlay VRF Identifier Range
+          computed: true
+
+        - model_name: LINK_STATE_ROUTING
+          tf_name: link_state_routing
+          type: String
+          description: Used for Spine-Leaf Connectivity
+          computed: true
+
+        - model_name: LINK_STATE_ROUTING_TAG
+          tf_name: link_state_routing_tag
+          type: String
+          description: Underlay Routing Process Tag
+          computed: true
+
+        - model_name: LOOPBACK0_IPV6_RANGE
+          tf_name: loopback0_ipv6_range
+          type: String
+          description: Typically Loopback0 IPv6 Address Range
+          computed: true
+
+        - model_name: LOOPBACK0_IP_RANGE
+          tf_name: loopback0_ip_range
+          type: String
+          description: Typically Loopback0 IP Address Range
+          computed: true
+
+        - model_name: LOOPBACK1_IPV6_RANGE
+          tf_name: loopback1_ipv6_range
+          type: String
+          description: Typically Loopback1 and Anycast Loopback IPv6 Address Range
+          computed: true
+
+        - model_name: LOOPBACK1_IP_RANGE
+          tf_name: loopback1_ip_range
+          type: String
+          description: Typically Loopback1 IP Address Range
+          computed: true
+
+        - model_name: MACSEC_ALGORITHM
+          tf_name: macsec_algorithm
+          type: String
+          description: AES_128_CMAC or AES_256_CMAC
+          computed: true
+
+        - model_name: MACSEC_CIPHER_SUITE
+          tf_name: macsec_cipher_suite
+          type: String
+          description: Configure Cipher Suite
+          computed: true
+
+        - model_name: MACSEC_FALLBACK_ALGORITHM
+          tf_name: macsec_fallback_algorithm
+          type: String
+          description: AES_128_CMAC or AES_256_CMAC
+          computed: true
+
+        - model_name: MACSEC_FALLBACK_KEY_STRING
+          tf_name: macsec_fallback_key_string
+          type: String
+          description: Cisco Type 7 Encrypted Octet String
+          computed: true
+
+        - model_name: MACSEC_KEY_STRING
+          tf_name: macsec_key_string
+          type: String
+          description: Cisco Type 7 Encrypted Octet String
+          computed: true
+
+        - model_name: MACSEC_REPORT_TIMER
+          tf_name: macsec_report_timer
+          type: Int64
+          handle_empty: true
+          description: MACsec Operational Status periodic report timer in minutes
+          computed: true
+
+        - model_name: MGMT_GW
+          tf_name: mgmt_gw
+          type: String
+          description: Default Gateway For Management VRF On The Switch
+          computed: true
+
+        - model_name: MGMT_PREFIX
+          tf_name: mgmt_prefix
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: MGMT_V6PREFIX
+          tf_name: mgmt_v6prefix
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: MPLS_HANDOFF
+          tf_name: mpls_handoff
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: MPLS_LB_ID
+          tf_name: mpls_lb_id
+          type: Int64
+          handle_empty: true
+          description: Used for VXLAN to MPLS SR/LDP Handoff
+          computed: true
+
+        - model_name: MPLS_LOOPBACK_IP_RANGE
+          tf_name: mpls_loopback_ip_range
+          type: String
+          description: Used for VXLAN to MPLS SR/LDP Handoff
+          computed: true
+
+        - model_name: MST_INSTANCE_RANGE
+          tf_name: mst_instance_range
+          type: String
+          description: 'MST instance range, Example: 0-3,5,7-9, Default is 0'
+          computed: true
+
+        - model_name: MULTICAST_GROUP_SUBNET
+          tf_name: multicast_group_subnet
+          type: String
+          description: >-
+            Multicast pool prefix between 8 to 30. A multicast group IP from this
+            pool is used for BUM traffic for each overlay network.
+          computed: true
+
+        - model_name: NETFLOW_EXPORTER_LIST
+          tf_name: netflow_exporter_list
+          type: String
+          description: One or Multiple Netflow Exporters
+          computed: true
+
+        - model_name: NETFLOW_MONITOR_LIST
+          tf_name: netflow_monitor_list
+          type: String
+          description: One or Multiple Netflow Monitors
+          computed: true
+
+        - model_name: NETFLOW_RECORD_LIST
+          tf_name: netflow_record_list
+          type: String
+          description: One or Multiple Netflow Records
+          computed: true
+
+        - model_name: NETWORK_VLAN_RANGE
+          tf_name: network_vlan_range
+          type: String
+          description: Per Switch Overlay Network VLAN Range
+          computed: true
+
+        - model_name: NTP_SERVER_IP_LIST
+          tf_name: ntp_server_ip_list
+          type: String
+          description: Comma separated list of IP Addresses(v4/v6)
+          computed: true
+
+        - model_name: NTP_SERVER_VRF
+          tf_name: ntp_server_vrf
+          type: String
+          description: >-
+            One VRF for all NTP servers or a comma separated list of VRFs, one per
+            NTP server
+          computed: true
+
+        - model_name: NVE_LB_ID
+          tf_name: nve_lb_id
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: NXAPI_HTTPS_PORT
+          tf_name: nxapi_https_port
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: NXAPI_HTTP_PORT
+          tf_name: nxapi_http_port
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: OBJECT_TRACKING_NUMBER_RANGE
+          tf_name: object_tracking_number_range
+          type: String
+          description: Per switch tracked object ID Range
+          computed: true
+
+        - model_name: OSPF_AREA_ID
+          tf_name: ospf_area_id
+          type: String
+          description: OSPF Area Id in IP address format
+          computed: true
+
+        - model_name: OSPF_AUTH_ENABLE
+          tf_name: ospf_auth_enable
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: OSPF_AUTH_KEY
+          tf_name: ospf_auth_key
+          type: String
+          description: 3DES Encrypted
+          computed: true
+
+        - model_name: OSPF_AUTH_KEY_ID
+          tf_name: ospf_auth_key_id
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: OVERLAY_MODE
+          tf_name: overlay_mode
+          type: String
+          description: VRF/Network configuration using config-profile or CLI
+          computed: true
+
+        - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION
+          tf_name: per_vrf_loopback_auto_provision
+          type: Bool
+          description: Auto provision a loopback on a VTEP on VRF attachment
+          computed: true
+
+        - model_name: PER_VRF_LOOPBACK_IP_RANGE
+          tf_name: per_vrf_loopback_ip_range
+          type: String
+          description: >-
+            Prefix pool to assign IP addresses to loopbacks on VTEPs on a per VRF
+            basis
+          computed: true
+
+        - model_name: PHANTOM_RP_LB_ID1
+          tf_name: phantom_rp_lb_id1
+          type: Int64
+          handle_empty: true
+          description: Used for Bidir-PIM Phantom RP
+          computed: true
+
+        - model_name: PHANTOM_RP_LB_ID2
+          tf_name: phantom_rp_lb_id2
+          type: Int64
+          handle_empty: true
+          description: Used for Fallback Bidir-PIM Phantom RP
+          computed: true
+
+        - model_name: PHANTOM_RP_LB_ID3
+          tf_name: phantom_rp_lb_id3
+          type: Int64
+          handle_empty: true
+          description: Used for second Fallback Bidir-PIM Phantom RP
+          computed: true
+
+        - model_name: PHANTOM_RP_LB_ID4
+          tf_name: phantom_rp_lb_id4
+          type: Int64
+          handle_empty: true
+          description: Used for third Fallback Bidir-PIM Phantom RP
+          computed: true
+
+        - model_name: PIM_HELLO_AUTH_ENABLE
+          tf_name: pim_hello_auth_enable
+          type: Bool
+          description: Valid for IPv4 Underlay only
+          computed: true
+
+        - model_name: PIM_HELLO_AUTH_KEY
+          tf_name: pim_hello_auth_key
+          type: String
+          description: 3DES Encrypted
+          computed: true
+
+        - model_name: PM_ENABLE
+          tf_name: pm_enable
+          type: Bool
+          description: No description available
+          computed: true
+
+        - model_name: POWER_REDUNDANCY_MODE
+          tf_name: power_redundancy_mode
+          type: String
+          description: Default Power Supply Mode For The Fabric
+          computed: true
+
+        - model_name: PTP_DOMAIN_ID
+          tf_name: ptp_domain_id
+          type: Int64
+          handle_empty: true
+          description: Multiple Independent PTP Clocking Subdomains on a Single Network
+          computed: true
+
+        - model_name: PTP_LB_ID
+          tf_name: ptp_lb_id
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: REPLICATION_MODE
+          tf_name: replication_mode
+          type: String
+          description: Replication Mode for BUM Traffic
+          computed: true
+
+        - model_name: ROUTER_ID_RANGE
+          tf_name: router_id_range
+          type: String
+          description: No description available
+          computed: true
+
+        - model_name: ROUTE_MAP_SEQUENCE_NUMBER_RANGE
+          tf_name: route_map_sequence_number_range
+          type: String
+          description: No description available
+          computed: true
+
+        - model_name: RP_COUNT
+          tf_name: rp_count
+          type: Int64
+          handle_empty: true
+          description: Number of spines acting as Rendezvous-Point (RP)
+          computed: true
+
+        - model_name: RP_LB_ID
+          tf_name: rp_lb_id
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: RP_MODE
+          tf_name: rp_mode
+          type: String
+          description: Multicast RP Mode
+          computed: true
+
+        - model_name: RR_COUNT
+          tf_name: rr_count
+          type: Int64
+          handle_empty: true
+          description: Number of spines acting as Route-Reflectors
+          computed: true
+
+        - model_name: SEED_SWITCH_CORE_INTERFACES
+          tf_name: seed_switch_core_interfaces
+          type: String
+          description: 'Core-facing Interface list on Seed Switch (e.g. e1/1-30,e1/32)'
+          computed: true
+
+        - model_name: SERVICE_NETWORK_VLAN_RANGE
+          tf_name: service_network_vlan_range
+          type: String
+          description: Per Switch Overlay Service Network VLAN Range
+          computed: true
+
+        - model_name: SITE_ID
+          tf_name: site_id
+          type: String
+          description: For EVPN Multi-Site Support . Defaults to Fabric ASN
+          computed: true
+
+        - model_name: SLA_ID_RANGE
+          tf_name: sla_id_range
+          type: String
+          description: Per switch SLA ID Range
+          computed: true
+
+        - model_name: SNMP_SERVER_HOST_TRAP
+          tf_name: snmp_server_host_trap
+          type: Bool
+          description: Configure NDFC as a receiver for SNMP traps
+          computed: true
+
+        - model_name: SPINE_SWITCH_CORE_INTERFACES
+          tf_name: spine_switch_core_interfaces
+          type: String
+          description: 'Core-facing Interface list on all Spines (e.g. e1/1-30,e1/32)'
+          computed: true
+
+        - model_name: STATIC_UNDERLAY_IP_ALLOC
+          tf_name: static_underlay_ip_alloc
+          type: Bool
+          description: Checking this will disable Dynamic Underlay IP Address Allocations
+          computed: true
+
+        - model_name: STP_BRIDGE_PRIORITY
+          tf_name: stp_bridge_priority
+          type: Int64
+          handle_empty: true
+          description: Bridge priority for the spanning tree in increments of 4096
+          computed: true
+
+        - model_name: STP_ROOT_OPTION
+          tf_name: stp_root_option
+          type: String
+          description: >-
+            Which protocol to use for configuring root bridge? rpvst+: Rapid
+            Per-VLAN Spanning Tree, mst: Multiple Spanning Tree, unmanaged
+            (default): STP Root not managed by NDFC
+          computed: true
+
+        - model_name: STP_VLAN_RANGE
+          tf_name: stp_vlan_range
+          type: String
+          description: 'Vlan range, Example: 1,3-5,7,9-11, Default is 1-3967'
+          computed: true
+
+        - model_name: STRICT_CC_MODE
+          tf_name: strict_cc_mode
+          type: Bool
+          description: >-
+            Enable bi-directional compliance checks to flag additional configs in
+            the running config that are not in the intent/expected config
+          computed: true
+
+        - model_name: SUBINTERFACE_RANGE
+          tf_name: subinterface_range
+          type: String
+          description: Per Border Dot1q Range For VRF Lite Connectivity
+          computed: true
+
+        - model_name: SUBNET_RANGE
+          tf_name: subnet_range
+          type: String
+          description: Address range to assign Numbered and Peer Link SVI IPs
+          computed: true
+
+        - model_name: SUBNET_TARGET_MASK
+          tf_name: subnet_target_mask
+          type: Int64
+          handle_empty: true
+          description: Mask for Underlay Subnet IP Range
+          computed: true
+
+        - model_name: SYSLOG_SERVER_IP_LIST
+          tf_name: syslog_server_ip_list
+          type: String
+          description: Comma separated list of IP Addresses(v4/v6)
+          computed: true
+
+        - model_name: SYSLOG_SERVER_VRF
+          tf_name: syslog_server_vrf
+          type: String
+          description: >-
+            One VRF for all Syslog servers or a comma separated list of VRFs, one
+            per Syslog server
+          computed: true
+
+        - model_name: SYSLOG_SEV
+          tf_name: syslog_sev
+          type: String
+          description: 'Comma separated list of Syslog severity values, one per Syslog server'
+          computed: true
+
+        - model_name: TCAM_ALLOCATION
+          tf_name: tcam_allocation
+          type: Bool
+          description: >-
+            TCAM commands are automatically generated for VxLAN and vPC
+            Fabric Peering when Enabled
+          computed: true
+
+        - model_name: UNDERLAY_IS_V6
+          tf_name: underlay_is_v6
+          type: Bool
+          description: 'If not enabled, IPv4 underlay is used'
+          computed: true
+
+        - model_name: UNNUM_BOOTSTRAP_LB_ID
+          tf_name: unnum_bootstrap_lb_id
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: UNNUM_DHCP_END
+          tf_name: unnum_dhcp_end
+          type: String
+          description: Must be a subset of IGP/BGP Loopback Prefix Pool
+          computed: true
+
+        - model_name: UNNUM_DHCP_START
+          tf_name: unnum_dhcp_start
+          type: String
+          description: Must be a subset of IGP/BGP Loopback Prefix Pool
+          computed: true
+
+        - model_name: USE_LINK_LOCAL
+          tf_name: use_link_local
+          type: Bool
+          description: 'If not enabled, Spine-Leaf interfaces will use global IPv6 addresses'
+          computed: true
+
+        - model_name: V6_SUBNET_RANGE
+          tf_name: v6_subnet_range
+          type: String
+          description: IPv6 Address range to assign Numbered and Peer Link SVI IPs
+          computed: true
+
+        - model_name: V6_SUBNET_TARGET_MASK
+          tf_name: v6_subnet_target_mask
+          type: Int64
+          handle_empty: true
+          description: Mask for Underlay Subnet IPv6 Range
+          computed: true
+
+        - model_name: VPC_AUTO_RECOVERY_TIME
+          tf_name: vpc_auto_recovery_time
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: VPC_DELAY_RESTORE
+          tf_name: vpc_delay_restore
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: VPC_DOMAIN_ID_RANGE
+          tf_name: vpc_domain_id_range
+          type: String
+          description: vPC Domain id range to use for new pairings
+          computed: true
+
+        - model_name: VPC_ENABLE_IPv6_ND_SYNC
+          tf_name: vpc_enable_ipv6_nd_sync
+          type: Bool
+          description: Enable IPv6 ND synchronization between vPC peers
+          computed: true
+
+        - model_name: VPC_PEER_KEEP_ALIVE_OPTION
+          tf_name: vpc_peer_keep_alive_option
+          type: String
+          description: Use vPC Peer Keep Alive with Loopback or Management
+          computed: true
+
+        - model_name: VPC_PEER_LINK_PO
+          tf_name: vpc_peer_link_po
+          type: Int64
+          handle_empty: true
+          description: No description available
+          computed: true
+
+        - model_name: VPC_PEER_LINK_VLAN
+          tf_name: vpc_peer_link_vlan
+          type: Int64
+          handle_empty: true
+          description: VLAN range for vPC Peer Link SVI
+          computed: true
+
+        - model_name: VRF_LITE_AUTOCONFIG
+          tf_name: vrf_lite_autoconfig
+          type: String
+          description: >-
+            VRF Lite Inter-Fabric Connection Deployment Options. If
+            Back2Back&ToExternal is selected, VRF Lite IFCs are auto created between
+            border devices of two Easy Fabrics, and between border devices in Easy
+            Fabric and edge routers in External Fabric. The IP address is taken from
+            the VRF Lite Subnet IP Range pool.
+          computed: true
+
+        - model_name: VRF_VLAN_RANGE
+          tf_name: vrf_vlan_range
+          type: String
+          description: Per Switch Overlay VRF VLAN Range
+          computed: true
+
+        - model_name: default_network
+          tf_name: default_network
+          type: String
+          description: Default Overlay Network Template For Leafs
+          computed: true
+
+        - model_name: default_pvlan_sec_network
+          tf_name: default_pvlan_sec_network
+          type: String
+          description: Default PVLAN Secondary Network Template
+          computed: true
+
+        - model_name: default_vrf
+          tf_name: default_vrf
+          type: String
+          description: Default Overlay VRF Template For Leafs
+          computed: true
+
+        - model_name: enableRealTimeBackup
+          tf_name: enable_real_time_backup
+          type: Bool
+          description: Backup hourly only if there is any config deployment since last backup
+          computed: true
+
+        - model_name: enableScheduledBackup
+          tf_name: enable_scheduled_backup
+          type: Bool
+          description: Backup at the specified time
+          computed: true
+
+        - model_name: network_extension_template
+          tf_name: network_extension_template
+          type: String
+          description: Default Overlay Network Template For Borders
+          computed: true
+
+        - model_name: scheduledTime
+          tf_name: scheduled_time
+          type: String
+          description: 'Time (UTC) in 24hr format. (00:00 to 23:59)'
+          computed: true
+
+        - model_name: vrf_extension_template
+          tf_name: vrf_extension_template
+          type: String
+          description: Default Overlay VRF Template For Borders
+          computed: true
+
+        - model_name: deployment_status
+          tf_name: deployment_status
+          type: String
+          description: >-
+            This fields shows the actual status of the deployment. It can be one of the following:
+            Deployment successful
+          computed: true
+
+        - model_name: IPv6_MULTICAST_GROUP_SUBNET
+          tf_name: ipv6_multicast_group_subnet
+          description: IPv6 Multicast Group Subnet - IPv6 Multicast address with prefix 112 to 128
+          type: String
+          example: "ff1e::/121"
+          computed: true
+
+        - model_name: ENABLE_TRMv6
+          tf_name: enable_trmv6
+          description: For Overlay IPv6 Multicast Support In VXLAN Fabrics
+          type: Bool
+          computed: true
+
+        - model_name: L3VNI_IPv6_MCAST_GROUP
+          tf_name: l3vni_ipv6_mcast_group
+          description: Default MDT IPv6 Address for TRM VRFs - Default Underlay Multicast group IP6 address assigned for every overlay VRF
+          type: String
+          example: "ff1e::"
+          computed: true
+
+        - model_name: MVPN_VRI_ID_RANGE
+          tf_name: mvpn_vri_id_range
+          description: MVPN VRI ID for vPC, applicable when TRM is enabled with IPv6 underlay, or TRM is enabled with IPv4 underlay while fabric allows L3VNI without VLAN option
+          type: String
+          computed: true
+
+        - model_name: ENABLE_VRI_ID_REALLOC
+          tf_name: enable_vri_id_realloc
+          description: One time VRI ID re-allocation based on 'MVPN VRI ID Range'
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_AGG_ACC_ID_RANGE
+          tf_name: enable_agg_acc_id_range
+          description: Use specific vPC/Port-channel ID range for leaf-tor pairings
+          type: Bool
+          computed: true
+
+        - model_name: AGG_ACC_VPC_PO_ID_RANGE
+          tf_name: agg_acc_vpc_po_id_range
+          description: Specify one vPC/Port-Channel ID range, this range is used for auto-allocating vPC/Port-Channel IDs for leaf-tor pairings
+          type: String
+          example: 1-499
+          computed: true
+
+        - model_name: ISIS_AREA_NUM
+          tf_name: isis_area_num
+          description: IS-IS NET Area Number - NET in form of XX.<4-hex-digit Custom Area Number>.XXXX.XXXX.XXXX.00
+          type: String
+          example: 0001
+          computed: true
+
+        - model_name: ENABLE_SGT
+          tf_name: enable_sgt
+          description: Enable Security Groups - Security group can be enabled only with V4 underlay and CLI overlay mode
+          type: Bool
+          computed: true
+
+        - model_name: SGT_NAME_PREFIX
+          tf_name: sgt_name_prefix
+          description: Security Group Name Prefix - Prefix to be used when a new Security Group is created (Min:1, Max:10 characters)
+          type: String
+          example: SG_
+          computed: true
+
+        - model_name: SGT_ID_RANGE
+          tf_name: sgt_id_range
+          description: "Security Group Tag (SGT) ID Range - Min:16, Max:65535. Reserved Range: 0-15"
+          type: String
+          example: 10000-14000
+          computed: true
+
+        - model_name: SGT_PREPROVISION
+          tf_name: sgt_preprovision
+          description: Security Groups Pre-provision - Generate security groups configuration for non-enforced VRFs
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_DCI_MACSEC
+          tf_name: enable_dci_macsec
+          description: Enable DCI MACsec - Enable MACsec on DCI links. DCI MACsec fabric parameters are used for configuring MACsec on a DCI link if 'Use Link MACsec Setting' is disabled on the link.
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_QKD
+          tf_name: enable_qkd
+          description: Enable QKD - Enable DCI MACsec with QKD config
+          type: Bool
+          computed: true
+
+        - model_name: ALLOW_L3VNI_NO_VLAN
+          tf_name: allow_l3vni_no_vlan
+          description: Whether allows L3 VNI configuration without VLAN configuration
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_L3VNI_NO_VLAN
+          tf_name: enable_l3vni_no_vlan
+          description: L3 VNI configuration without VLAN configuration. This value is propagated on vrf creation as the default value of 'Enable L3VNI w/o VLAN' in vrf
+          type: Bool
+          computed: true
+
+        - model_name: MPLS_ISIS_AREA_NUM
+          tf_name: mpls_isis_area_num
+          description: IS-IS NET Area Number for MPLS Handoff - NET in form of XX.<4-hex-digit Custom Area Number>.XXXX.XXXX.XXXX.00
+          type: String
+          example: 0001
+          computed: true
+
+        - model_name: ENABLE_AI_ML_QOS_POLICY
+          tf_name: enable_ai_ml_qos_policy
+          description: Configures QoS and Queuing Policies specific to N9K Cloud Scale switch fabric for AI/ML network loads
+          type: Bool
+          computed: true
+
+        - model_name: AI_ML_QOS_POLICY
+          tf_name: ai_ml_qos_policy
+          description: "Queuing Policy based on predominant fabric link speed: 400G / 100G / 25G"
+          type: String
+          example: AI_Fabric_QOS_400G
+          computed: true
+
+        - model_name: PFC_WATCH_INT
+          tf_name: pfc_watch_int
+          description: Priority flow control watch-dog interval - Acceptable values from 101 to 1000 (milliseconds). Leave blank for system default (100ms).
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: ENABLE_RT_INTF_STATS
+          tf_name: enable_rt_intf_stats
+          description: Enable Real Time Interface Statistics Collection - Valid for NX-OS only
+          type: Bool
+          computed: true
+
+        - model_name: IPv6_ANYCAST_RP_IP_RANGE
+          tf_name: ipv6_anycast_rp_ip_range
+          description: Anycast RP IPv6 Address Range
+          type: String
+          example: fd00::254:254:0/118
+          computed: true
+
+        - model_name: KME_SERVER_IP
+          tf_name: kme_server_ip
+          description: Key Management Entity server IPv4 address
+          type: String
+          computed: true
+
+        - model_name: KME_SERVER_PORT
+          tf_name: kme_server_port
+          description: Key Management Entity server port number
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: TRUSTPOINT_LABEL
+          tf_name: trustpoint_label
+          description: Tls authentication type trustpoint label (Max Size 64)
+          type: String
+          computed: true
+
+        - model_name: IGNORE_CERT
+          tf_name: ignore_cert
+          description: Skip verification of incoming certificate
+          type: Bool
+          computed: true
+
+        - model_name: DEPLOYMENT_FREEZE
+          tf_name: deployment_freeze
+          description: Disable all deployments in this fabric
+          type: Bool
+          computed: true
+
+        - model_name: QKD_PROFILE_NAME
+          tf_name: qkd_profile_name
+          description: Name of crypto profile (Max Size 63)
+          type: String
+          computed: true
+
+        - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION_V6
+          tf_name: per_vrf_loopback_auto_provision_v6
+          description: Auto provision a loopback IPv6 on a VTEP on VRF attachment
+          type: Bool
+          computed: true
+
+        - model_name: PER_VRF_LOOPBACK_IP_RANGE_V6
+          tf_name: per_vrf_loopback_ip_range_v6
+          description: Prefix pool to assign IPv6 addresses to loopbacks on VTEPs on a per VRF basis
+          type: String
+          example: fd00::a05:0/112
+          computed: true
+
+        - model_name: ESR_OPTION
+          tf_name: esr_option
+          description: Policy-Based Routing (PBR) or Enhanced PBR (ePBR)
+          type: String
+          computed: true
+          validator: 'OneOf("PBR", "ePBR")'
+
+        - model_name: PTP_VLAN_ID
+          tf_name: ptp_vlan_id
+          description: (Min:2, Max:3967) SVI used for PTP source on ToRs
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: ALLOW_NXC
+          tf_name: allow_nxc
+          description: Allow onboarding of this fabric to Nexus Cloud
+          type: Bool
+          computed: true
+
+        - model_name: OVERWRITE_GLOBAL_NXC
+          tf_name: overwrite_global_nxc
+          description: If enabled, Fabric NxCloud Settings will be used
+          type: Bool
+          computed: true
+
+        - model_name: NXC_DEST_VRF
+          tf_name: nxc_dest_vrf
+          description: VRF to be used to reach Nexus Cloud, enter 'management' for management VRF and 'default' for default VRF
+          type: String
+          example: management
+          computed: true
+
+        - model_name: NXC_SRC_INTF
+          tf_name: nxc_src_intf
+          description: "Source interface for communication to Nexus Cloud, mandatory if Destination VRF is not management, supported interfaces: loopback, port-channel, vlan"
+          type: String
+          computed: true
+
+        - model_name: NXC_PROXY_SERVER
+          tf_name: nxc_proxy_server
+          description: IPv4 or IPv6 address, or DNS name of the proxy server
+          type: String
+          computed: true
+
+        - model_name: NXC_PROXY_PORT
+          tf_name: nxc_proxy_port
+          description: Proxy port number, default is 8080
+          type: Int64
+          handle_empty: true
+          example: 8080
+          computed: true
+
+        - model_name: VPC_DELAY_RESTORE_TIME
+          tf_name: vpc_delay_restore_time
+          description: vPC Delay Restore Time For vPC links in seconds (Min:1, Max:3600)
+          type: Int64
+          handle_empty: true
+          example: 60
+          computed: true
+
+        - model_name: FABRIC_TYPE
+          tf_name: fabric_type
+          description: Fabric Type
+          type: String
+          example: Switch_Fabric
+          computed: true
+
+        - model_name: EXT_FABRIC_TYPE
+          tf_name: ext_fabric_type
+          description: External Fabric Type
+          type: String
+          computed: true
+
+        - model_name: ENABLE_AGENT
+          tf_name: enable_agent
+          description: Enable Agnet (development purpose only)
+          type: Bool
+          computed: true
+
+        - model_name: AGENT_INTF
+          tf_name: agent_intf
+          description: Interface to connect to Agent
+          type: String
+          example: eth0
+          computed: true
+
+        - model_name: SSPINE_ADD_DEL_DEBUG_FLAG
+          tf_name: sspine_add_del_debug_flag
+          description: Allow First Super Spine Add or Last Super Spine Delete From Topology
+          type: String
+          example: Disable
+          computed: true
+
+        - model_name: BRFIELD_DEBUG_FLAG
+          tf_name: brfield_debug_flag
+          description: "!!! Only for brf debugging purpose !!!"
+          type: String
+          example: Disable
+          computed: true
+
+        - model_name: ACTIVE_MIGRATION
+          tf_name: active_migration
+          description: Active Migration
+          type: Bool
+          computed: true
+
+        - model_name: FF
+          tf_name: ff
+          description: Template Family
+          type: String
+          example: Easy_Fabric
+          computed: true
+
+        - model_name: BGP_AS_PREV
+          tf_name: bgp_as_prev
+          description: Previous BGP AS value
+          type: String
+          computed: true
+
+        - model_name: UNDERLAY_IS_V6_PREV
+          tf_name: underlay_is_v6_prev
+          description: Previous state of UNDERLAY_IS_V6
+          type: Bool
+          computed: true
+
+        - model_name: PM_ENABLE_PREV
+          tf_name: pm_enable_prev
+          description: Previous state of Performance Monitoring Enable
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_FABRIC_VPC_DOMAIN_ID_PREV
+          tf_name: enable_fabric_vpc_domain_id_prev
+          description: Previous state of Enable Fabric VPC Domain ID
+          type: Bool
+          computed: true
+
+        - model_name: OVERLAY_MODE_PREV
+          tf_name: overlay_mode_prev
+          description: Previous Overlay Mode value
+          type: String
+          computed: true
+
+        - model_name: ALLOW_L3VNI_NO_VLAN_PREV
+          tf_name: allow_l3vni_no_vlan_prev
+          description: Previous state of Allow L3VNI without VLAN
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_PVLAN_PREV
+          tf_name: enable_pvlan_prev
+          description: Previous state of Enable Private VLAN
+          type: Bool
+          computed: true
+
+        - model_name: AUTO_UNIQUE_VRF_LITE_IP_PREFIX_PREV
+          tf_name: auto_unique_vrf_lite_ip_prefix_prev
+          description: Previous state of Auto Unique VRF Lite IP Prefix
+          type: Bool
+          computed: true
+
+        - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION_PREV
+          tf_name: per_vrf_loopback_auto_provision_prev
+          description: Previous state of Per VRF Loopback Auto Provisioning
+          type: Bool
+          computed: true
+
+        - model_name: PER_VRF_LOOPBACK_AUTO_PROVISION_V6_PREV
+          tf_name: per_vrf_loopback_auto_provision_v6_prev
+          description: Previous state of Per VRF Loopback IPv6 Auto Provisioning
+          type: Bool
+          computed: true
+
+        - model_name: MSO_SITE_ID
+          tf_name: mso_site_id
+          description: MSO Site ID
+          type: String
+          computed: true
+
+        - model_name: MSO_CONTROLER_ID
+          tf_name: mso_controler_id
+          description: MSO Controller ID
+          type: String
+          computed: true
+
+        - model_name: MSO_SITE_GROUP_NAME
+          tf_name: mso_site_group_name
+          description: MSO Site Group Name
+          type: String
+          computed: true
+
+        - model_name: PREMSO_PARENT_FABRIC
+          tf_name: premso_parent_fabric
+          description: Pre-MSO Parent Fabric
+          type: String
+          computed: true
+
+        - model_name: MSO_CONNECTIVITY_DEPLOYED
+          tf_name: mso_connectivity_deployed
+          description: MSO Connectivity Deployed
+          type: String
+          computed: true
+
+        - model_name: ANYCAST_RP_IP_RANGE_INTERNAL
+          tf_name: anycast_rp_ip_range_internal
+          description: Internal Anycast RP IP Range
+          type: String
+          computed: true
+
+        - model_name: IPv6_ANYCAST_RP_IP_RANGE_INTERNAL
+          tf_name: ipv6_anycast_rp_ip_range_internal
+          description: Internal IPv6 Anycast RP IP Range
+          type: String
+          computed: true
+
+        - model_name: DHCP_START_INTERNAL
+          tf_name: dhcp_start_internal
+          description: Internal DHCP Scope Start Address
+          type: String
+          computed: true
+
+        - model_name: DHCP_END_INTERNAL
+          tf_name: dhcp_end_internal
+          description: Internal DHCP Scope End Address
+          type: String
+          computed: true
+
+        - model_name: MGMT_GW_INTERNAL
+          tf_name: mgmt_gw_internal
+          description: Internal Management Gateway
+          type: String
+          computed: true
+
+        - model_name: MGMT_PREFIX_INTERNAL
+          tf_name: mgmt_prefix_internal
+          description: Internal Management Subnet Prefix
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: BOOTSTRAP_MULTISUBNET_INTERNAL
+          tf_name: bootstrap_multisubnet_internal
+          description: Internal Bootstrap Multi Subnet Scope
+          type: String
+          computed: true
+
+        - model_name: MGMT_V6PREFIX_INTERNAL
+          tf_name: mgmt_v6prefix_internal
+          description: Internal Management IPv6 Subnet Prefix
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: DHCP_IPV6_ENABLE_INTERNAL
+          tf_name: dhcp_ipv6_enable_internal
+          description: Internal DHCP IPv6 Enable Flag
+          type: String
+          computed: true
+
+        - model_name: UNNUM_DHCP_START_INTERNAL
+          tf_name: unnum_dhcp_start_internal
+          description: Internal Unnumbered DHCP Start Address
+          type: String
+          computed: true
+
+        - model_name: UNNUM_DHCP_END_INTERNAL
+          tf_name: unnum_dhcp_end_internal
+          description: Internal Unnumbered DHCP End Address
+          type: String
+          computed: true
+
+        - model_name: ENABLE_EVPN
+          tf_name: enable_evpn
+          description: Enable EVPN
+          type: Bool
+          computed: true
+
+        - model_name: FEATURE_PTP_INTERNAL
+          tf_name: feature_ptp_internal
+          description: Internal PTP Feature Enable Flag
+          type: Bool
+          computed: true
+
+        - model_name: SSPINE_COUNT
+          tf_name: sspine_count
+          description: Super Spine Count
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: SPINE_COUNT
+          tf_name: spine_count
+          description: Spine Count
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: abstract_feature_leaf
+          tf_name: abstract_feature_leaf
+          description: Feature Configuration for Leaf
+          type: String
+          computed: true
+
+        - model_name: abstract_feature_spine
+          tf_name: abstract_feature_spine
+          description: Feature Configuration for Spine
+          type: String
+          computed: true
+
+        - model_name: abstract_dhcp
+          tf_name: abstract_dhcp
+          description: DHCP Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_multicast
+          tf_name: abstract_multicast
+          description: Multicast Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_anycast_rp
+          tf_name: abstract_anycast_rp
+          description: Anycast RP Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_loopback_interface
+          tf_name: abstract_loopback_interface
+          description: Primary Loopback Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_isis
+          tf_name: abstract_isis
+          description: ISIS Network Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_ospf
+          tf_name: abstract_ospf
+          description: OSPF Network Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_vpc_domain
+          tf_name: abstract_vpc_domain
+          description: vPC Domain Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_vlan_interface
+          tf_name: abstract_vlan_interface
+          description: VLAN Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_isis_interface
+          tf_name: abstract_isis_interface
+          description: ISIS Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_ospf_interface
+          tf_name: abstract_ospf_interface
+          description: OSPF Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_pim_interface
+          tf_name: abstract_pim_interface
+          description: PIM Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_route_map
+          tf_name: abstract_route_map
+          description: Route-Map Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_bgp
+          tf_name: abstract_bgp
+          description: BGP Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_bgp_rr
+          tf_name: abstract_bgp_rr
+          description: BGP RR Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_bgp_neighbor
+          tf_name: abstract_bgp_neighbor
+          description: BGP Neighbor Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_extra_config_leaf
+          tf_name: abstract_extra_config_leaf
+          description: Add Extra Configuration for Leaf
+          type: String
+          computed: true
+
+        - model_name: abstract_extra_config_spine
+          tf_name: abstract_extra_config_spine
+          description: Add Extra Configuration for Spine
+          type: String
+          computed: true
+
+        - model_name: abstract_extra_config_tor
+          tf_name: abstract_extra_config_tor
+          description: Add Extra Configuration for ToR
+          type: String
+          computed: true
+
+        - model_name: abstract_extra_config_bootstrap
+          tf_name: abstract_extra_config_bootstrap
+          description: Add Extra Configuration for Bootstrap
+          type: String
+          computed: true
+
+        - model_name: temp_anycast_gateway
+          tf_name: temp_anycast_gateway
+          description: Anycast Gateway MAC Configuration
+          type: String
+          computed: true
+
+        - model_name: temp_vpc_domain_mgmt
+          tf_name: temp_vpc_domain_mgmt
+          description: vPC Keep-alive Configuration using Management VRF
+          type: String
+          computed: true
+
+        - model_name: temp_vpc_peer_link
+          tf_name: temp_vpc_peer_link
+          description: vPC Peer-Link Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_routed_host
+          tf_name: abstract_routed_host
+          description: Routed Host Port Configuration
+          type: String
+          computed: true
+
+        - model_name: UPGRADE_FROM_VERSION
+          tf_name: upgrade_from_version
+          description: Upgrade from Version
+          type: String
+          computed: true
+
+        - model_name: TOPDOWN_CONFIG_RM_TRACKING
+          tf_name: topdown_config_rm_tracking
+          description: Top-Down Config RM Tracking
+          type: String
+          computed: true
+
+        - model_name: SITE_ID_POLICY_ID
+          tf_name: site_id_policy_id
+          description: Site ID Policy ID
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: FABRIC_VPC_DOMAIN_ID_PREV
+          tf_name: fabric_vpc_domain_id_prev
+          description: Internal Fabric Wide vPC Domain ID
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: LINK_STATE_ROUTING_TAG_PREV
+          tf_name: link_state_routing_tag_prev
+          description: Previous Link State Routing Tag
+          type: String
+          computed: true
+
+        - model_name: BFD_ENABLE_PREV
+          tf_name: bfd_enable_prev
+          description: Previous state of BFD Enable
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_SGT_PREV
+          tf_name: enable_sgt_prev
+          description: Previous state of Enable Security Groups
+          type: Bool
+          computed: true
+
+        - model_name: SGT_PREPROVISION_PREV
+          tf_name: sgt_preprovision_prev
+          description: Previous state of Security Group Tag Preprovision
+          type: Bool
+          computed: true
+
+        - model_name: SGT_PREPROV_RECALC_STATUS
+          tf_name: sgt_preprov_recalc_status
+          description: Recalculation status for Security Group pre-provisioning
+          type: String
+          computed: true
+          enum_values: ['start', 'empty', 'completed']
+
+        - model_name: SGT_RECALC_STATUS
+          tf_name: sgt_recalc_status
+          description: Recalculation status for Security Group
+          type: String
+          computed: true
+          enum_values: ['start', 'empty', 'completed']
+
+        - model_name: SGT_OPER_STATUS
+          tf_name: sgt_oper_status
+          description: Operational status for Security Group
+          type: String
+          computed: true
+          enum_values: ['on', 'off']
+
+        - model_name: ENABLE_MACSEC_PREV
+          tf_name: enable_macsec_prev
+          description: Previous state of Enable MACsec
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_DCI_MACSEC_PREV
+          tf_name: enable_dci_macsec_prev
+          description: Previous state of Enable DCI MACsec
+          type: Bool
+          computed: true
+
+        - model_name: DCI_MACSEC_FALLBACK_KEY_STRING
+          tf_name: dci_macsec_fallback_key_string
+          description: Cisco Type 7 Encrypted Octet String. This parameter is used when DCI link has QKD disabled.
+          type: String
+          computed: true
+
+        - model_name: DCI_MACSEC_FALLBACK_ALGORITHM
+          tf_name: dci_macsec_fallback_algorithm
+          description: AES_128_CMAC or AES_256_CMAC. This parameter is used when DCI link has QKD disabled.
+          type: String
+          computed: true
+          enum_values: ['AES_128_CMAC', 'AES_256_CMAC']
+
+        - model_name: DCI_MACSEC_ALGORITHM
+          tf_name: dci_macsec_algorithm
+          description: AES_128_CMAC or AES_256_CMAC
+          type: String
+          computed: true
+          enum_values: ['AES_128_CMAC', 'AES_256_CMAC']
+
+        - model_name: DCI_MACSEC_KEY_STRING
+          tf_name: dci_macsec_key_string
+          description: Cisco Type 7 Encrypted Octet String
+          type: String
+          computed: true
+
+        - model_name: DCI_MACSEC_CIPHER_SUITE
+          tf_name: dci_macsec_cipher_suite
+          description: Configure Cipher Suite
+          type: String
+          computed: true
+          enum_values: ['GCM-AES-128', 'GCM-AES-256', 'GCM-AES-XPN-128', 'GCM-AES-XPN-256']
+
+        - model_name: QKD_PROFILE_NAME_PREV
+          tf_name: qkd_profile_name_prev
+          description: Previous state of QKD Profile Name
+          type: Bool
+          computed: true
+
+        - model_name: FABRIC_MTU_PREV
+          tf_name: fabric_mtu_prev
+          description: Previous state of Fabric MTU
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: L2_HOST_INTF_MTU_PREV
+          tf_name: l2_host_intf_mtu_prev
+          description: Previous state of Layer 2 Host Interface MTU
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: MPLS_ISIS_AREA_NUM_PREV
+          tf_name: mpls_isis_area_num_prev
+          description: Previous state of MPLS IS-IS Area Number
+          type: String
+          computed: true
+
+        - model_name: ISIS_AREA_NUM_PREV
+          tf_name: isis_area_num_prev
+          description: Area Number last used for generating IS-IS NET
+          type: String
+          computed: true
+
+        - model_name: ENABLE_AI_ML_QOS_POLICY_FLAP
+          tf_name: enable_ai_ml_qos_policy_flap
+          description: Previous state of Enable AI/ML QoS Policy Flap
+          type: Bool
+          computed: true
+
+        - model_name: PFC_WATCH_INT_PREV
+          tf_name: pfc_watch_int_prev
+          description: Previous state of Priority Flow Control Watch Interval
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: INBAND_MGMT_PREV
+          tf_name: inband_mgmt_prev
+          description: Previous state of Inband Management
+          type: Bool
+          computed: true
+
+        - model_name: BOOTSTRAP_ENABLE_PREV
+          tf_name: bootstrap_enable_prev
+          description: Previous state of Bootstrap Enable
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_NETFLOW_PREV
+          tf_name: enable_netflow_prev
+          description: Previous state of Enable Netflow
+          type: Bool
+          computed: true
+
+        - model_name: ALLOW_NXC_PREV
+          tf_name: allow_nxc_prev
+          description: Previous state of Allow Nexus Cloud
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_NBM_PASSIVE_PREV
+          tf_name: enable_nbm_passive_prev
+          description: Previous state of Enable NBM Passive Mode
+          type: Bool
+          computed: true
+
+        - model_name: FABRIC_TECHNOLOGY
+          tf_name: fabric_technology
+          description: Fabric Technology
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_ETHERNET_DEFAULT_POLICY
+          tf_name: interface_ethernet_default_policy
+          description: Default policy for Ethernet interface of spine/leaf/tier2-leaf switches
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_LOOPBACK_DEFAULT_POLICY
+          tf_name: interface_loopback_default_policy
+          description: Loopback Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_PORT_CHANNEL_DEFAULT_POLICY
+          tf_name: interface_port_channel_default_policy
+          description: Port Channel Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_VLAN_DEFAULT_POLICY
+          tf_name: interface_vlan_default_policy
+          description: VLAN Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: RP_IP_RANGE_INTERNAL
+          tf_name: rp_ip_range_internal
+          description: Internal RP IP Range
+          type: String
+          computed: true
+
+        - model_name: INBAND_ENABLE_PREV
+          tf_name: inband_enable_prev
+          description: "Previous state of Enable POAP over Inband Interface"
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_ASM
+          tf_name: enable_asm
+          description: Enable groups with receivers sending (*,G) joins
+          type: Bool
+          computed: true
+
+        - model_name: DOMAIN_NAME_INTERNAL
+          tf_name: domain_name_internal
+          description: Internal Domain Name
+          type: String
+          computed: true
+
+        - model_name: PNP_ENABLE_INTERNAL
+          tf_name: pnp_enable_internal
+          description: Internal PnP Enable
+          type: Bool
+          computed: true
+
+        - model_name: BGW_ROUTING_TAG
+          tf_name: bgw_routing_tag
+          description: Routing tag associated with IP address of loopback
+              and DCI interfaces
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: DCNM_ID
+          tf_name: dcnm_id
+          description: DCNM ID
+          type: String
+          computed: true
+
+        - model_name: ENABLE_TRM_TRMv6
+          tf_name: enable_trm_trmv6
+          description: Enable IPv4 and/or IPv6 Tenant Routed Multicast
+              across sites
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_TRM_TRMv6_PREV
+          tf_name: enable_trm_trmv6_prev
+          description: Previous state of Enable IPv4 and/or IPv6 Tenant
+              Routed Multicast across sites
+          type: Bool
+          computed: true
+
+        - model_name: LOOPBACK100_IPV6_RANGE
+          tf_name: loopback100_ipv6_range
+          description: Multi-Site VTEP VIP Loopback IPv6 Range
+          type: String
+          computed: true
+
+        - model_name: BGW_ROUTING_TAG_PREV
+          tf_name: bgw_routing_tag_prev
+          description: Previous state of Border Gateway Routing Tag
+          type: String
+          computed: true
+
+        - model_name: MS_IFC_BGP_AUTH_KEY_TYPE
+          tf_name: ms_ifc_bgp_auth_key_type
+          description: 'BGP Key Encryption Type: 3 - 3DES, 7 - Cisco'
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: MS_IFC_BGP_AUTH_KEY_TYPE_PREV
+          tf_name: ms_ifc_bgp_auth_key_type_prev
+          description: 'BGP Key Encryption Type: 3 - 3DES, 7 - Cisco'
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: MS_IFC_BGP_PASSWORD_ENABLE_PREV
+          tf_name: ms_ifc_bgp_password_enable_prev
+          description: Previous state of Enable Multi-Site eBGP Password
+          type: Bool
+          computed: true
+
+        - model_name: MS_IFC_BGP_PASSWORD_PREV
+          tf_name: ms_ifc_bgp_password_prev
+          description: Previous state of eBGP Password
+          type: String
+          computed: true
+
+        - model_name: PARENT_ONEMANAGE_FABRIC
+          tf_name: parent_onemanage_fabric
+          description: Parent OneManage Fabric
+          type: String
+          computed: true
+
+        - model_name: SGT_ID_RANGE_PREV
+          tf_name: sgt_id_range_prev
+          description: Previous state of Security Group Tag (SGT) ID Range
+          type: String
+          computed: true
+
+        - model_name: SGT_NAME_PREFIX_PREV
+          tf_name: sgt_name_prefix_prev
+          description: Previous state of Security Group Name Prefix
+          type: String
+          computed: true
+
+        - model_name: V6_DCI_SUBNET_RANGE
+          tf_name: v6_dci_subnet_range
+          description: Address range to assign P2P DCI Links
+          type: String
+          computed: true
+
+        - model_name: V6_DCI_SUBNET_TARGET_MASK
+          tf_name: v6_dci_subnet_target_mask
+          description: Target IPv6 Mask for Subnet Range (Min:120, Max:127)
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: VXLAN_UNDERLAY_IS_V6
+          tf_name: vxlan_underlay_is_v6
+          description: If not enabled, IPv4 underlay is used in child VXLAN
+              fabric
+          type: Bool
+          computed: true

--- a/generator/defs/fabric_ipfm.yaml
+++ b/generator/defs/fabric_ipfm.yaml
@@ -5,11 +5,14 @@ resource:
     generate_tf_resource: true
     parent_package: resource_fabric_common
     parent_model: fabric_common
-    description: Resource to configure and manage IP Fabric Media
+    description: >-  
+        Resource to configure and manage IP Fabric Media. 
+        Only creation/updation/deletion of the fabric is supported,
+        resources on top of the fabric are not supported yet.
     attributes:
         - model_name: id
           tf_name: id
-          description: Terraform unique Id for the fabric resource
+          description: Terraform unique Id for the ipfm fabric resource
           type: String
           id: true
           computed: true
@@ -17,7 +20,7 @@ resource:
 
         - model_name: FABRIC_NAME
           tf_name: fabric_name
-          description: 'Fabric name to be created, updated or deleted (Max Size 64).'
+          description: 'Fabric name to be created, updated or deleted.'
           type: String
           example: IP_FABRIC_MEDIA
           mandatory: true
@@ -25,104 +28,229 @@ resource:
 
         - model_name: AAA_REMOTE_IP_ENABLED
           tf_name: aaa_remote_ip_enabled
-          description: Enable only when IP Authorization is enabled in the AAA Server
+          description: Enable only, when IP Authorization is enabled in the AAA \
+            Server
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: AAA_SERVER_CONF
           tf_name: aaa_server_conf
           description: AAA Configurations
           type: String
+          optional: true
+          computed: true
+
+        - model_name: ACTIVE_MIGRATION
+          tf_name: active_migration
+          description: Active Migration
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: AGENT_INTF
+          tf_name: agent_intf
+          description: Interface to connect to Agent
+          type: String
+          optional: true
+          computed: true
+          validator: OneOf("eth0", "eth1")
 
         - model_name: ASM_GROUP_RANGES
           tf_name: asm_group_ranges
           description: >-
-            ASM group ranges with prefixes (len:4-32) example: 239.1.1.0/25, max 20
-            ranges. Enabling SPT-Threshold Infinity to prevent switchover to
-            source-tree.
+            ASM group ranges with prefixes (len:4-32) example: 239.1.1.0/25,
+            max 20 ranges. Enabling SPT-Threshold Infinity to prevent switchover
+            to source-tree.
           type: String
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_CONF
           tf_name: bootstrap_conf
-          description: Additional CLIs required during device bootup/login e.g. AAA/Radius
+          description: Additional CLIs required during device bootup/login e.g.
+            AAA/Radius
           type: String
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_ENABLE
           tf_name: bootstrap_enable
           description: Automatic IP Assignment For POAP
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_MULTISUBNET
           tf_name: bootstrap_multisubnet
-          description: 'lines with # prefix are ignored here'
+          description: "DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here"
           type: String
           example: >-
             #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
             Scope_Subnet_Prefix
+          optional: true
+          computed: true
+
+        - model_name: BOOTSTRAP_MULTISUBNET_INTERNAL
+          tf_name: bootstrap_multisubnet_internal
+          description: Internal Bootstrap Multi Subnet Scope
+          type: String
+          computed: true
+
+        - model_name: BRFIELD_DEBUG_FLAG
+          tf_name: brfield_debug_flag
+          description: !!! Only for brf debugging purpose !!!
+          type: String
+          optional: true
+          computed: true
+          validator: OneOf("Enable", "Disable")
 
         - model_name: CDP_ENABLE
           tf_name: cdp_enable
           description: Enable CDP on management interface
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: DEPLOYMENT_FREEZE
+          tf_name: deployment_freeze
+          description: Disable all deployments in this fabric
+          type: Bool
+          optional: true
+          computed: true
 
         - model_name: DHCP_ENABLE
           tf_name: dhcp_enable
           description: Automatic IP Assignment For POAP From Local DHCP Server
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: DHCP_END
           tf_name: dhcp_end
           description: End Address For Switch Out-of-Band POAP
           type: String
+          optional: true
+          computed: true
+
+        - model_name: DHCP_END_INTERNAL
+          tf_name: dhcp_end_internal
+          description: Internal DHCP End Address
+          type: String
+          computed: true
 
         - model_name: DHCP_IPV6_ENABLE
           tf_name: dhcp_ipv6_enable
           description: No description available
           type: String
           validator: OneOf("DHCPv4")
+          optional: true
+          computed: true
+
+        - model_name: DHCP_IPV6_ENABLE_INTERNAL
+          tf_name: dhcp_ipv6_enable_internal
+          description: Internal DHCP IPv6 Enable
+          type: String
+          computed: true
 
         - model_name: DHCP_START
           tf_name: dhcp_start
           description: Start Address For Switch Out-of-Band POAP
           type: String
+          optional: true
+          computed: true
+
+        - model_name: DHCP_START_INTERNAL
+          tf_name: dhcp_start_internal
+          description: Internal DHCP Start Address
+          type: String
+          computed: true
 
         - model_name: DNS_SERVER_IP_LIST
           tf_name: dns_server_ip_list
           description: Comma separated list of IP Addresses (v4/v6)
           type: String
+          optional: true
+          computed: true
 
         - model_name: DNS_SERVER_VRF
           tf_name: dns_server_vrf
           description: >-
-            One VRF for all DNS servers or a comma separated list of VRFs, one per
-            DNS server
+            One VRF for all DNS servers or a comma separated list of VRFs, one
+            per DNS server
           type: String
+          optional: true
+          computed: true
 
         - model_name: ENABLE_AAA
           tf_name: enable_aaa
-          description: Include AAA configs from Manageability tab during device bootup
+          description: Include AAA configs from Manageability tab during device
+            bootup
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_AGENT
+          tf_name: enable_agent
+          description: Enable Agent (development purpose only)
+          type: Bool
+          optional: true
+          computed: true
 
         - model_name: ENABLE_ASM
           tf_name: enable_asm
-          description: 'Enable groups with receivers sending (*,G) joins'
+          description: Enable groups with receivers sending (*,G) joins
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: ENABLE_NBM_PASSIVE
           tf_name: enable_nbm_passive
           description: Enable NBM mode to pim-passive for default VRF
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_NBM_PASSIVE_PREV
+          tf_name: enable_nbm_passive_prev
+          description: Previous state of Enable NBM Passive Mode
+          type: Bool
+          computed: true
+
+        - model_name: ENABLE_NXAPI
+          tf_name: enable_nxapi
+          description: Enable HTTPS NX-API
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_NXAPI_HTTP
+          tf_name: enable_nxapi_http
+          description: Enable HTTP NX-API
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_RT_INTF_STATS
+          tf_name: enable_rt_intf_stats
+          description: Valid for NX-OS only
+          type: Bool
+          optional: true
+          computed: true
 
         - model_name: EXTRA_CONF_INTRA_LINKS
           tf_name: extra_conf_intra_links
           description: Additional CLIs For All Intra-Fabric Links
           type: String
+          optional: true
+          computed: true
 
         - model_name: EXTRA_CONF_LEAF
           tf_name: extra_conf_leaf
@@ -130,6 +258,8 @@ resource:
             Additional CLIs For All Leafs and Tier2 Leafs As Captured From Show
             Running Configuration
           type: String
+          optional: true
+          computed: true
 
         - model_name: EXTRA_CONF_SPINE
           tf_name: extra_conf_spine
@@ -137,13 +267,22 @@ resource:
             Additional CLIs For All Spines As Captured From Show Running
             Configuration
           type: String
+          optional: true
+          computed: true
+
+        - model_name: EXT_FABRIC_TYPE
+          tf_name: ext_fabric_type
+          description: External Fabric Type
+          type: String
+          optional: true
+          computed: true
 
         - model_name: FABRIC_INTERFACE_TYPE
           tf_name: fabric_interface_type
           description: Only Numbered(Point-to-Point) is supported
           type: String
+          computed: true
           validator: OneOf("p2p")
-          example: p2p
 
         - model_name: FABRIC_MTU
           tf_name: fabric_mtu
@@ -151,48 +290,138 @@ resource:
           type: Int64
           handle_empty: true
           example: 9216
+          optional: true
+          computed: true
+
+        - model_name: FABRIC_MTU_PREV
+          tf_name: fabric_mtu_prev
+          description: Previous state of Fabric MTU
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: FABRIC_TECHNOLOGY
+          tf_name: fabric_technology
+          description: Fabric Technology
+          type: String
+          computed: true
+
+        - model_name: FABRIC_TYPE
+          tf_name: fabric_type
+          description: Fabric Type
+          type: String
+          computed: true
 
         - model_name: FEATURE_PTP
           tf_name: feature_ptp
-          description: No description available
+          description: Enable Precision Time Protocol (PTP)
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: FEATURE_PTP_INTERNAL
+          tf_name: feature_ptp_internal
+          description: Internal Feature PTP
+          type: Bool
+          computed: true
+
+        - model_name: FF
+          tf_name: ff
+          description: Template Family
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: GRFIELD_DEBUG_FLAG
+          tf_name: grfield_debug_flag
+          description: Enable to clean switch configuration without reload when
+            PreserveConfig=no
+          type: String
+          optional: true
+          computed: true
+          validator: OneOf("Enable", "Disable")
+
+        - model_name: INTERFACE_ETHERNET_DEFAULT_POLICY
+          tf_name: interface_ethernet_default_policy
+          description: Default policy for Ethernet interface of spine/leaf/
+            tier2-leaf switches
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_LOOPBACK_DEFAULT_POLICY
+          tf_name: interface_loopback_default_policy
+          description: Loopback Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_PORT_CHANNEL_DEFAULT_POLICY
+          tf_name: interface_port_channel_default_policy
+          description: Port Channel Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: INTERFACE_VLAN_DEFAULT_POLICY
+          tf_name: interface_vlan_default_policy
+          description: VLAN Interface Default Policy
+          type: String
+          computed: true
+
+        - model_name: INTF_STAT_LOAD_INTERVAL
+          tf_name: intf_stat_load_interval
+          description: Time in seconds (Min:5, Max:300)
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: ISIS_AUTH_ENABLE
           tf_name: isis_auth_enable
-          description: No description available
+          description: Enable IS-IS Authentication
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: ISIS_AUTH_KEY
           tf_name: isis_auth_key
           description: Cisco Type 7 Encrypted
           type: String
+          optional: true
+          computed: true
 
         - model_name: ISIS_AUTH_KEYCHAIN_KEY_ID
           tf_name: isis_auth_keychain_key_id
-          description: No description available
+          description: IS-IS Authentication Key ID (Min:0, Max:65535)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: ISIS_AUTH_KEYCHAIN_NAME
           tf_name: isis_auth_keychain_name
-          description: No description available
+          description: IS-IS Authentication Keychain Name
           type: String
+          optional: true
+          computed: true
 
         - model_name: ISIS_LEVEL
           tf_name: isis_level
-          description: 'Supported IS types: level-1, level-2'
+          description: "Supported IS types: level-1, level-2"
           type: String
           validator: 'OneOf("level-1", "level-2")'
           example: level-2
+          optional: true
+          computed: true
 
         - model_name: ISIS_P2P_ENABLE
           tf_name: isis_p2p_enable
           description: >-
-            This will enable network point-to-point on fabric interfaces which are
-            numbered
+            This will enable network point-to-point on fabric interfaces which
+            are numbered
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: L2_HOST_INTF_MTU
           tf_name: l2_host_intf_mtu
@@ -200,6 +429,15 @@ resource:
           type: Int64
           handle_empty: true
           example: 9216
+          optional: true
+          computed: true
+
+        - model_name: L2_HOST_INTF_MTU_PREV
+          tf_name: l2_host_intf_mtu_prev
+          description: Previous state of Layer 2 Host Interface MTU
+          type: Int64
+          handle_empty: true
+          computed: true
 
         - model_name: LINK_STATE_ROUTING
           tf_name: link_state_routing
@@ -207,41 +445,104 @@ resource:
           type: String
           validator: 'OneOf("ospf", "is-is")'
           example: ospf
+          optional: true
+          computed: true
 
         - model_name: LINK_STATE_ROUTING_TAG
           tf_name: link_state_routing_tag
           description: Routing process tag for the fabric
           type: String
           example: '1'
+          optional: true
+          computed: true
+
+        - model_name: LINK_STATE_ROUTING_TAG_PREV
+          tf_name: link_state_routing_tag_prev
+          description: Previous state of Link State Routing Tag
+          type: String
+          computed: true
 
         - model_name: LOOPBACK0_IP_RANGE
           tf_name: loopback0_ip_range
           description: Routing Loopback IP Address Range
           type: String
           example: 10.2.0.0/22
+          optional: true
+          computed: true
 
         - model_name: MGMT_GW
           tf_name: mgmt_gw
           description: Default Gateway For Management VRF On The Switch
           type: String
+          optional: true
+          computed: true
+
+        - model_name: MGMT_GW_INTERNAL
+          tf_name: mgmt_gw_internal
+          description: Internal Management Gateway
+          type: String
+          computed: true
 
         - model_name: MGMT_PREFIX
           tf_name: mgmt_prefix
-          description: No description available
+          description: Switch Mgmt IP Subnet Prefix (Min:8, Max:30)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: MGMT_PREFIX_INTERNAL
+          tf_name: mgmt_prefix_internal
+          description: Internal Management Prefix
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: MGMT_V6PREFIX
+          tf_name: mgmt_v6prefix
+          description: Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)
+          type: Int64
+          handle_empty: true
+          computed: true
+
+        - model_name: MGMT_V6PREFIX_INTERNAL
+          tf_name: mgmt_v6prefix_internal
+          description: Internal Management IPv6 Prefix
+          type: Int64
+          handle_empty: true
+          computed: true
 
         - model_name: NTP_SERVER_IP_LIST
           tf_name: ntp_server_ip_list
           description: Comma separated list of IP Addresses (v4/v6)
           type: String
+          optional: true
+          computed: true
 
         - model_name: NTP_SERVER_VRF
           tf_name: ntp_server_vrf
           description: >-
-            One VRF for all NTP servers or a comma separated list of VRFs, one per
-            NTP server
+            One VRF for all NTP servers or a comma separated list of VRFs, one
+            per NTP server
           type: String
+          optional: true
+          computed: true
+
+        - model_name: NXAPI_HTTPS_PORT
+          tf_name: nxapi_https_port
+          description: NX-API HTTPS Port Number
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: NXAPI_HTTP_PORT
+          tf_name: nxapi_http_port
+          description: NX-API HTTP Port Number
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: NXAPI_VRF
           tf_name: nxapi_vrf
@@ -249,46 +550,68 @@ resource:
           type: String
           validator: 'OneOf("management", "default")'
           example: management
+          optional: true
+          computed: true
 
         - model_name: OSPF_AREA_ID
           tf_name: ospf_area_id
           description: OSPF Area Id in IP address format
           type: String
           example: 0.0.0.0
+          optional: true
+          computed: true
 
         - model_name: OSPF_AUTH_ENABLE
           tf_name: ospf_auth_enable
-          description: No description available
+          description: Enable OSPF Authentication
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: OSPF_AUTH_KEY
           tf_name: ospf_auth_key
           description: 3DES Encrypted
           type: String
+          optional: true
+          computed: true
 
         - model_name: OSPF_AUTH_KEY_ID
           tf_name: ospf_auth_key_id
           description: No description available
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: PIM_HELLO_AUTH_ENABLE
           tf_name: pim_hello_auth_enable
-          description: No description available
+          description: Enable PIM Hello Authentication
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: PIM_HELLO_AUTH_KEY
           tf_name: pim_hello_auth_key
           description: 3DES Encrypted
           type: String
+          optional: true
+          computed: true
 
         - model_name: PM_ENABLE
           tf_name: pm_enable
-          description: No description available
+          description: Enable Performance Monitoring
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: PM_ENABLE_PREV
+          tf_name: pm_enable_prev
+          description: Previous state of Enable Performance Monitoring
+          type: Bool
+          computed: true
 
         - model_name: POWER_REDUNDANCY_MODE
           tf_name: power_redundancy_mode
@@ -296,24 +619,42 @@ resource:
           type: String
           validator: 'OneOf("ps-redundant", "combined", "insrc-redundant")'
           example: ps-redundant
+          optional: true
+          computed: true
 
         - model_name: PTP_DOMAIN_ID
           tf_name: ptp_domain_id
-          description: Multiple Independent PTP Clocking Subdomains on a Single Network
+          description: >-
+            Multiple Independent PTP Clocking Subdomains on a Single Network
+            (Min:0, Max:127)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: PTP_LB_ID
           tf_name: ptp_lb_id
           description: No description available
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: PTP_PROFILE
           tf_name: ptp_profile
           description: Enabled on ISL links only
           type: String
           validator: 'OneOf("IEEE-1588v2", "SMPTE-2059-2", "AES67-2015")'
+          optional: true
+          computed: true
+
+        - model_name: REPLICATION_MODE
+          tf_name: replication_mode
+          description: Replication Mode
+          type: String
+          optional: true
+          computed: true
+          validator: OneOf("Multicast")
 
         - model_name: ROUTING_LB_ID
           tf_name: routing_lb_id
@@ -321,35 +662,61 @@ resource:
           type: Int64
           handle_empty: true
           example: 0
+          optional: true
+          computed: true
 
         - model_name: RP_IP_RANGE
           tf_name: rp_ip_range
           description: RP Loopback IP Address Range
           type: String
+          optional: true
+          computed: true
+
+        - model_name: RP_IP_RANGE_INTERNAL
+          tf_name: rp_ip_range_internal
+          description: Internal RP IP Range
+          type: String
+          computed: true
 
         - model_name: RP_LB_ID
           tf_name: rp_lb_id
           description: No description available
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: SNMP_SERVER_HOST_TRAP
           tf_name: snmp_server_host_trap
           description: Configure NDFC as a receiver for SNMP traps
           type: Bool
           example: true
+          optional: true
+          computed: true
+
+        - model_name: SPINE_COUNT
+          tf_name: spine_count
+          description: Spine Count
+          type: Int64
+          handle_empty: true
+          computed: true
 
         - model_name: STATIC_UNDERLAY_IP_ALLOC
           tf_name: static_underlay_ip_alloc
-          description: Checking this will disable Dynamic Fabric IP Address Allocations
+          description: Checking this will disable Dynamic Fabric IP Address
+            Allocations
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: SUBNET_RANGE
           tf_name: subnet_range
           description: Address range to assign Numbered IPs
           type: String
           example: 10.4.0.0/16
+          optional: true
+          computed: true
 
         - model_name: SUBNET_TARGET_MASK
           tf_name: subnet_target_mask
@@ -358,23 +725,105 @@ resource:
           handle_empty: true
           validator: 'OneOf(30, 31)'
           example: 30
+          optional: true
+          computed: true
 
         - model_name: SYSLOG_SERVER_IP_LIST
           tf_name: syslog_server_ip_list
           description: Comma separated list of IP Addresses (v4/v6)
           type: String
+          optional: true
+          computed: true
 
         - model_name: SYSLOG_SERVER_VRF
           tf_name: syslog_server_vrf
           description: >-
-            One VRF for all Syslog servers or a comma separated list of VRFs, one
-            per Syslog server
+            One VRF for all Syslog servers or a comma separated list of VRFs,
+            one per Syslog server
           type: String
+          optional: true
+          computed: true
 
         - model_name: SYSLOG_SEV
           tf_name: syslog_sev
-          description: 'Comma separated list of Syslog severity values, one per Syslog server'
+          description: >-
+            Comma separated list of Syslog severity values, one per Syslog
+            server (Min:0, Max:7)
           type: String
+          optional: true
+          computed: true
+
+        - model_name: UPGRADE_FROM_VERSION
+          tf_name: upgrade_from_version
+          description: Upgrade From Version
+          type: String
+          computed: true
+
+        - model_name: abstract_dhcp
+          tf_name: abstract_dhcp
+          description: DHCP Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_extra_config_bootstrap
+          tf_name: abstract_extra_config_bootstrap
+          description: Add Extra Configuration for Bootstrap
+          type: String
+          computed: true
+
+        - model_name: abstract_extra_config_leaf
+          tf_name: abstract_extra_config_leaf
+          description: Add Extra Configuration for Leaf
+          type: String
+          computed: true
+
+        - model_name: abstract_extra_config_spine
+          tf_name: abstract_extra_config_spine
+          description: Add Extra Configuration for Spine
+          type: String
+          computed: true
+
+        - model_name: abstract_isis
+          tf_name: abstract_isis
+          description: ISIS Network Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_isis_interface
+          tf_name: abstract_isis_interface
+          description: ISIS Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_loopback_interface
+          tf_name: abstract_loopback_interface
+          description: Primary Loopback Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_ospf
+          tf_name: abstract_ospf
+          description: OSPF Network Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_ospf_interface
+          tf_name: abstract_ospf_interface
+          description: OSPF Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_pim_interface
+          tf_name: abstract_pim_interface
+          description: PIM Interface Configuration
+          type: String
+          computed: true
+
+        - model_name: abstract_routed_host
+          tf_name: abstract_routed_host
+          description: L3 Port Configuration
+          type: String
+          computed: true
 
         - model_name: deploy
           tf_name: deploy
@@ -388,8 +837,8 @@ resource:
         - model_name: deployment_status
           tf_name: deployment_status
           description: >-
-            This fields shows the actual status of the deployment. It can be one of
-            the following: Deployment pending Deployment successful
+            This fields shows the actual status of the deployment. It can be one
+            of the following: Deployment pending Deployment successful
           type: String
           computed: true
           payload_hide: true

--- a/generator/defs/fabric_lan_classic.yaml
+++ b/generator/defs/fabric_lan_classic.yaml
@@ -5,7 +5,10 @@ resource:
     generate_tf_resource: true
     parent_package: resource_fabric_common
     parent_model: fabric_common
-    description: Resource to configure and manage a LAN Classic Fabric
+    description: >- 
+        Resource to configure and manage a LAN Classic Fabric.
+        Only creation/updation/deletion of the fabric is supported,
+        resources on top of the fabric are not supported yet.
     attributes:
         - model_name: id
           tf_name: id
@@ -17,7 +20,7 @@ resource:
 
         - model_name: FABRIC_NAME
           tf_name: fabric_name
-          description: 'Fabric name to be created, updated or deleted (Max Size 64).'
+          description: Fabric name to be created, updated or deleted.
           type: String
           example: TF_FABRIC_LAN_CLASSIC
           mandatory: true
@@ -25,147 +28,355 @@ resource:
 
         - model_name: AAA_REMOTE_IP_ENABLED
           tf_name: aaa_remote_ip_enabled
-          description: 'Enable only, when IP Authorization is enabled in the AAA Server'
+          description: Enable only, when IP Authorization is enabled in the AAA
+              Server
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: AAA_SERVER_CONF
           tf_name: aaa_server_conf
           description: AAA Configurations
           type: String
+          optional: true
+          computed: true
+
+        - model_name: ALLOW_NXC
+          tf_name: allow_nxc
+          description: Allow onboarding of this fabric to Nexus Cloud
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: ALLOW_NXC_PREV
+          tf_name: allow_nxc_prev
+          description: Previous state of Allow onboarding of this fabric to
+              Nexus Cloud
+          type: Bool
+          computed: true
 
         - model_name: BOOTSTRAP_CONF
           tf_name: bootstrap_conf
-          description: Additional CLIs required during device bootup/login e.g. AAA/Radius
+          description: Additional CLIs required during device bootup/login
+              e.g. AAA/Radius
           type: String
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_ENABLE
           tf_name: bootstrap_enable
           description: Automatic IP Assignment For POAP
+              (For NX-OS Switches Only)
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_MULTISUBNET
           tf_name: bootstrap_multisubnet
-          description: 'lines with # prefix are ignored here'
+          description: "DHCPv4 Multi Subnet Scope -
+              lines with # prefix are ignored here"
           type: String
           example: >-
             #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
             Scope_Subnet_Prefix
+          optional: true
+          computed: true
+
+        - model_name: BOOTSTRAP_MULTISUBNET_INTERNAL
+          tf_name: bootstrap_multisubnet_internal
+          description: Internal Bootstrap Multi Subnet Scope
+          type: String
+          computed: true
 
         - model_name: CDP_ENABLE
           tf_name: cdp_enable
           description: Enable CDP on management interface
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: DCI_SUBNET_RANGE
+          tf_name: dci_subnet_range
+          description: Address range to assign P2P DCI Links
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: DCI_SUBNET_TARGET_MASK
+          tf_name: dci_subnet_target_mask
+          description: Target Mask for Subnet Range (Min:8, Max:31)
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: DEPLOYMENT_FREEZE
+          tf_name: deployment_freeze
+          description: Disable all deployments in this fabric
+          type: Bool
+          optional: true
+          computed: true
 
         - model_name: DHCP_ENABLE
           tf_name: dhcp_enable
           description: Automatic IP Assignment For POAP From Local DHCP Server
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: DHCP_END
           tf_name: dhcp_end
           description: End Address For Switch POAP
           type: String
+          optional: true
+          computed: true
+
+        - model_name: DHCP_END_INTERNAL
+          tf_name: dhcp_end_internal
+          description: Internal DHCP End Address
+          type: String
+          computed: true
 
         - model_name: DHCP_IPV6_ENABLE
           tf_name: dhcp_ipv6_enable
-          description: No description available
+          description: DHCP Version
           type: String
-          validator: 'OneOf("DHCPv4", "DHCPv6")'
+          validator: OneOf("DHCPv4", "DHCPv6")
+          optional: true
+          computed: true
+
+        - model_name: DHCP_IPV6_ENABLE_INTERNAL
+          tf_name: dhcp_ipv6_enable_internal
+          description: Internal DHCP IPv6 Enable
+          type: String
+          computed: true
 
         - model_name: DHCP_START
           tf_name: dhcp_start
           description: Start Address For Switch POAP
           type: String
+          optional: true
+          computed: true
+
+        - model_name: DHCP_START_INTERNAL
+          tf_name: dhcp_start_internal
+          description: Internal DHCP Start Address
+          type: String
+          computed: true
 
         - model_name: ENABLE_AAA
           tf_name: enable_aaa
-          description: Include AAA configs from Advanced tab during device bootup
+          description: Include AAA configs from Advanced
+              tab during device bootup
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: ENABLE_NETFLOW
           tf_name: enable_netflow
           description: Enable Netflow on VTEPs
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_NETFLOW_PREV
+          tf_name: enable_netflow_prev
+          description: Previous state of Enable Netflow on VTEPs
+          type: Bool
+          computed: true
 
         - model_name: ENABLE_NXAPI
           tf_name: enable_nxapi
           description: Enable HTTPS NX-API
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: ENABLE_NXAPI_HTTP
           tf_name: enable_nxapi_http
-          description: No description available
+          description: Enable HTTP NX-API
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_RT_INTF_STATS
+          tf_name: enable_rt_intf_stats
+          description: Valid for NX-OS only
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: EXT_FABRIC_TYPE
+          tf_name: ext_fabric_type
+          description: External Fabric Type
+          type: String
+          optional: true
+          computed: true
 
         - model_name: FABRIC_FREEFORM
           tf_name: fabric_freeform
-          description: Additional supported CLIs for all same OS (e.g. all NxOS etc) switches
+          description: Additional supported CLIs for all same OS
+              (e.g. all NxOS etc) switches
           type: String
+          optional: true
+          computed: true
+
+        - model_name: FABRIC_TECHNOLOGY
+          tf_name: fabric_technology
+          description: Fabric Technology
+          type: String
+          computed: true
+
+        - model_name: FABRIC_TYPE
+          tf_name: fabric_type
+          description: Fabric Type
+          type: String
+          computed: true
 
         - model_name: FEATURE_PTP
           tf_name: feature_ptp
-          description: No description available
+          description: Enable Precision Time Protocol (PTP)
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: FEATURE_PTP_INTERNAL
+          tf_name: feature_ptp_internal
+          description: Internal Feature PTP
+          type: Bool
+          computed: true
+
+        - model_name: FF
+          tf_name: ff
+          description: Template Family
+          type: String
+          optional: true
+          computed: true
 
         - model_name: INBAND_ENABLE
           tf_name: inband_enable
           description: >-
-            Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should be
-            Enabled)
+            Enable POAP over Inband Interface (Pre-req:
+            Inband Mgmt Knob should be Enabled)
           type: Bool
+          optional: true
+          computed: true
+
+        - model_name: INBAND_ENABLE_PREV
+          tf_name: inband_enable_prev
+          description: Previous state of Enable POAP over Inband Interface
+          type: Bool
+          computed: true
 
         - model_name: INBAND_MGMT
           tf_name: inband_mgmt
           description: Import switches with inband connectivity
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: INBAND_MGMT_PREV
+          tf_name: inband_mgmt_prev
+          description: Previous state of Inband Management
+          type: Bool
+          computed: true
+
+        - model_name: INTF_STAT_LOAD_INTERVAL
+          tf_name: intf_stat_load_interval
+          description: Time in seconds (Min:5, Max:300)
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: IS_READ_ONLY
           tf_name: is_read_only
-          description: 'If enabled, fabric is only monitored. No configuration will be deployed'
+          description: If enabled, fabric is only monitored.
+              No configuration will be deployed
           type: Bool
           example: true
+          optional: true
+          computed: true
+
+        - model_name: LOOPBACK0_IP_RANGE
+          tf_name: loopback0_ip_range
+          description: Underlay Routing Loopback IP Range
+          type: String
+          optional: true
+          computed: true
 
         - model_name: MGMT_GW
           tf_name: mgmt_gw
           description: Default Gateway For Management VRF On The Switch
           type: String
+          optional: true
+          computed: true
+
+        - model_name: MGMT_GW_INTERNAL
+          tf_name: mgmt_gw_internal
+          description: Internal Management Gateway
+          type: String
+          computed: true
 
         - model_name: MGMT_PREFIX
           tf_name: mgmt_prefix
-          description: No description available
+          description: Switch Mgmt IP Subnet Prefix (Min:8, Max:30)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: MGMT_PREFIX_INTERNAL
+          tf_name: mgmt_prefix_internal
+          description: Internal Management Prefix
+          type: Int64
+          handle_empty: true
+          computed: true
 
         - model_name: MGMT_V6PREFIX
           tf_name: mgmt_v6prefix
-          description: No description available
+          description: Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)
           type: Int64
           handle_empty: true
+          computed: true
+
+        - model_name: MGMT_V6PREFIX_INTERNAL
+          tf_name: mgmt_v6prefix_internal
+          description: Internal Management IPv6 Prefix
+          type: Int64
+          handle_empty: true
+          computed: true
 
         - model_name: MPLS_HANDOFF
           tf_name: mpls_handoff
-          description: No description available
+          description: Enable MPLS Handoff
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: MPLS_LB_ID
           tf_name: mpls_lb_id
-          description: No description available
+          description: (Min:0, Max:1023)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: MPLS_LOOPBACK_IP_RANGE
           tf_name: mpls_loopback_ip_range
           description: MPLS Loopback IP Address Range
           type: String
+          optional: true
+          computed: true
 
         - model_name: NETFLOW_EXPORTER_LIST
           tf_name: netflow_exporter_list
@@ -174,6 +385,8 @@ resource:
             {"NETFLOW_EXPORTER_LIST":[{"EXPORTER_NAME":"Test2","IP":"10.1.1.1","VRF":"","SRC_IF_NAME":"eth1/1","UDP_PORT":"800"}]}
           type: String
           ndfc_type: jsonencode
+          optional: true
+          computed: true
 
         - model_name: NETFLOW_MONITOR_LIST
           tf_name: netflow_monitor_list
@@ -182,6 +395,8 @@ resource:
             {"NETFLOW_MONITOR_LIST":[{"MONITOR_NAME":"Test","RECORD_NAME":"Test1","EXPORTER1":"Test2","EXPORTER2":""}]}
           type: String
           ndfc_type: jsonencode
+          optional: true
+          computed: true
 
         - model_name: NETFLOW_RECORD_LIST
           tf_name: netflow_record_list
@@ -190,34 +405,88 @@ resource:
           ndfc_type: jsonencode
           example: >-
             {"NETFLOW_RECORD_LIST":[{"RECORD_NAME":"Test1","RECORD_TEMPLATE":"netflow_ipv4_record","LAYER2_RECORD":"false"}]}
+          optional: true
+          computed: true
 
         - model_name: NETFLOW_SAMPLER_LIST
           tf_name: netflow_sampler_list
-          description: One or multiple netflow Samplers. Applicable to N7K only
-          type: String
-          ndfc_type: jsonencode
+          description: One or multiple Netflow Samplers. Applicable to N7K only
           example: >-
             {"NETFLOW_SAMPLER_LIST":[{"SAMPLER_NAME":"Test1","NUM_SAMPLES":12,"SAMPLING_RATE":10}]}
+          type: String
+          ndfc_type: jsonencode
+          optional: true
+          computed: true
 
         - model_name: NXAPI_HTTPS_PORT
           tf_name: nxapi_https_port
-          description: No description available
+          description: NX-API HTTPS Port Number
           type: Int64
           handle_empty: true
           example: 443
+          optional: true
+          computed: true
 
         - model_name: NXAPI_HTTP_PORT
           tf_name: nxapi_http_port
-          description: No description available
+          description: NX-API HTTP Port Number
           type: Int64
           handle_empty: true
           example: 80
+          optional: true
+          computed: true
+
+        - model_name: NXC_DEST_VRF
+          tf_name: nxc_dest_vrf
+          description: VRF to be used to reach Nexus Cloud, enter 'management'
+              for management VRF and 'default' for default VRF
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: NXC_PROXY_PORT
+          tf_name: nxc_proxy_port
+          description: Proxy port number, default is 8080
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: NXC_PROXY_SERVER
+          tf_name: nxc_proxy_server
+          description: IPv4 or IPv6 address, or DNS name of the proxy server
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: NXC_SRC_INTF
+          tf_name: nxc_src_intf
+          description: Source interface for communication to Nexus Cloud,
+              mandatory if Destination VRF is not management
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: OVERWRITE_GLOBAL_NXC
+          tf_name: overwrite_global_nxc
+          description: If enabled, Fabric NxCloud Settings will be used
+          type: Bool
+          optional: true
+          computed: true
 
         - model_name: PM_ENABLE
           tf_name: pm_enable
-          description: No description available
+          description: Enable Performance Monitoring (For NX-OS Switches Only)
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: PM_ENABLE_PREV
+          tf_name: pm_enable_prev
+          description: Previous state of Enable Performance Monitoring
+          type: Bool
+          computed: true
 
         - model_name: POWER_REDUNDANCY_MODE
           tf_name: power_redundancy_mode
@@ -225,47 +494,66 @@ resource:
           type: String
           validator: 'OneOf("ps-redundant", "combined", "insrc-redundant")'
           example: ps-redundant
+          optional: true
+          computed: true
 
         - model_name: PTP_DOMAIN_ID
           tf_name: ptp_domain_id
-          description: Multiple Independent PTP Clocking Subdomains on a Single Network
+          description: Multiple Independent PTP Clocking Subdomains on
+              a Single Network (Min:0, Max:127)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: PTP_LB_ID
           tf_name: ptp_lb_id
-          description: No description available
+          description: (Min:0, Max:1023)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: SNMP_SERVER_HOST_TRAP
           tf_name: snmp_server_host_trap
           description: Configure NDFC as a receiver for SNMP traps
           type: Bool
           example: true
+          optional: true
+          computed: true
 
         - model_name: SUBINTERFACE_RANGE
           tf_name: subinterface_range
           description: Per Border Dot1q Range For VRF Lite Connectivity
+              (Min:2, Max:4093)
           type: String
           example: 2-511
+          optional: true
+          computed: true
 
         - model_name: enableRealTimeBackup
           tf_name: enable_real_time_backup
-          description: Backup hourly only if there is any config deployment since last backup
+          description: Backup hourly only if there is any config
+              deployment since last backup
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: enableScheduledBackup
           tf_name: enable_scheduled_backup
           description: Backup at the specified time
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: scheduledTime
           tf_name: scheduled_time
-          description: 'Time (UTC) in 24hr format. (00:00 to 23:59)'
+          description: Time (UTC) in 24hr format. (00:00 to 23:59)
           type: String
+          optional: true
+          computed: true
 
         - model_name: deploy
           tf_name: deploy
@@ -279,8 +567,8 @@ resource:
         - model_name: deployment_status
           tf_name: deployment_status
           description: >-
-            This fields shows the  status of the deployment. It can be one of the
-            following: Deployment pending Deployment successful
+            This fields shows the  status of the deployment. It can be one of
+            the following: Deployment pending Deployment successful
           type: String
           computed: true
           payload_hide: true

--- a/generator/defs/fabric_msite_ext_net.yaml
+++ b/generator/defs/fabric_msite_ext_net.yaml
@@ -5,7 +5,10 @@ resource:
     generate_tf_resource: true
     parent_package: resource_fabric_common
     parent_model: fabric_common
-    description: Resource to configure an Multi-Site Network Fabric
+    description: >-
+        Resource to configure an Multi-Site Network Fabric.
+        Only creation/updation/deletion of the fabric is supported,
+        resources on top of the fabric are not supported yet.
     attributes:
         - model_name: id
           tf_name: id
@@ -17,7 +20,7 @@ resource:
 
         - model_name: FABRIC_NAME
           tf_name: fabric_name
-          description: 'Fabric name to be created, updated or deleted (Max Size 64).'
+          description: Fabric name to be created, updated or deleted.
           type: String
           example: TF_FABRIC_MSITE_EXT_NET
           mandatory: true
@@ -25,182 +28,409 @@ resource:
 
         - model_name: AAA_REMOTE_IP_ENABLED
           tf_name: aaa_remote_ip_enabled
-          description: 'Enable only, when IP Authorization is enabled in the AAA Server'
+          description: >-
+            Enable only, when IP Authorization is enabled in the AAA Server
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: AAA_SERVER_CONF
           tf_name: aaa_server_conf
           description: AAA Configurations
           type: String
+          optional: true
+          computed: true
+
+        - model_name: ALLOW_NXC
+          tf_name: allow_nxc
+          description: Allow onboarding of this fabric to Nexus Cloud
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: ALLOW_NXC_PREV
+          tf_name: allow_nxc_prev
+          description: Previous state of Allow onboarding of this fabric
+              to Nexus Cloud
+          type: Bool
+          computed: true
 
         - model_name: BGP_AS
           tf_name: bgp_as
           description: >-
-            1-4294967295 | 1-65535.0-65535 It is a good practice to have a unique
-            ASN for each Fabric.
+            1-4294967295 | 1-65535.0-65535. It is a good practice to have a
+            unique ASN for each Fabric.
           type: String
           mandatory: true
           example: 65000
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_CONF
           tf_name: bootstrap_conf
-          description: Additional CLIs required during device bootup/login e.g. AAA/Radius
+          description: >-
+            Additional CLIs required during device bootup/login e.g. AAA/Radius
           type: String
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_CONF_XE
           tf_name: bootstrap_conf_xe
-          description: Additional CLIs required during device bootup/login e.g. AAA/Radius
+          description: >-
+            Additional CLIs required during device bootup/login e.g. AAA/Radius
           type: String
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_ENABLE
           tf_name: bootstrap_enable
-          description: Automatic IP Assignment For POAP
+          description: >-
+              Automatic IP Assignment For POAP (For NX-OS and IOS XE
+              (Cat9K) Switches Only)
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: BOOTSTRAP_MULTISUBNET
           tf_name: bootstrap_multisubnet
-          description: 'lines with # prefix are ignored here'
+          description: >-
+              "DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here"
           type: String
           example: >-
             #Scope_Start_IP, Scope_End_IP, Scope_Default_Gateway,
             Scope_Subnet_Prefix
+          optional: true
+          computed: true
+
+        - model_name: BOOTSTRAP_MULTISUBNET_INTERNAL
+          tf_name: bootstrap_multisubnet_internal
+          description: Internal Bootstrap Multi Subnet Scope
+          type: String
+          computed: true
 
         - model_name: CDP_ENABLE
           tf_name: cdp_enable
           description: Enable CDP on management interface
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: DCI_SUBNET_RANGE
+          tf_name: dci_subnet_range
+          description: Address range to assign P2P DCI Links
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: DCI_SUBNET_TARGET_MASK
+          tf_name: dci_subnet_target_mask
+          description: Target Mask for Subnet Range (Min:8, Max:31)
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: DEPLOYMENT_FREEZE
+          tf_name: deployment_freeze
+          description: Disable all deployments in this fabric
+          type: Bool
+          optional: true
+          computed: true
 
         - model_name: DHCP_ENABLE
           tf_name: dhcp_enable
           description: Automatic IP Assignment For POAP From Local DHCP Server
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: DHCP_END
           tf_name: dhcp_end
           description: End Address For Switch POAP
           type: String
+          optional: true
+          computed: true
+
+        - model_name: DHCP_END_INTERNAL
+          tf_name: dhcp_end_internal
+          description: Internal DHCP End Address
+          type: String
+          computed: true
 
         - model_name: DHCP_IPV6_ENABLE
           tf_name: dhcp_ipv6_enable
-          description: No description available
+          description: DHCP Version
           type: String
           validator: 'OneOf("DHCPv4", "DHCPv6")'
+          optional: true
+          computed: true
+
+        - model_name: DHCP_IPV6_ENABLE_INTERNAL
+          tf_name: dhcp_ipv6_enable_internal
+          description: Internal DHCP IPv6 Enable
+          type: String
+          computed: true
 
         - model_name: DHCP_START
           tf_name: dhcp_start
           description: Start Address For Switch POAP
           type: String
+          optional: true
+          computed: true
+
+        - model_name: DHCP_START_INTERNAL
+          tf_name: dhcp_start_internal
+          description: Internal DHCP Start Address
+          type: String
+          computed: true
 
         - model_name: DOMAIN_NAME
           tf_name: domain_name
           description: Domain name for DHCP server PnP block
           type: String
+          optional: true
+          computed: true
+
+        - model_name: DOMAIN_NAME_INTERNAL
+          tf_name: domain_name_internal
+          description: Internal Domain Name
+          type: String
+          computed: true
 
         - model_name: ENABLE_AAA
           tf_name: enable_aaa
-          description: Include AAA configs from Advanced tab during device bootup
+          description: >-
+            Include AAA configs from Advanced tab during device bootup
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: ENABLE_NETFLOW
           tf_name: enable_netflow
           description: Enable Netflow on VTEPs
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_NETFLOW_PREV
+          tf_name: enable_netflow_prev
+          description: Previous state of Enable Netflow on VTEPs
+          type: Bool
+          computed: true
 
         - model_name: ENABLE_NXAPI
           tf_name: enable_nxapi
           description: Enable HTTPS NX-API
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: ENABLE_NXAPI_HTTP
           tf_name: enable_nxapi_http
-          description: No description available
+          description: Enable HTTP NX-API
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: ENABLE_RT_INTF_STATS
           tf_name: enable_rt_intf_stats
           description: Valid for NX-OS only
-          computed: true
-          optional: true
-          # This present in old 12.2.2 not in 12.1.3b
           type: Bool
+          optional: true
+          computed: true
+
+        - model_name: EXT_FABRIC_TYPE
+          tf_name: ext_fabric_type
+          description: External Fabric Type
+          type: String
+          optional: true
+          computed: true
 
         - model_name: FABRIC_FREEFORM
           tf_name: fabric_freeform
           description: >-
-            Additional supported CLIs for all same OS (e.g. all NxOS or IOS-XE, etc)
-            switches
+            Additional supported CLIs for all same OS (e.g. all NxOS or IOS-XE,
+            etc) switches
           type: String
+          optional: true
+          computed: true
+
+        - model_name: FABRIC_TYPE
+          tf_name: fabric_type
+          description: Fabric Type
+          type: String
+          computed: true
 
         - model_name: FEATURE_PTP
           tf_name: feature_ptp
-          description: No description available
+          description: Enable Precision Time Protocol (PTP)
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: FEATURE_PTP_INTERNAL
+          tf_name: feature_ptp_internal
+          description: Internal Feature PTP
+          type: Bool
+          computed: true
+
+        - model_name: FF
+          tf_name: ff
+          description: Template Family
+          type: String
+          optional: true
+          computed: true
 
         - model_name: INBAND_ENABLE
           tf_name: inband_enable
           description: >-
-            Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should be
-            Enabled)
+            Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should
+            be Enabled)
           type: Bool
+          optional: true
+          computed: true
+
+        - model_name: INBAND_ENABLE_PREV
+          tf_name: inband_enable_prev
+          description: Previous state of Enable POAP over Inband Interface
+          type: Bool
+          computed: true
 
         - model_name: INBAND_MGMT
           tf_name: inband_mgmt
           description: Import switches with inband connectivity
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: INBAND_MGMT_PREV
+          tf_name: inband_mgmt_prev
+          description: Previous state of Inband Management
+          type: Bool
+          computed: true
 
         - model_name: INTF_STAT_LOAD_INTERVAL
           tf_name: intf_stat_load_interval
           description: Time in seconds
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: IS_READ_ONLY
           tf_name: is_read_only
-          description: 'If enabled, fabric is only monitored. No configuration will be deployed'
+          description: >-
+            If enabled, fabric is only monitored. No configuration will be
+            deployed
           type: Bool
           example: true
+          optional: true
+          computed: true
+
+        - model_name: LOOPBACK0_IP_RANGE
+          tf_name: loopback0_ip_range
+          description: Underlay Routing Loopback IP Range
+          type: String
+          optional: true
+          computed: true
 
         - model_name: MGMT_GW
           tf_name: mgmt_gw
           description: Default Gateway For Management VRF On The Switch
           type: String
+          optional: true
+          computed: true
+
+        - model_name: MGMT_GW_INTERNAL
+          tf_name: mgmt_gw_internal
+          description: Internal Management Gateway
+          type: String
+          computed: true
 
         - model_name: MGMT_PREFIX
           tf_name: mgmt_prefix
-          description: No description available
+          description: Switch Mgmt IP Subnet Prefix
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: MGMT_PREFIX_INTERNAL
+          tf_name: mgmt_prefix_internal
+          description: Internal Management Prefix
+          type: Int64
+          handle_empty: true
+          computed: true
 
         - model_name: MGMT_V6PREFIX
           tf_name: mgmt_v6prefix
-          description: No description available
+          description: Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: MGMT_V6PREFIX_INTERNAL
+          tf_name: mgmt_v6prefix_internal
+          description: Internal Management IPv6 Prefix
+          type: Int64
+          handle_empty: true
+          computed: true
 
         - model_name: MPLS_HANDOFF
           tf_name: mpls_handoff
-          description: No description available
+          description: Enable MPLS Handoff
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: MPLS_LB_ID
           tf_name: mpls_lb_id
-          description: No description available
+          description: (Min:0, Max:1023)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: MPLS_LOOPBACK_IP_RANGE
           tf_name: mpls_loopback_ip_range
           description: MPLS Loopback IP Address Range
           type: String
+          optional: true
+          computed: true
+
+        - model_name: MSO_CONNECTIVITY_DEPLOYED
+          tf_name: mso_connectivity_deployed
+          description: MSO Connectivity Deployed
+          type: String
+          computed: true
+
+        - model_name: MSO_CONTROLER_ID
+          tf_name: mso_controler_id
+          description: MSO Controller ID
+          type: String
+          computed: true
+
+        - model_name: MSO_SITE_GROUP_NAME
+          tf_name: mso_site_group_name
+          description: MSO Site Group Name
+          type: String
+          computed: true
+
+        - model_name: MSO_SITE_ID
+          tf_name: mso_site_id
+          description: MSO Site ID
+          type: String
+          computed: true
 
         - model_name: NETFLOW_EXPORTER_LIST
           tf_name: netflow_exporter_list
@@ -209,6 +439,8 @@ resource:
             {"NETFLOW_EXPORTER_LIST":[{"EXPORTER_NAME":"Test2","IP":"10.1.1.1","VRF":"","SRC_IF_NAME":"eth1/1","UDP_PORT":"800"}]}
           type: String
           ndfc_type: jsonencode
+          optional: true
+          computed: true
 
         - model_name: NETFLOW_MONITOR_LIST
           tf_name: netflow_monitor_list
@@ -217,6 +449,8 @@ resource:
             {"NETFLOW_MONITOR_LIST":[{"MONITOR_NAME":"Test","RECORD_NAME":"Test1","EXPORTER1":"Test2","EXPORTER2":""}]}
           type: String
           ndfc_type: jsonencode
+          optional: true
+          computed: true
 
         - model_name: NETFLOW_RECORD_LIST
           tf_name: netflow_record_list
@@ -225,6 +459,8 @@ resource:
           ndfc_type: jsonencode
           example: >-
             {"NETFLOW_RECORD_LIST":[{"RECORD_NAME":"Test1","RECORD_TEMPLATE":"netflow_ipv4_record","LAYER2_RECORD":"false"}]}
+          optional: true
+          computed: true
 
         - model_name: NETFLOW_SAMPLER_LIST
           tf_name: netflow_sampler_list
@@ -233,31 +469,94 @@ resource:
           ndfc_type: jsonencode
           example: >-
             {"NETFLOW_SAMPLER_LIST":[{"SAMPLER_NAME":"Test1","NUM_SAMPLES":12,"SAMPLING_RATE":10}]}
+          optional: true
+          computed: true
 
         - model_name: NXAPI_HTTPS_PORT
           tf_name: nxapi_https_port
-          description: No description available
+          description: NX-API HTTPS Port Number
           type: Int64
           handle_empty: true
           example: 443
+          optional: true
+          computed: true
 
         - model_name: NXAPI_HTTP_PORT
           tf_name: nxapi_http_port
-          description: No description available
+          description: NX-API HTTP Port Number
           type: Int64
           handle_empty: true
           example: 80
+          optional: true
+          computed: true
+
+        - model_name: NXC_DEST_VRF
+          tf_name: nxc_dest_vrf
+          description: VRF to be used to reach Nexus Cloud,
+              enter 'management' for management VRF and 'default' for default
+              VRF
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: NXC_PROXY_PORT
+          tf_name: nxc_proxy_port
+          description: Proxy port number, default is 8080
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: NXC_PROXY_SERVER
+          tf_name: nxc_proxy_server
+          description: IPv4 or IPv6 address, or DNS name of the proxy server
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: NXC_SRC_INTF
+          tf_name: nxc_src_intf
+          description: Source interface for communication to Nexus Cloud,
+              mandatory if Destination VRF is not management
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: OVERWRITE_GLOBAL_NXC
+          tf_name: overwrite_global_nxc
+          description: If enabled, Fabric NxCloud Settings will be used
+          type: Bool
+          optional: true
+          computed: true
 
         - model_name: PM_ENABLE
           tf_name: pm_enable
-          description: No description available
+          description: Enable Performance Monitoring
+              (For NX-OS and IOS XE Switches Only)
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: PM_ENABLE_PREV
+          tf_name: pm_enable_prev
+          description: Previous state of Enable Performance Monitoring
+          type: Bool
+          computed: true
 
         - model_name: PNP_ENABLE
           tf_name: pnp_enable
-          description: Enable Plug n Play (Automatic IP Assignment) for Cat9K switches
+          description: >-
+            Enable Plug n Play (Automatic IP Assignment) for Cat9K switches
           type: Bool
+          optional: true
+          computed: true
+
+        - model_name: PNP_ENABLE_INTERNAL
+          tf_name: pnp_enable_internal
+          description: Internal PnP Enable
+          type: Bool
+          computed: true
 
         - model_name: POWER_REDUNDANCY_MODE
           tf_name: power_redundancy_mode
@@ -265,45 +564,71 @@ resource:
           type: String
           validator: 'OneOf("ps-redundant", "combined", "insrc-redundant")'
           example: ps-redundant
+          optional: true
+          computed: true
+
+        - model_name: PREMSO_PARENT_FABRIC
+          tf_name: premso_parent_fabric
+          description: Pre-MSO Parent Fabric
+          type: String
+          computed: true
 
         - model_name: PTP_DOMAIN_ID
           tf_name: ptp_domain_id
-          description: Multiple Independent PTP Clocking Subdomains on a Single Network
+          description: >-
+            Multiple Independent PTP Clocking Subdomains on a Single Network
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: PTP_LB_ID
           tf_name: ptp_lb_id
-          description: No description available
+          description: (Min:0, Max:1023)
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: SNMP_SERVER_HOST_TRAP
           tf_name: snmp_server_host_trap
           description: Configure NDFC as a receiver for SNMP traps
           type: Bool
           example: true
+          optional: true
+          computed: true
 
         - model_name: SUBINTERFACE_RANGE
           tf_name: subinterface_range
           description: Per Border Dot1q Range For VRF Lite Connectivity
+              (Min:2, Max:4093)
           type: String
           example: 2-511
+          optional: true
+          computed: true
 
         - model_name: enableRealTimeBackup
           tf_name: enable_real_time_backup
-          description: Backup hourly only if there is any config deployment since last backup
+          description: >-
+            Backup hourly only if there is any config deployment since last
+            backup
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: enableScheduledBackup
           tf_name: enable_scheduled_backup
           description: Backup at the specified time
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: scheduledTime
           tf_name: scheduled_time
-          description: 'Time (UTC) in 24hr format. (00:00 to 23:59)'
+          description: Time (UTC) in 24hr format. (00:00 to 23:59)
           type: String
+          optional: true
+          computed: true
 
         - model_name: deploy
           tf_name: deploy
@@ -313,12 +638,15 @@ resource:
           ndfc_type: bool
           example: false
           payload_hide: true
+          optional: true
+          computed: true
 
         - model_name: deployment_status
           tf_name: deployment_status
           description: >-
-            This fields shows the actual status of the deployment. It can be one of
-            the following: Deployment pending Deployment successful
+            This fields shows the actual status of the deployment. It can be one
+            of the following: Deployment pending Deployment successful
           type: String
           computed: true
           payload_hide: true
+          optional: true

--- a/generator/defs/fabric_vxlan_msd.yaml
+++ b/generator/defs/fabric_vxlan_msd.yaml
@@ -5,7 +5,10 @@ resource:
     generate_tf_resource: true
     parent_package: resource_fabric_common
     parent_model: fabric_common
-    description: Resource to configure and manage a VXLAN MSD Fabric
+    description: >-
+        Resource to configure and manage a VXLAN MSD Fabric.
+        Only creation/updation/deletion of the fabric is supported,
+        resources on top of the fabric are not supported yet.
     attributes:
         - model_name: id
           tf_name: id
@@ -17,7 +20,7 @@ resource:
 
         - model_name: FABRIC_NAME
           tf_name: fabric_name
-          description: 'Fabric name to be created, updated or deleted (Max Size 64).'
+          description: Fabric name to be created, updated or deleted.
           type: String
           example: TF_FABRIC_VXLAN_MSD
           mandatory: true
@@ -25,70 +28,109 @@ resource:
 
         - model_name: ANYCAST_GW_MAC
           tf_name: anycast_gw_mac
-          description: Shared MAC address for all leaves
+          description: Shared MAC address for all leafs
           type: String
           example: 2020.0000.00aa
+          optional: true
+          computed: true
 
         - model_name: BGP_RP_ASN
           tf_name: bgp_rp_asn
-          description: '1-4294967295 | 1-65535.0-65535, e.g. 65000, 65001'
+          description: 1-4294967295 | 1-65535[.0-65535], e.g. 65000, 65001
           type: String
+          optional: true
+          computed: true
 
         - model_name: BGW_ROUTING_TAG
           tf_name: bgw_routing_tag
-          description: Routing tag associated with IP address of loopback and DCI interfaces
+          description: Routing tag associated with IP address of loopback
+              and DCI interfaces
           type: Int64
           handle_empty: true
           example: 54321
+          optional: true
+          computed: true
+
+        - model_name: BGW_ROUTING_TAG_PREV
+          tf_name: bgw_routing_tag_prev
+          description: Previous state of Border Gateway Routing Tag
+          type: String
+          computed: true
 
         - model_name: BORDER_GWY_CONNECTIONS
           tf_name: border_gwy_connections
           description: >-
-            Manual, Auto Overlay EVPN Peering to Route Servers, Auto Overlay EVPN
-            Direct Peering to Border Gateways
+            Manual, Auto Overlay EVPN Peering to Route Servers, Auto
+            Overlay EVPN Direct Peering to Border Gateways
           type: String
-          validator: 'OneOf("Manual", "Centralized_To_Route_Server", "Direct_To_BGWS")'
+          validator: 'OneOf("Manual", "Centralized_To_Route_Server",
+              "Direct_To_BGWS")'
           example: Manual
+          optional: true
+          computed: true
 
         - model_name: CLOUDSEC_ALGORITHM
           tf_name: cloudsec_algorithm
-          description: AES_128_CMAC or AES_256_CMAC
+          description: CloudSec Cryptographic Algorithm
           type: String
+          validator: 'OneOf("AES_128_CMAC", "AES_256_CMAC")'
+          optional: true
+          computed: true
 
         - model_name: CLOUDSEC_AUTOCONFIG
           tf_name: cloudsec_autoconfig
           description: Auto Config CloudSec on Border Gateways
           type: Bool
           example: false
+          optional: true
+          computed: true
 
         - model_name: CLOUDSEC_ENFORCEMENT
           tf_name: cloudsec_enforcement
-          description: 'If set to strict, data across site must be encrypted.'
+          description: If set to 'strict', data across site must be encrypted.
           type: String
+          validator: 'OneOf("strict", "loose")'
+          optional: true
+          computed: true
 
         - model_name: CLOUDSEC_KEY_STRING
           tf_name: cloudsec_key_string
           description: Cisco Type 7 Encrypted Octet String
           type: String
+          optional: true
+          computed: true
 
         - model_name: CLOUDSEC_REPORT_TIMER
           tf_name: cloudsec_report_timer
-          description: CloudSec Operational Status periodic report timer in minutes
+          description: CloudSec Operational Status periodic report timer in
+              minutes
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
 
         - model_name: DCI_SUBNET_RANGE
           tf_name: dci_subnet_range
           description: Address range to assign P2P DCI Links
           type: String
           example: 10.10.1.0/24
+          optional: true
+          computed: true
 
         - model_name: DCI_SUBNET_TARGET_MASK
           tf_name: dci_subnet_target_mask
-          description: Target Mask for Subnet Range
+          description: Target Mask for Subnet Range (Min:8, Max:31)
           type: Int64
           handle_empty: true
           example: 30
+          optional: true
+          computed: true
+
+        - model_name: DCNM_ID
+          tf_name: dcnm_id
+          description: DCNM ID
+          type: String
+          computed: true
 
         - model_name: DELAY_RESTORE
           tf_name: delay_restore
@@ -98,53 +140,146 @@ resource:
           type: Int64
           handle_empty: true
           example: 300
+          optional: true
+          computed: true
 
         - model_name: ENABLE_BGP_BFD
           tf_name: enable_bgp_bfd
-          description: For auto-created Multi-Site Underlay IFCs
+          description: BGP BFD on Multi-Site Underlay IFCs
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: ENABLE_BGP_LOG_NEIGHBOR_CHANGE
           tf_name: enable_bgp_log_neighbor_change
-          description: For auto-created Multi-Site Underlay IFCs
+          description: BGP log neighbor change on Multi-Site Underlay IFCs
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: ENABLE_BGP_SEND_COMM
           tf_name: enable_bgp_send_comm
-          description: For auto-created Multi-Site Underlay IFCs
+          description: BGP Send-community on Multi-Site Underlay IFCs
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: ENABLE_PVLAN
           tf_name: enable_pvlan
           description: Enable PVLAN on MSD and its child fabrics
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_PVLAN_PREV
+          tf_name: enable_pvlan_prev
+          description: Previous state of Enable PVLAN
+          type: Bool
+          computed: true
 
         - model_name: ENABLE_RS_REDIST_DIRECT
           tf_name: enable_rs_redist_direct
           description: >-
-            For auto-created Multi-Site overlay IFCs in Route Servers. Applicable
-            only when Multi-Site Overlay IFC Deployment Method is
+            For auto-created Multi-Site overlay IFCs in Route Servers.
+            Applicable only when Multi-Site Overlay IFC Deployment Method is
             Centralized_To_Route_Server.
           type: Bool
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_SGT
+          tf_name: enable_sgt
+          description: Enable Security Groups
+          type: String
+          validator: 'OneOf("off", "strict")'
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_SGT_PREV
+          tf_name: enable_sgt_prev
+          description: Previous state of Enable Security Groups
+          type: String
+          validator: 'OneOf("off", "strict")'
+          computed: true
+
+        - model_name: ENABLE_TRM_TRMv6
+          tf_name: enable_trm_trmv6
+          description: Enable IPv4 and/or IPv6 Tenant Routed Multicast
+              across sites
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: ENABLE_TRM_TRMv6_PREV
+          tf_name: enable_trm_trmv6_prev
+          description: Previous state of Enable IPv4 and/or IPv6 Tenant Routed
+              Multicast across sites
+          type: Bool
+          computed: true
+
+        - model_name: EXT_FABRIC_TYPE
+          tf_name: ext_fabric_type
+          description: External Fabric Type
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: FABRIC_TYPE
+          tf_name: fabric_type
+          description: Fabric Type
+          type: String
+          computed: true
+
+        - model_name: FF
+          tf_name: ff
+          description: Template Family
+          type: String
+          optional: true
+          computed: true
 
         - model_name: L2_SEGMENT_ID_RANGE
           tf_name: l2_segment_id_range
           description: Overlay Network Identifier Range
           type: String
           example: 30000-49000
+          optional: true
+          computed: true
 
         - model_name: L3_PARTITION_ID_RANGE
           tf_name: l3_partition_id_range
           description: Overlay VRF Identifier Range
           type: String
           example: 50000-59000
+          optional: true
+          computed: true
+
+        - model_name: LOOPBACK100_IPV6_RANGE
+          tf_name: loopback100_ipv6_range
+          description: Multi-Site VTEP VIP Loopback IPv6 Range
+          type: String
+          optional: true
+          computed: true
 
         - model_name: LOOPBACK100_IP_RANGE
           tf_name: loopback100_ip_range
-          description: Typically Loopback100 IP Address Range
+          description: Multi-Site VTEP VIP Loopback IP Range
           type: String
           example: 10.10.0.0/24
+          optional: true
+          computed: true
+
+        - model_name: MSO_CONTROLER_ID
+          tf_name: mso_controler_id
+          description: MSO Controller ID
+          type: String
+          computed: true
+
+        - model_name: MSO_SITE_GROUP_NAME
+          tf_name: mso_site_group_name
+          description: MSO Site Group Name
+          type: String
+          computed: true
 
         - model_name: MS_IFC_BGP_AUTH_KEY_TYPE
           tf_name: ms_ifc_bgp_auth_key_type
@@ -152,38 +287,81 @@ resource:
           type: Int64
           handle_empty: true
           validator: 'OneOf(3, 7)'
+          optional: true
+          computed: true
+
+        - model_name: MS_IFC_BGP_AUTH_KEY_TYPE_PREV
+          tf_name: ms_ifc_bgp_auth_key_type_prev
+          description: 'BGP Key Encryption Type: 3 - 3DES, 7 - Cisco'
+          type: Int64
+          handle_empty: true
+          computed: true
 
         - model_name: MS_IFC_BGP_PASSWORD
           tf_name: ms_ifc_bgp_password
           description: Encrypted eBGP Password Hex String
           type: String
+          optional: true
+          computed: true
 
         - model_name: MS_IFC_BGP_PASSWORD_ENABLE
           tf_name: ms_ifc_bgp_password_enable
-          description: eBGP password for Multi-Site underlay/overlay IFCs
+          description: Enable Multi-Site eBGP Password
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: MS_IFC_BGP_PASSWORD_ENABLE_PREV
+          tf_name: ms_ifc_bgp_password_enable_prev
+          description: Previous state of Enable Multi-Site eBGP Password
+          type: Bool
+          computed: true
+
+        - model_name: MS_IFC_BGP_PASSWORD_PREV
+          tf_name: ms_ifc_bgp_password_prev
+          description: Previous state of eBGP Password
+          type: String
+          computed: true
 
         - model_name: MS_LOOPBACK_ID
           tf_name: ms_loopback_id
-          description: No description available
+          description: Multi-Site VTEP VIP Loopback ID
           type: Int64
           handle_empty: true
           example: 100
+          optional: true
+          computed: true
 
         - model_name: MS_UNDERLAY_AUTOCONFIG
           tf_name: ms_underlay_autoconfig
-          description: No description available
+          description: Multi-Site Underlay IFC Auto Deployment Flag
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: PARENT_ONEMANAGE_FABRIC
+          tf_name: parent_onemanage_fabric
+          description: Parent OneManage Fabric
+          type: String
+          computed: true
+
+        - model_name: PREMSO_PARENT_FABRIC
+          tf_name: premso_parent_fabric
+          description: Pre-MSO Parent Fabric
+          type: String
+          computed: true
 
         - model_name: RP_SERVER_IP
           tf_name: rp_server_ip
           description: >-
             Multi-Site Route-Server peer list (typically loopback IP address on
-            Route-Server for Multi-Site EVPN peering with BGWs), e.g. 128.89.0.1,
-            128.89.0.2
+            Route-Server for Multi-Site EVPN peering with BGWs),
+            e.g. 128.89.0.1, 128.89.0.2
           type: String
+          optional: true
+          computed: true
 
         - model_name: RS_ROUTING_TAG
           tf_name: rs_routing_tag
@@ -192,55 +370,158 @@ resource:
             This is the IP used in eBGP EVPN peering.
           type: Int64
           handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: SGT_ID_RANGE
+          tf_name: sgt_id_range
+          description: Security Group Tag (SGT) ID Range
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: SGT_ID_RANGE_PREV
+          tf_name: sgt_id_range_prev
+          description: Previous state of Security Group Tag (SGT) ID Range
+          type: String
+          computed: true
+
+        - model_name: SGT_NAME_PREFIX
+          tf_name: sgt_name_prefix
+          description: Prefix to be used when a new Security Group is created.
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: SGT_NAME_PREFIX_PREV
+          tf_name: sgt_name_prefix_prev
+          description: Previous state of Security Group Name Prefix
+          type: String
+          computed: true
+
+        - model_name: SGT_OPER_STATUS
+          tf_name: sgt_oper_status
+          description: Operational status for Security Groups
+          type: String
+          validator: 'OneOf("on", "off")'
+          computed: true
+
+        - model_name: SGT_PREPROVISION
+          tf_name: sgt_preprovision
+          description: Generate security groups configuration for non-enforced
+              VRFs
+          type: Bool
+          optional: true
+          computed: true
+
+        - model_name: SGT_PREPROVISION_PREV
+          tf_name: sgt_preprovision_prev
+          description: Previous state of Security Groups Pre-provision
+          type: Bool
+          computed: true
+
+        - model_name: SGT_PREPROV_RECALC_STATUS
+          tf_name: sgt_preprov_recalc_status
+          description: Recalculation status for Security Groups Pre-provision
+          type: String
+          validator: 'OneOf("start", "empty", "completed")'
+          computed: true
+
+        - model_name: SGT_RECALC_STATUS
+          tf_name: sgt_recalc_status
+          description: Recalculation status for Security Groups
+          validator: 'OneOf("start", "empty", "completed")'
+          type: String
+          computed: true
 
         - model_name: TOR_AUTO_DEPLOY
           tf_name: tor_auto_deploy
           description: Enables Overlay VLANs on uplink between ToRs and Leafs
           type: Bool
           example: false
+          optional: true
+          computed: true
+
+        - model_name: V6_DCI_SUBNET_RANGE
+          tf_name: v6_dci_subnet_range
+          description: Address range to assign P2P DCI Links
+          type: String
+          optional: true
+          computed: true
+
+        - model_name: V6_DCI_SUBNET_TARGET_MASK
+          tf_name: v6_dci_subnet_target_mask
+          description: Target IPv6 Mask for Subnet Range (Min:120, Max:127)
+          type: Int64
+          handle_empty: true
+          optional: true
+          computed: true
+
+        - model_name: VXLAN_UNDERLAY_IS_V6
+          tf_name: vxlan_underlay_is_v6
+          description: If not enabled, IPv4 underlay is used in child VXLAN
+              fabric
+          type: Bool
+          optional: true
+          computed: true
 
         - model_name: default_network
           tf_name: default_network
           description: Default Overlay Network Template For Leafs
           type: String
-          validator: 'OneOf("Default_Network_Universal", "Service_Network_Universal")'
+          validator: 'OneOf("Default_Network_Universal",
+              "Service_Network_Universal")'
           example: Default_Network_Universal
+          optional: true
+          computed: true
 
         - model_name: default_pvlan_sec_network
           tf_name: default_pvlan_sec_network
           description: Default PVLAN Secondary Network Template
           type: String
+          optional: true
+          computed: true
 
         - model_name: default_vrf
           tf_name: default_vrf
           description: Default Overlay VRF Template For Leafs
           type: String
           example: Default_VRF_Universal
+          optional: true
+          computed: true
 
         - model_name: enableScheduledBackup
           tf_name: enable_scheduled_backup
           description: >-
-            Backup at the specified time. Note: Fabric Backup/Restore functionality
-            is being deprecated for MSD fabrics. Recommendation is to use NDFC
-            Backup & Restore
+            Backup at the specified time. Note: Fabric Backup/Restore
+            functionality is being deprecated for MSD fabrics.
+            Recommendation is to use NDFC Backup & Restore
           type: Bool
+          optional: true
+          computed: true
 
         - model_name: network_extension_template
           tf_name: network_extension_template
           description: Default Overlay Network Template For Borders
           type: String
           example: Default_Network_Extension_Universal
+          optional: true
+          computed: true
 
         - model_name: scheduledTime
           tf_name: scheduled_time
-          description: 'Time (UTC) in 24hr format. (00:00 to 23:59)'
+          description: Time (UTC) in 24hr format. (00:00 to 23:59)
           type: String
+          optional: true
+          computed: true
 
         - model_name: vrf_extension_template
           tf_name: vrf_extension_template
           description: Default Overlay VRF Template For Borders
           type: String
           example: Default_VRF_Extension_Universal
+          optional: true
+          computed: true
 
         - model_name: deploy
           tf_name: deploy
@@ -254,8 +535,8 @@ resource:
         - model_name: deployment_status
           tf_name: deployment_status
           description: >-
-            This fields shows the actual status of the deployment. It can be one of
-            the following: Deployment pending Deployment successful
+            This fields shows the actual status of the deployment. It can be
+            one of the following: Deployment pending Deployment successful
           type: String
           computed: true
           payload_hide: true

--- a/internal/provider/datasources/datasource_fabric/datasource_codec_gen.go
+++ b/internal/provider/datasources/datasource_fabric/datasource_codec_gen.go
@@ -54,7 +54,7 @@ type NDFCFabricModel struct {
 	CdpEnable                               string       `json:"CDP_ENABLE,omitempty"`
 	CoppPolicy                              string       `json:"COPP_POLICY,omitempty"`
 	DciSubnetRange                          string       `json:"DCI_SUBNET_RANGE,omitempty"`
-	DciSubnetTargetMask                     *Int64Custom `json:"DCI_SUBNET_TARGET_MASK,omitempty"`
+	DciSubnetTargetMask                     *int64       `json:"DCI_SUBNET_TARGET_MASK,omitempty"`
 	DefaultQueuingPolicyCloudscale          string       `json:"DEAFULT_QUEUING_POLICY_CLOUDSCALE,omitempty"`
 	DefaultQueuingPolicyOther               string       `json:"DEAFULT_QUEUING_POLICY_OTHER,omitempty"`
 	DefaultQueuingPolicyRSeries             string       `json:"DEAFULT_QUEUING_POLICY_R_SERIES,omitempty"`
@@ -335,6 +335,33 @@ type NDFCFabricModel struct {
 	BootstrapEnablePrev                     string       `json:"BOOTSTRAP_ENABLE_PREV,omitempty"`
 	EnableNetflowPrev                       string       `json:"ENABLE_NETFLOW_PREV,omitempty"`
 	AllowNxcPrev                            string       `json:"ALLOW_NXC_PREV,omitempty"`
+	EnableNbmPassivePrev                    string       `json:"ENABLE_NBM_PASSIVE_PREV,omitempty"`
+	FabricTechnology                        string       `json:"FABRIC_TECHNOLOGY,omitempty"`
+	InterfaceEthernetDefaultPolicy          string       `json:"INTERFACE_ETHERNET_DEFAULT_POLICY,omitempty"`
+	InterfaceLoopbackDefaultPolicy          string       `json:"INTERFACE_LOOPBACK_DEFAULT_POLICY,omitempty"`
+	InterfacePortChannelDefaultPolicy       string       `json:"INTERFACE_PORT_CHANNEL_DEFAULT_POLICY,omitempty"`
+	InterfaceVlanDefaultPolicy              string       `json:"INTERFACE_VLAN_DEFAULT_POLICY,omitempty"`
+	RpIpRangeInternal                       string       `json:"RP_IP_RANGE_INTERNAL,omitempty"`
+	InbandEnablePrev                        string       `json:"INBAND_ENABLE_PREV,omitempty"`
+	EnableAsm                               string       `json:"ENABLE_ASM,omitempty"`
+	DomainNameInternal                      string       `json:"DOMAIN_NAME_INTERNAL,omitempty"`
+	PnpEnableInternal                       string       `json:"PNP_ENABLE_INTERNAL,omitempty"`
+	BgwRoutingTag                           *Int64Custom `json:"BGW_ROUTING_TAG,omitempty"`
+	DcnmId                                  string       `json:"DCNM_ID,omitempty"`
+	EnableTrmTrmv6                          string       `json:"ENABLE_TRM_TRMv6,omitempty"`
+	EnableTrmTrmv6Prev                      string       `json:"ENABLE_TRM_TRMv6_PREV,omitempty"`
+	Loopback100Ipv6Range                    string       `json:"LOOPBACK100_IPV6_RANGE,omitempty"`
+	BgwRoutingTagPrev                       string       `json:"BGW_ROUTING_TAG_PREV,omitempty"`
+	MsIfcBgpAuthKeyType                     *Int64Custom `json:"MS_IFC_BGP_AUTH_KEY_TYPE,omitempty"`
+	MsIfcBgpAuthKeyTypePrev                 *Int64Custom `json:"MS_IFC_BGP_AUTH_KEY_TYPE_PREV,omitempty"`
+	MsIfcBgpPasswordEnablePrev              string       `json:"MS_IFC_BGP_PASSWORD_ENABLE_PREV,omitempty"`
+	MsIfcBgpPasswordPrev                    string       `json:"MS_IFC_BGP_PASSWORD_PREV,omitempty"`
+	ParentOnemanageFabric                   string       `json:"PARENT_ONEMANAGE_FABRIC,omitempty"`
+	SgtIdRangePrev                          string       `json:"SGT_ID_RANGE_PREV,omitempty"`
+	SgtNamePrefixPrev                       string       `json:"SGT_NAME_PREFIX_PREV,omitempty"`
+	V6DciSubnetRange                        string       `json:"V6_DCI_SUBNET_RANGE,omitempty"`
+	V6DciSubnetTargetMask                   *Int64Custom `json:"V6_DCI_SUBNET_TARGET_MASK,omitempty"`
+	VxlanUnderlayIsV6                       string       `json:"VXLAN_UNDERLAY_IS_V6,omitempty"`
 }
 
 func (v *FabricModel) SetModelData(jsonData *NDFCFabricModel) diag.Diagnostics {
@@ -586,11 +613,8 @@ func (v *FabricModel) SetModelData(jsonData *NDFCFabricModel) diag.Diagnostics {
 	}
 
 	if jsonData.DciSubnetTargetMask != nil {
-		if jsonData.DciSubnetTargetMask.IsEmpty() {
-			v.DciSubnetTargetMask = types.Int64Null()
-		} else {
-			v.DciSubnetTargetMask = types.Int64Value(int64(*jsonData.DciSubnetTargetMask))
-		}
+		v.DciSubnetTargetMask = types.Int64Value(*jsonData.DciSubnetTargetMask)
+
 	} else {
 		v.DciSubnetTargetMask = types.Int64Null()
 	}
@@ -2527,6 +2551,192 @@ func (v *FabricModel) SetModelData(jsonData *NDFCFabricModel) diag.Diagnostics {
 		v.AllowNxcPrev = types.BoolValue(x)
 	} else {
 		v.AllowNxcPrev = types.BoolNull()
+	}
+
+	if jsonData.EnableNbmPassivePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableNbmPassivePrev)
+		v.EnableNbmPassivePrev = types.BoolValue(x)
+	} else {
+		v.EnableNbmPassivePrev = types.BoolNull()
+	}
+
+	if jsonData.FabricTechnology != "" {
+		v.FabricTechnology = types.StringValue(jsonData.FabricTechnology)
+	} else {
+		v.FabricTechnology = types.StringNull()
+	}
+
+	if jsonData.InterfaceEthernetDefaultPolicy != "" {
+		v.InterfaceEthernetDefaultPolicy = types.StringValue(jsonData.InterfaceEthernetDefaultPolicy)
+	} else {
+		v.InterfaceEthernetDefaultPolicy = types.StringNull()
+	}
+
+	if jsonData.InterfaceLoopbackDefaultPolicy != "" {
+		v.InterfaceLoopbackDefaultPolicy = types.StringValue(jsonData.InterfaceLoopbackDefaultPolicy)
+	} else {
+		v.InterfaceLoopbackDefaultPolicy = types.StringNull()
+	}
+
+	if jsonData.InterfacePortChannelDefaultPolicy != "" {
+		v.InterfacePortChannelDefaultPolicy = types.StringValue(jsonData.InterfacePortChannelDefaultPolicy)
+	} else {
+		v.InterfacePortChannelDefaultPolicy = types.StringNull()
+	}
+
+	if jsonData.InterfaceVlanDefaultPolicy != "" {
+		v.InterfaceVlanDefaultPolicy = types.StringValue(jsonData.InterfaceVlanDefaultPolicy)
+	} else {
+		v.InterfaceVlanDefaultPolicy = types.StringNull()
+	}
+
+	if jsonData.RpIpRangeInternal != "" {
+		v.RpIpRangeInternal = types.StringValue(jsonData.RpIpRangeInternal)
+	} else {
+		v.RpIpRangeInternal = types.StringNull()
+	}
+
+	if jsonData.InbandEnablePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.InbandEnablePrev)
+		v.InbandEnablePrev = types.BoolValue(x)
+	} else {
+		v.InbandEnablePrev = types.BoolNull()
+	}
+
+	if jsonData.EnableAsm != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableAsm)
+		v.EnableAsm = types.BoolValue(x)
+	} else {
+		v.EnableAsm = types.BoolNull()
+	}
+
+	if jsonData.DomainNameInternal != "" {
+		v.DomainNameInternal = types.StringValue(jsonData.DomainNameInternal)
+	} else {
+		v.DomainNameInternal = types.StringNull()
+	}
+
+	if jsonData.PnpEnableInternal != "" {
+		x, _ := strconv.ParseBool(jsonData.PnpEnableInternal)
+		v.PnpEnableInternal = types.BoolValue(x)
+	} else {
+		v.PnpEnableInternal = types.BoolNull()
+	}
+
+	if jsonData.BgwRoutingTag != nil {
+		if jsonData.BgwRoutingTag.IsEmpty() {
+			v.BgwRoutingTag = types.Int64Null()
+		} else {
+			v.BgwRoutingTag = types.Int64Value(int64(*jsonData.BgwRoutingTag))
+		}
+	} else {
+		v.BgwRoutingTag = types.Int64Null()
+	}
+
+	if jsonData.DcnmId != "" {
+		v.DcnmId = types.StringValue(jsonData.DcnmId)
+	} else {
+		v.DcnmId = types.StringNull()
+	}
+
+	if jsonData.EnableTrmTrmv6 != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableTrmTrmv6)
+		v.EnableTrmTrmv6 = types.BoolValue(x)
+	} else {
+		v.EnableTrmTrmv6 = types.BoolNull()
+	}
+
+	if jsonData.EnableTrmTrmv6Prev != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableTrmTrmv6Prev)
+		v.EnableTrmTrmv6Prev = types.BoolValue(x)
+	} else {
+		v.EnableTrmTrmv6Prev = types.BoolNull()
+	}
+
+	if jsonData.Loopback100Ipv6Range != "" {
+		v.Loopback100Ipv6Range = types.StringValue(jsonData.Loopback100Ipv6Range)
+	} else {
+		v.Loopback100Ipv6Range = types.StringNull()
+	}
+
+	if jsonData.BgwRoutingTagPrev != "" {
+		v.BgwRoutingTagPrev = types.StringValue(jsonData.BgwRoutingTagPrev)
+	} else {
+		v.BgwRoutingTagPrev = types.StringNull()
+	}
+
+	if jsonData.MsIfcBgpAuthKeyType != nil {
+		if jsonData.MsIfcBgpAuthKeyType.IsEmpty() {
+			v.MsIfcBgpAuthKeyType = types.Int64Null()
+		} else {
+			v.MsIfcBgpAuthKeyType = types.Int64Value(int64(*jsonData.MsIfcBgpAuthKeyType))
+		}
+	} else {
+		v.MsIfcBgpAuthKeyType = types.Int64Null()
+	}
+
+	if jsonData.MsIfcBgpAuthKeyTypePrev != nil {
+		if jsonData.MsIfcBgpAuthKeyTypePrev.IsEmpty() {
+			v.MsIfcBgpAuthKeyTypePrev = types.Int64Null()
+		} else {
+			v.MsIfcBgpAuthKeyTypePrev = types.Int64Value(int64(*jsonData.MsIfcBgpAuthKeyTypePrev))
+		}
+	} else {
+		v.MsIfcBgpAuthKeyTypePrev = types.Int64Null()
+	}
+
+	if jsonData.MsIfcBgpPasswordEnablePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.MsIfcBgpPasswordEnablePrev)
+		v.MsIfcBgpPasswordEnablePrev = types.BoolValue(x)
+	} else {
+		v.MsIfcBgpPasswordEnablePrev = types.BoolNull()
+	}
+
+	if jsonData.MsIfcBgpPasswordPrev != "" {
+		v.MsIfcBgpPasswordPrev = types.StringValue(jsonData.MsIfcBgpPasswordPrev)
+	} else {
+		v.MsIfcBgpPasswordPrev = types.StringNull()
+	}
+
+	if jsonData.ParentOnemanageFabric != "" {
+		v.ParentOnemanageFabric = types.StringValue(jsonData.ParentOnemanageFabric)
+	} else {
+		v.ParentOnemanageFabric = types.StringNull()
+	}
+
+	if jsonData.SgtIdRangePrev != "" {
+		v.SgtIdRangePrev = types.StringValue(jsonData.SgtIdRangePrev)
+	} else {
+		v.SgtIdRangePrev = types.StringNull()
+	}
+
+	if jsonData.SgtNamePrefixPrev != "" {
+		v.SgtNamePrefixPrev = types.StringValue(jsonData.SgtNamePrefixPrev)
+	} else {
+		v.SgtNamePrefixPrev = types.StringNull()
+	}
+
+	if jsonData.V6DciSubnetRange != "" {
+		v.V6DciSubnetRange = types.StringValue(jsonData.V6DciSubnetRange)
+	} else {
+		v.V6DciSubnetRange = types.StringNull()
+	}
+
+	if jsonData.V6DciSubnetTargetMask != nil {
+		if jsonData.V6DciSubnetTargetMask.IsEmpty() {
+			v.V6DciSubnetTargetMask = types.Int64Null()
+		} else {
+			v.V6DciSubnetTargetMask = types.Int64Value(int64(*jsonData.V6DciSubnetTargetMask))
+		}
+	} else {
+		v.V6DciSubnetTargetMask = types.Int64Null()
+	}
+
+	if jsonData.VxlanUnderlayIsV6 != "" {
+		x, _ := strconv.ParseBool(jsonData.VxlanUnderlayIsV6)
+		v.VxlanUnderlayIsV6 = types.BoolValue(x)
+	} else {
+		v.VxlanUnderlayIsV6 = types.BoolNull()
 	}
 
 	return err

--- a/internal/provider/datasources/datasource_fabric/fabric_data_source_gen.go
+++ b/internal/provider/datasources/datasource_fabric/fabric_data_source_gen.go
@@ -314,6 +314,16 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
 			},
+			"bgw_routing_tag": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Routing tag associated with IP address of loopback and DCI interfaces",
+				MarkdownDescription: "Routing tag associated with IP address of loopback and DCI interfaces",
+			},
+			"bgw_routing_tag_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of Border Gateway Routing Tag",
+				MarkdownDescription: "Previous state of Border Gateway Routing Tag",
+			},
 			"bootstrap_conf": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Additional CLIs required during device bootup/login e.g. AAA/Radius",
@@ -398,6 +408,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
+			},
+			"dcnm_id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "DCNM ID",
+				MarkdownDescription: "DCNM ID",
 			},
 			"default_network": schema.StringAttribute{
 				Computed:            true,
@@ -489,6 +504,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "One VRF for all DNS servers or a comma separated list of VRFs, one per DNS server",
 				MarkdownDescription: "One VRF for all DNS servers or a comma separated list of VRFs, one per DNS server",
 			},
+			"domain_name_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal Domain Name",
+				MarkdownDescription: "Internal Domain Name",
+			},
 			"enable_aaa": schema.BoolAttribute{
 				Computed:            true,
 				Description:         "Include AAA configs from Manageability tab during device bootup",
@@ -513,6 +533,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Previous state of Enable AI/ML QoS Policy Flap",
 				MarkdownDescription: "Previous state of Enable AI/ML QoS Policy Flap",
+			},
+			"enable_asm": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Enable groups with receivers sending (*,G) joins",
+				MarkdownDescription: "Enable groups with receivers sending (*,G) joins",
 			},
 			"enable_dci_macsec": schema.BoolAttribute{
 				Computed:            true,
@@ -558,6 +583,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Previous state of Enable MACsec",
 				MarkdownDescription: "Previous state of Enable MACsec",
+			},
+			"enable_nbm_passive_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable NBM Passive Mode",
+				MarkdownDescription: "Previous state of Enable NBM Passive Mode",
 			},
 			"enable_netflow": schema.BoolAttribute{
 				Computed:            true,
@@ -639,6 +669,16 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "For Overlay Multicast Support In VXLAN Fabrics",
 				MarkdownDescription: "For Overlay Multicast Support In VXLAN Fabrics",
 			},
+			"enable_trm_trmv6": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites",
+				MarkdownDescription: "Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites",
+			},
+			"enable_trm_trmv6_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites",
+				MarkdownDescription: "Previous state of Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites",
+			},
 			"enable_trmv6": schema.BoolAttribute{
 				Computed:            true,
 				Description:         "For Overlay IPv6 Multicast Support In VXLAN Fabrics",
@@ -706,6 +746,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Required:            true,
 				Description:         "Fabric name",
 				MarkdownDescription: "Fabric name",
+			},
+			"fabric_technology": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Fabric Technology",
+				MarkdownDescription: "Fabric Technology",
 			},
 			"fabric_type": schema.StringAttribute{
 				Computed:            true,
@@ -782,6 +827,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Comma separated list of IPv4 Addresses (Max 3)",
 				MarkdownDescription: "Comma separated list of IPv4 Addresses (Max 3)",
 			},
+			"inband_enable_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable POAP over Inband Interface",
+				MarkdownDescription: "Previous state of Enable POAP over Inband Interface",
+			},
 			"inband_mgmt": schema.BoolAttribute{
 				Computed:            true,
 				Description:         "Manage switches with only Inband connectivity",
@@ -791,6 +841,26 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Previous state of Inband Management",
 				MarkdownDescription: "Previous state of Inband Management",
+			},
+			"interface_ethernet_default_policy": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Default policy for Ethernet interface of spine/leaf/tier2-leaf switches",
+				MarkdownDescription: "Default policy for Ethernet interface of spine/leaf/tier2-leaf switches",
+			},
+			"interface_loopback_default_policy": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Loopback Interface Default Policy",
+				MarkdownDescription: "Loopback Interface Default Policy",
+			},
+			"interface_port_channel_default_policy": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Port Channel Interface Default Policy",
+				MarkdownDescription: "Port Channel Interface Default Policy",
+			},
+			"interface_vlan_default_policy": schema.StringAttribute{
+				Computed:            true,
+				Description:         "VLAN Interface Default Policy",
+				MarkdownDescription: "VLAN Interface Default Policy",
 			},
 			"ipv6_anycast_rp_ip_range": schema.StringAttribute{
 				Computed:            true,
@@ -922,6 +992,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Typically Loopback0 IPv6 Address Range",
 				MarkdownDescription: "Typically Loopback0 IPv6 Address Range",
 			},
+			"loopback100_ipv6_range": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Multi-Site VTEP VIP Loopback IPv6 Range",
+				MarkdownDescription: "Multi-Site VTEP VIP Loopback IPv6 Range",
+			},
 			"loopback1_ip_range": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Typically Loopback1 IP Address Range",
@@ -1016,6 +1091,26 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Used for VXLAN to MPLS SR/LDP Handoff",
 				MarkdownDescription: "Used for VXLAN to MPLS SR/LDP Handoff",
+			},
+			"ms_ifc_bgp_auth_key_type": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "BGP Key Encryption Type: 3 - 3DES, 7 - Cisco",
+				MarkdownDescription: "BGP Key Encryption Type: 3 - 3DES, 7 - Cisco",
+			},
+			"ms_ifc_bgp_auth_key_type_prev": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "BGP Key Encryption Type: 3 - 3DES, 7 - Cisco",
+				MarkdownDescription: "BGP Key Encryption Type: 3 - 3DES, 7 - Cisco",
+			},
+			"ms_ifc_bgp_password_enable_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable Multi-Site eBGP Password",
+				MarkdownDescription: "Previous state of Enable Multi-Site eBGP Password",
+			},
+			"ms_ifc_bgp_password_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of eBGP Password",
+				MarkdownDescription: "Previous state of eBGP Password",
 			},
 			"mso_connectivity_deployed": schema.StringAttribute{
 				Computed:            true,
@@ -1162,6 +1257,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "If enabled, Fabric NxCloud Settings will be used",
 				MarkdownDescription: "If enabled, Fabric NxCloud Settings will be used",
 			},
+			"parent_onemanage_fabric": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Parent OneManage Fabric",
+				MarkdownDescription: "Parent OneManage Fabric",
+			},
 			"per_vrf_loopback_auto_provision": schema.BoolAttribute{
 				Computed:            true,
 				Description:         "Auto provision a loopback on a VTEP on VRF attachment",
@@ -1242,6 +1342,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Previous state of Performance Monitoring Enable",
 				MarkdownDescription: "Previous state of Performance Monitoring Enable",
 			},
+			"pnp_enable_internal": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Internal PnP Enable",
+				MarkdownDescription: "Internal PnP Enable",
+			},
 			"power_redundancy_mode": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Default Power Supply Mode For The Fabric",
@@ -1297,6 +1402,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Number of spines acting as Rendezvous-Point (RP)",
 				MarkdownDescription: "Number of spines acting as Rendezvous-Point (RP)",
 			},
+			"rp_ip_range_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal RP IP Range",
+				MarkdownDescription: "Internal RP IP Range",
+			},
 			"rp_lb_id": schema.Int64Attribute{
 				Computed:            true,
 				Description:         "No description available",
@@ -1332,10 +1442,20 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Security Group Tag (SGT) ID Range - Min:16, Max:65535. Reserved Range: 0-15",
 				MarkdownDescription: "Security Group Tag (SGT) ID Range - Min:16, Max:65535. Reserved Range: 0-15",
 			},
+			"sgt_id_range_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of Security Group Tag (SGT) ID Range",
+				MarkdownDescription: "Previous state of Security Group Tag (SGT) ID Range",
+			},
 			"sgt_name_prefix": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Security Group Name Prefix - Prefix to be used when a new Security Group is created (Min:1, Max:10 characters)",
 				MarkdownDescription: "Security Group Name Prefix - Prefix to be used when a new Security Group is created (Min:1, Max:10 characters)",
+			},
+			"sgt_name_prefix_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of Security Group Name Prefix",
+				MarkdownDescription: "Previous state of Security Group Name Prefix",
 			},
 			"sgt_oper_status": schema.StringAttribute{
 				Computed:            true,
@@ -1532,6 +1652,16 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "If not enabled, Spine-Leaf interfaces will use global IPv6 addresses",
 				MarkdownDescription: "If not enabled, Spine-Leaf interfaces will use global IPv6 addresses",
 			},
+			"v6_dci_subnet_range": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Address range to assign P2P DCI Links",
+				MarkdownDescription: "Address range to assign P2P DCI Links",
+			},
+			"v6_dci_subnet_target_mask": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Target IPv6 Mask for Subnet Range (Min:120, Max:127)",
+				MarkdownDescription: "Target IPv6 Mask for Subnet Range (Min:120, Max:127)",
+			},
 			"v6_subnet_range": schema.StringAttribute{
 				Computed:            true,
 				Description:         "IPv6 Address range to assign Numbered and Peer Link SVI IPs",
@@ -1596,6 +1726,11 @@ func FabricDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Per Switch Overlay VRF VLAN Range",
 				MarkdownDescription: "Per Switch Overlay VRF VLAN Range",
+			},
+			"vxlan_underlay_is_v6": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "If not enabled, IPv4 underlay is used in child VXLAN fabric",
+				MarkdownDescription: "If not enabled, IPv4 underlay is used in child VXLAN fabric",
 			},
 		},
 		Description:         "Basic data source attribute for all fabric types",
@@ -1664,6 +1799,8 @@ type FabricModel struct {
 	BgpAuthKey                              types.String `tfsdk:"bgp_auth_key"`
 	BgpAuthKeyType                          types.Int64  `tfsdk:"bgp_auth_key_type"`
 	BgpLbId                                 types.Int64  `tfsdk:"bgp_lb_id"`
+	BgwRoutingTag                           types.Int64  `tfsdk:"bgw_routing_tag"`
+	BgwRoutingTagPrev                       types.String `tfsdk:"bgw_routing_tag_prev"`
 	BootstrapConf                           types.String `tfsdk:"bootstrap_conf"`
 	BootstrapEnable                         types.Bool   `tfsdk:"bootstrap_enable"`
 	BootstrapEnablePrev                     types.Bool   `tfsdk:"bootstrap_enable_prev"`
@@ -1681,6 +1818,7 @@ type FabricModel struct {
 	DciMacsecKeyString                      types.String `tfsdk:"dci_macsec_key_string"`
 	DciSubnetRange                          types.String `tfsdk:"dci_subnet_range"`
 	DciSubnetTargetMask                     types.Int64  `tfsdk:"dci_subnet_target_mask"`
+	DcnmId                                  types.String `tfsdk:"dcnm_id"`
 	DefaultNetwork                          types.String `tfsdk:"default_network"`
 	DefaultPvlanSecNetwork                  types.String `tfsdk:"default_pvlan_sec_network"`
 	DefaultQueuingPolicyCloudscale          types.String `tfsdk:"default_queuing_policy_cloudscale"`
@@ -1699,11 +1837,13 @@ type FabricModel struct {
 	DhcpStartInternal                       types.String `tfsdk:"dhcp_start_internal"`
 	DnsServerIpList                         types.String `tfsdk:"dns_server_ip_list"`
 	DnsServerVrf                            types.String `tfsdk:"dns_server_vrf"`
+	DomainNameInternal                      types.String `tfsdk:"domain_name_internal"`
 	EnableAaa                               types.Bool   `tfsdk:"enable_aaa"`
 	EnableAgent                             types.Bool   `tfsdk:"enable_agent"`
 	EnableAggAccIdRange                     types.Bool   `tfsdk:"enable_agg_acc_id_range"`
 	EnableAiMlQosPolicy                     types.Bool   `tfsdk:"enable_ai_ml_qos_policy"`
 	EnableAiMlQosPolicyFlap                 types.Bool   `tfsdk:"enable_ai_ml_qos_policy_flap"`
+	EnableAsm                               types.Bool   `tfsdk:"enable_asm"`
 	EnableDciMacsec                         types.Bool   `tfsdk:"enable_dci_macsec"`
 	EnableDciMacsecPrev                     types.Bool   `tfsdk:"enable_dci_macsec_prev"`
 	EnableDefaultQueuingPolicy              types.Bool   `tfsdk:"enable_default_queuing_policy"`
@@ -1713,6 +1853,7 @@ type FabricModel struct {
 	EnableL3vniNoVlan                       types.Bool   `tfsdk:"enable_l3vni_no_vlan"`
 	EnableMacsec                            types.Bool   `tfsdk:"enable_macsec"`
 	EnableMacsecPrev                        types.Bool   `tfsdk:"enable_macsec_prev"`
+	EnableNbmPassivePrev                    types.Bool   `tfsdk:"enable_nbm_passive_prev"`
 	EnableNetflow                           types.Bool   `tfsdk:"enable_netflow"`
 	EnableNetflowPrev                       types.Bool   `tfsdk:"enable_netflow_prev"`
 	EnableNgoam                             types.Bool   `tfsdk:"enable_ngoam"`
@@ -1729,6 +1870,8 @@ type FabricModel struct {
 	EnableSgtPrev                           types.Bool   `tfsdk:"enable_sgt_prev"`
 	EnableTenantDhcp                        types.Bool   `tfsdk:"enable_tenant_dhcp"`
 	EnableTrm                               types.Bool   `tfsdk:"enable_trm"`
+	EnableTrmTrmv6                          types.Bool   `tfsdk:"enable_trm_trmv6"`
+	EnableTrmTrmv6Prev                      types.Bool   `tfsdk:"enable_trm_trmv6_prev"`
 	EnableTrmv6                             types.Bool   `tfsdk:"enable_trmv6"`
 	EnableVpcPeerLinkNativeVlan             types.Bool   `tfsdk:"enable_vpc_peer_link_native_vlan"`
 	EnableVriIdRealloc                      types.Bool   `tfsdk:"enable_vri_id_realloc"`
@@ -1742,6 +1885,7 @@ type FabricModel struct {
 	FabricMtu                               types.Int64  `tfsdk:"fabric_mtu"`
 	FabricMtuPrev                           types.Int64  `tfsdk:"fabric_mtu_prev"`
 	FabricName                              types.String `tfsdk:"fabric_name"`
+	FabricTechnology                        types.String `tfsdk:"fabric_technology"`
 	FabricType                              types.String `tfsdk:"fabric_type"`
 	FabricVpcDomainId                       types.Int64  `tfsdk:"fabric_vpc_domain_id"`
 	FabricVpcDomainIdPrev                   types.Int64  `tfsdk:"fabric_vpc_domain_id_prev"`
@@ -1757,8 +1901,13 @@ type FabricModel struct {
 	IbgpPeerTemplateLeaf                    types.String `tfsdk:"ibgp_peer_template_leaf"`
 	IgnoreCert                              types.Bool   `tfsdk:"ignore_cert"`
 	InbandDhcpServers                       types.String `tfsdk:"inband_dhcp_servers"`
+	InbandEnablePrev                        types.Bool   `tfsdk:"inband_enable_prev"`
 	InbandMgmt                              types.Bool   `tfsdk:"inband_mgmt"`
 	InbandMgmtPrev                          types.Bool   `tfsdk:"inband_mgmt_prev"`
+	InterfaceEthernetDefaultPolicy          types.String `tfsdk:"interface_ethernet_default_policy"`
+	InterfaceLoopbackDefaultPolicy          types.String `tfsdk:"interface_loopback_default_policy"`
+	InterfacePortChannelDefaultPolicy       types.String `tfsdk:"interface_port_channel_default_policy"`
+	InterfaceVlanDefaultPolicy              types.String `tfsdk:"interface_vlan_default_policy"`
 	Ipv6AnycastRpIpRange                    types.String `tfsdk:"ipv6_anycast_rp_ip_range"`
 	Ipv6AnycastRpIpRangeInternal            types.String `tfsdk:"ipv6_anycast_rp_ip_range_internal"`
 	Ipv6MulticastGroupSubnet                types.String `tfsdk:"ipv6_multicast_group_subnet"`
@@ -1785,6 +1934,7 @@ type FabricModel struct {
 	LinkStateRoutingTagPrev                 types.String `tfsdk:"link_state_routing_tag_prev"`
 	Loopback0IpRange                        types.String `tfsdk:"loopback0_ip_range"`
 	Loopback0Ipv6Range                      types.String `tfsdk:"loopback0_ipv6_range"`
+	Loopback100Ipv6Range                    types.String `tfsdk:"loopback100_ipv6_range"`
 	Loopback1IpRange                        types.String `tfsdk:"loopback1_ip_range"`
 	Loopback1Ipv6Range                      types.String `tfsdk:"loopback1_ipv6_range"`
 	MacsecAlgorithm                         types.String `tfsdk:"macsec_algorithm"`
@@ -1804,6 +1954,10 @@ type FabricModel struct {
 	MplsIsisAreaNumPrev                     types.String `tfsdk:"mpls_isis_area_num_prev"`
 	MplsLbId                                types.Int64  `tfsdk:"mpls_lb_id"`
 	MplsLoopbackIpRange                     types.String `tfsdk:"mpls_loopback_ip_range"`
+	MsIfcBgpAuthKeyType                     types.Int64  `tfsdk:"ms_ifc_bgp_auth_key_type"`
+	MsIfcBgpAuthKeyTypePrev                 types.Int64  `tfsdk:"ms_ifc_bgp_auth_key_type_prev"`
+	MsIfcBgpPasswordEnablePrev              types.Bool   `tfsdk:"ms_ifc_bgp_password_enable_prev"`
+	MsIfcBgpPasswordPrev                    types.String `tfsdk:"ms_ifc_bgp_password_prev"`
 	MsoConnectivityDeployed                 types.String `tfsdk:"mso_connectivity_deployed"`
 	MsoControlerId                          types.String `tfsdk:"mso_controler_id"`
 	MsoSiteGroupName                        types.String `tfsdk:"mso_site_group_name"`
@@ -1833,6 +1987,7 @@ type FabricModel struct {
 	OverlayMode                             types.String `tfsdk:"overlay_mode"`
 	OverlayModePrev                         types.String `tfsdk:"overlay_mode_prev"`
 	OverwriteGlobalNxc                      types.Bool   `tfsdk:"overwrite_global_nxc"`
+	ParentOnemanageFabric                   types.String `tfsdk:"parent_onemanage_fabric"`
 	PerVrfLoopbackAutoProvision             types.Bool   `tfsdk:"per_vrf_loopback_auto_provision"`
 	PerVrfLoopbackAutoProvisionPrev         types.Bool   `tfsdk:"per_vrf_loopback_auto_provision_prev"`
 	PerVrfLoopbackAutoProvisionV6           types.Bool   `tfsdk:"per_vrf_loopback_auto_provision_v6"`
@@ -1849,6 +2004,7 @@ type FabricModel struct {
 	PimHelloAuthKey                         types.String `tfsdk:"pim_hello_auth_key"`
 	PmEnable                                types.Bool   `tfsdk:"pm_enable"`
 	PmEnablePrev                            types.Bool   `tfsdk:"pm_enable_prev"`
+	PnpEnableInternal                       types.Bool   `tfsdk:"pnp_enable_internal"`
 	PowerRedundancyMode                     types.String `tfsdk:"power_redundancy_mode"`
 	PremsoParentFabric                      types.String `tfsdk:"premso_parent_fabric"`
 	PtpDomainId                             types.Int64  `tfsdk:"ptp_domain_id"`
@@ -1860,6 +2016,7 @@ type FabricModel struct {
 	RouteMapSequenceNumberRange             types.String `tfsdk:"route_map_sequence_number_range"`
 	RouterIdRange                           types.String `tfsdk:"router_id_range"`
 	RpCount                                 types.Int64  `tfsdk:"rp_count"`
+	RpIpRangeInternal                       types.String `tfsdk:"rp_ip_range_internal"`
 	RpLbId                                  types.Int64  `tfsdk:"rp_lb_id"`
 	RpMode                                  types.String `tfsdk:"rp_mode"`
 	RrCount                                 types.Int64  `tfsdk:"rr_count"`
@@ -1867,7 +2024,9 @@ type FabricModel struct {
 	SeedSwitchCoreInterfaces                types.String `tfsdk:"seed_switch_core_interfaces"`
 	ServiceNetworkVlanRange                 types.String `tfsdk:"service_network_vlan_range"`
 	SgtIdRange                              types.String `tfsdk:"sgt_id_range"`
+	SgtIdRangePrev                          types.String `tfsdk:"sgt_id_range_prev"`
 	SgtNamePrefix                           types.String `tfsdk:"sgt_name_prefix"`
+	SgtNamePrefixPrev                       types.String `tfsdk:"sgt_name_prefix_prev"`
 	SgtOperStatus                           types.String `tfsdk:"sgt_oper_status"`
 	SgtPreprovRecalcStatus                  types.String `tfsdk:"sgt_preprov_recalc_status"`
 	SgtPreprovision                         types.Bool   `tfsdk:"sgt_preprovision"`
@@ -1907,6 +2066,8 @@ type FabricModel struct {
 	UnnumDhcpStartInternal                  types.String `tfsdk:"unnum_dhcp_start_internal"`
 	UpgradeFromVersion                      types.String `tfsdk:"upgrade_from_version"`
 	UseLinkLocal                            types.Bool   `tfsdk:"use_link_local"`
+	V6DciSubnetRange                        types.String `tfsdk:"v6_dci_subnet_range"`
+	V6DciSubnetTargetMask                   types.Int64  `tfsdk:"v6_dci_subnet_target_mask"`
 	V6SubnetRange                           types.String `tfsdk:"v6_subnet_range"`
 	V6SubnetTargetMask                      types.Int64  `tfsdk:"v6_subnet_target_mask"`
 	VpcAutoRecoveryTime                     types.Int64  `tfsdk:"vpc_auto_recovery_time"`
@@ -1920,4 +2081,5 @@ type FabricModel struct {
 	VrfExtensionTemplate                    types.String `tfsdk:"vrf_extension_template"`
 	VrfLiteAutoconfig                       types.String `tfsdk:"vrf_lite_autoconfig"`
 	VrfVlanRange                            types.String `tfsdk:"vrf_vlan_range"`
+	VxlanUnderlayIsV6                       types.Bool   `tfsdk:"vxlan_underlay_is_v6"`
 }

--- a/internal/provider/resources/resource_fabric_common/resource_codec_gen.go
+++ b/internal/provider/resources/resource_fabric_common/resource_codec_gen.go
@@ -30,7 +30,6 @@ type NDFCFabricCommonModel struct {
 	DnsServerIpList                         string       `json:"DNS_SERVER_IP_LIST,omitempty"`
 	DnsServerVrf                            string       `json:"DNS_SERVER_VRF,omitempty"`
 	EnableAaa                               string       `json:"ENABLE_AAA,omitempty"`
-	EnableAsm                               string       `json:"ENABLE_ASM,omitempty"`
 	EsrOption                               string       `json:"ESR_OPTION,omitempty"`
 	EnableNbmPassive                        string       `json:"ENABLE_NBM_PASSIVE,omitempty"`
 	ExtraConfIntraLinks                     string       `json:"EXTRA_CONF_INTRA_LINKS,omitempty"`
@@ -217,7 +216,6 @@ type NDFCFabricCommonModel struct {
 	NetworkExtensionTemplate                string       `json:"network_extension_template,omitempty"`
 	VrfExtensionTemplate                    string       `json:"vrf_extension_template,omitempty"`
 	BgpRpAsn                                string       `json:"BGP_RP_ASN,omitempty"`
-	BgwRoutingTag                           *Int64Custom `json:"BGW_ROUTING_TAG,omitempty"`
 	BorderGwyConnections                    string       `json:"BORDER_GWY_CONNECTIONS,omitempty"`
 	CloudsecAlgorithm                       string       `json:"CLOUDSEC_ALGORITHM,omitempty"`
 	CloudsecAutoconfig                      string       `json:"CLOUDSEC_AUTOCONFIG,omitempty"`
@@ -369,4 +367,30 @@ type NDFCFabricCommonModel struct {
 	BootstrapEnablePrev                     string       `json:"BOOTSTRAP_ENABLE_PREV,omitempty"`
 	EnableNetflowPrev                       string       `json:"ENABLE_NETFLOW_PREV,omitempty"`
 	AllowNxcPrev                            string       `json:"ALLOW_NXC_PREV,omitempty"`
+	EnableNbmPassivePrev                    string       `json:"ENABLE_NBM_PASSIVE_PREV,omitempty"`
+	FabricTechnology                        string       `json:"FABRIC_TECHNOLOGY,omitempty"`
+	InterfaceEthernetDefaultPolicy          string       `json:"INTERFACE_ETHERNET_DEFAULT_POLICY,omitempty"`
+	InterfaceLoopbackDefaultPolicy          string       `json:"INTERFACE_LOOPBACK_DEFAULT_POLICY,omitempty"`
+	InterfacePortChannelDefaultPolicy       string       `json:"INTERFACE_PORT_CHANNEL_DEFAULT_POLICY,omitempty"`
+	InterfaceVlanDefaultPolicy              string       `json:"INTERFACE_VLAN_DEFAULT_POLICY,omitempty"`
+	RpIpRangeInternal                       string       `json:"RP_IP_RANGE_INTERNAL,omitempty"`
+	InbandEnablePrev                        string       `json:"INBAND_ENABLE_PREV,omitempty"`
+	EnableAsm                               string       `json:"ENABLE_ASM,omitempty"`
+	DomainNameInternal                      string       `json:"DOMAIN_NAME_INTERNAL,omitempty"`
+	PnpEnableInternal                       string       `json:"PNP_ENABLE_INTERNAL,omitempty"`
+	BgwRoutingTag                           *Int64Custom `json:"BGW_ROUTING_TAG,omitempty"`
+	DcnmId                                  string       `json:"DCNM_ID,omitempty"`
+	EnableTrmTrmv6                          string       `json:"ENABLE_TRM_TRMv6,omitempty"`
+	EnableTrmTrmv6Prev                      string       `json:"ENABLE_TRM_TRMv6_PREV,omitempty"`
+	Loopback100Ipv6Range                    string       `json:"LOOPBACK100_IPV6_RANGE,omitempty"`
+	BgwRoutingTagPrev                       string       `json:"BGW_ROUTING_TAG_PREV,omitempty"`
+	MsIfcBgpAuthKeyTypePrev                 *Int64Custom `json:"MS_IFC_BGP_AUTH_KEY_TYPE_PREV,omitempty"`
+	MsIfcBgpPasswordEnablePrev              string       `json:"MS_IFC_BGP_PASSWORD_ENABLE_PREV,omitempty"`
+	MsIfcBgpPasswordPrev                    string       `json:"MS_IFC_BGP_PASSWORD_PREV,omitempty"`
+	ParentOnemanageFabric                   string       `json:"PARENT_ONEMANAGE_FABRIC,omitempty"`
+	SgtIdRangePrev                          string       `json:"SGT_ID_RANGE_PREV,omitempty"`
+	SgtNamePrefixPrev                       string       `json:"SGT_NAME_PREFIX_PREV,omitempty"`
+	V6DciSubnetRange                        string       `json:"V6_DCI_SUBNET_RANGE,omitempty"`
+	V6DciSubnetTargetMask                   *Int64Custom `json:"V6_DCI_SUBNET_TARGET_MASK,omitempty"`
+	VxlanUnderlayIsV6                       string       `json:"VXLAN_UNDERLAY_IS_V6,omitempty"`
 }

--- a/internal/provider/resources/resource_fabric_ipfm/fabric_ipfm_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_ipfm/fabric_ipfm_resource_gen.go
@@ -19,36 +19,127 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"aaa_remote_ip_enabled": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "Enable only when IP Authorization is enabled in the AAA Server",
-				MarkdownDescription: "Enable only when IP Authorization is enabled in the AAA Server",
+				Computed:            true,
+				Description:         "Enable only, when IP Authorization is enabled in the AAA \\ Server",
+				MarkdownDescription: "Enable only, when IP Authorization is enabled in the AAA \\ Server",
 			},
 			"aaa_server_conf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "AAA Configurations",
 				MarkdownDescription: "AAA Configurations",
 			},
+			"abstract_dhcp": schema.StringAttribute{
+				Computed:            true,
+				Description:         "DHCP Configuration",
+				MarkdownDescription: "DHCP Configuration",
+			},
+			"abstract_extra_config_bootstrap": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Add Extra Configuration for Bootstrap",
+				MarkdownDescription: "Add Extra Configuration for Bootstrap",
+			},
+			"abstract_extra_config_leaf": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Add Extra Configuration for Leaf",
+				MarkdownDescription: "Add Extra Configuration for Leaf",
+			},
+			"abstract_extra_config_spine": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Add Extra Configuration for Spine",
+				MarkdownDescription: "Add Extra Configuration for Spine",
+			},
+			"abstract_isis": schema.StringAttribute{
+				Computed:            true,
+				Description:         "ISIS Network Configuration",
+				MarkdownDescription: "ISIS Network Configuration",
+			},
+			"abstract_isis_interface": schema.StringAttribute{
+				Computed:            true,
+				Description:         "ISIS Interface Configuration",
+				MarkdownDescription: "ISIS Interface Configuration",
+			},
+			"abstract_loopback_interface": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Primary Loopback Interface Configuration",
+				MarkdownDescription: "Primary Loopback Interface Configuration",
+			},
+			"abstract_ospf": schema.StringAttribute{
+				Computed:            true,
+				Description:         "OSPF Network Configuration",
+				MarkdownDescription: "OSPF Network Configuration",
+			},
+			"abstract_ospf_interface": schema.StringAttribute{
+				Computed:            true,
+				Description:         "OSPF Interface Configuration",
+				MarkdownDescription: "OSPF Interface Configuration",
+			},
+			"abstract_pim_interface": schema.StringAttribute{
+				Computed:            true,
+				Description:         "PIM Interface Configuration",
+				MarkdownDescription: "PIM Interface Configuration",
+			},
+			"abstract_routed_host": schema.StringAttribute{
+				Computed:            true,
+				Description:         "L3 Port Configuration",
+				MarkdownDescription: "L3 Port Configuration",
+			},
+			"active_migration": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Active Migration",
+				MarkdownDescription: "Active Migration",
+			},
+			"agent_intf": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Interface to connect to Agent",
+				MarkdownDescription: "Interface to connect to Agent",
+				Validators: []validator.String{
+					stringvalidator.OneOf("eth0", "eth1"),
+				},
+			},
 			"asm_group_ranges": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "ASM group ranges with prefixes (len:4-32) example: 239.1.1.0/25, max 20 ranges. Enabling SPT-Threshold Infinity to prevent switchover to source-tree.",
 				MarkdownDescription: "ASM group ranges with prefixes (len:4-32) example: 239.1.1.0/25, max 20 ranges. Enabling SPT-Threshold Infinity to prevent switchover to source-tree.",
 			},
 			"bootstrap_conf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional CLIs required during device bootup/login e.g. AAA/Radius",
 				MarkdownDescription: "Additional CLIs required during device bootup/login e.g. AAA/Radius",
 			},
 			"bootstrap_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP",
 				MarkdownDescription: "Automatic IP Assignment For POAP",
 			},
 			"bootstrap_multisubnet": schema.StringAttribute{
 				Optional:            true,
-				Description:         "lines with # prefix are ignored here",
-				MarkdownDescription: "lines with # prefix are ignored here",
+				Computed:            true,
+				Description:         "DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here",
+				MarkdownDescription: "DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here",
+			},
+			"bootstrap_multisubnet_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal Bootstrap Multi Subnet Scope",
+				MarkdownDescription: "Internal Bootstrap Multi Subnet Scope",
+			},
+			"brfield_debug_flag": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Only for brf debugging purpose !!!",
+				MarkdownDescription: "Only for brf debugging purpose !!!",
+				Validators: []validator.String{
+					stringvalidator.OneOf("Enable", "Disable"),
+				},
 			},
 			"cdp_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable CDP on management interface",
 				MarkdownDescription: "Enable CDP on management interface",
 			},
@@ -57,6 +148,12 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "This flag does configuration save and deploy",
 				MarkdownDescription: "This flag does configuration save and deploy",
 			},
+			"deployment_freeze": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Disable all deployments in this fabric",
+				MarkdownDescription: "Disable all deployments in this fabric",
+			},
 			"deployment_status": schema.StringAttribute{
 				Computed:            true,
 				Description:         "This fields shows the actual status of the deployment. It can be one of the following: Deployment pending Deployment successful",
@@ -64,69 +161,131 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"dhcp_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP From Local DHCP Server",
 				MarkdownDescription: "Automatic IP Assignment For POAP From Local DHCP Server",
 			},
 			"dhcp_end": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "End Address For Switch Out-of-Band POAP",
 				MarkdownDescription: "End Address For Switch Out-of-Band POAP",
 			},
+			"dhcp_end_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP End Address",
+				MarkdownDescription: "Internal DHCP End Address",
+			},
 			"dhcp_ipv6_enable": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
 				Validators: []validator.String{
 					stringvalidator.OneOf("DHCPv4"),
 				},
 			},
+			"dhcp_ipv6_enable_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP IPv6 Enable",
+				MarkdownDescription: "Internal DHCP IPv6 Enable",
+			},
 			"dhcp_start": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Start Address For Switch Out-of-Band POAP",
 				MarkdownDescription: "Start Address For Switch Out-of-Band POAP",
 			},
+			"dhcp_start_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP Start Address",
+				MarkdownDescription: "Internal DHCP Start Address",
+			},
 			"dns_server_ip_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Comma separated list of IP Addresses (v4/v6)",
 				MarkdownDescription: "Comma separated list of IP Addresses (v4/v6)",
 			},
 			"dns_server_vrf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One VRF for all DNS servers or a comma separated list of VRFs, one per DNS server",
 				MarkdownDescription: "One VRF for all DNS servers or a comma separated list of VRFs, one per DNS server",
 			},
 			"enable_aaa": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Include AAA configs from Manageability tab during device bootup",
 				MarkdownDescription: "Include AAA configs from Manageability tab during device bootup",
 			},
+			"enable_agent": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Enable Agent (development purpose only)",
+				MarkdownDescription: "Enable Agent (development purpose only)",
+			},
 			"enable_asm": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable groups with receivers sending (*,G) joins",
 				MarkdownDescription: "Enable groups with receivers sending (*,G) joins",
 			},
 			"enable_nbm_passive": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable NBM mode to pim-passive for default VRF",
 				MarkdownDescription: "Enable NBM mode to pim-passive for default VRF",
 			},
+			"enable_nbm_passive_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable NBM Passive Mode",
+				MarkdownDescription: "Previous state of Enable NBM Passive Mode",
+			},
+			"enable_nxapi": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Enable HTTPS NX-API",
+				MarkdownDescription: "Enable HTTPS NX-API",
+			},
+			"enable_nxapi_http": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Enable HTTP NX-API",
+				MarkdownDescription: "Enable HTTP NX-API",
+			},
+			"enable_rt_intf_stats": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Valid for NX-OS only",
+				MarkdownDescription: "Valid for NX-OS only",
+			},
+			"ext_fabric_type": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "External Fabric Type",
+				MarkdownDescription: "External Fabric Type",
+			},
 			"extra_conf_intra_links": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional CLIs For All Intra-Fabric Links",
 				MarkdownDescription: "Additional CLIs For All Intra-Fabric Links",
 			},
 			"extra_conf_leaf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional CLIs For All Leafs and Tier2 Leafs As Captured From Show Running Configuration",
 				MarkdownDescription: "Additional CLIs For All Leafs and Tier2 Leafs As Captured From Show Running Configuration",
 			},
 			"extra_conf_spine": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional CLIs For All Spines As Captured From Show Running Configuration",
 				MarkdownDescription: "Additional CLIs For All Spines As Captured From Show Running Configuration",
 			},
 			"fabric_interface_type": schema.StringAttribute{
-				Optional:            true,
+				Computed:            true,
 				Description:         "Only Numbered(Point-to-Point) is supported",
 				MarkdownDescription: "Only Numbered(Point-to-Point) is supported",
 				Validators: []validator.String{
@@ -135,49 +294,117 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"fabric_mtu": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Must be an even number",
 				MarkdownDescription: "Must be an even number",
 			},
+			"fabric_mtu_prev": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Previous state of Fabric MTU",
+				MarkdownDescription: "Previous state of Fabric MTU",
+			},
 			"fabric_name": schema.StringAttribute{
 				Required:            true,
-				Description:         "Fabric name to be created, updated or deleted (Max Size 64).",
-				MarkdownDescription: "Fabric name to be created, updated or deleted (Max Size 64).",
+				Description:         "Fabric name to be created, updated or deleted.",
+				MarkdownDescription: "Fabric name to be created, updated or deleted.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"fabric_technology": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Fabric Technology",
+				MarkdownDescription: "Fabric Technology",
+			},
+			"fabric_type": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Fabric Type",
+				MarkdownDescription: "Fabric Type",
+			},
 			"feature_ptp": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable Precision Time Protocol (PTP)",
+				MarkdownDescription: "Enable Precision Time Protocol (PTP)",
+			},
+			"feature_ptp_internal": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Internal Feature PTP",
+				MarkdownDescription: "Internal Feature PTP",
+			},
+			"ff": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Template Family",
+				MarkdownDescription: "Template Family",
+			},
+			"grfield_debug_flag": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Enable to clean switch configuration without reload when PreserveConfig=no",
+				MarkdownDescription: "Enable to clean switch configuration without reload when PreserveConfig=no",
+				Validators: []validator.String{
+					stringvalidator.OneOf("Enable", "Disable"),
+				},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
-				Description:         "Terraform unique Id for the fabric resource",
-				MarkdownDescription: "Terraform unique Id for the fabric resource",
+				Description:         "Terraform unique Id for the ipfm fabric resource",
+				MarkdownDescription: "Terraform unique Id for the ipfm fabric resource",
+			},
+			"interface_ethernet_default_policy": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Default policy for Ethernet interface of spine/leaf/ tier2-leaf switches",
+				MarkdownDescription: "Default policy for Ethernet interface of spine/leaf/ tier2-leaf switches",
+			},
+			"interface_loopback_default_policy": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Loopback Interface Default Policy",
+				MarkdownDescription: "Loopback Interface Default Policy",
+			},
+			"interface_port_channel_default_policy": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Port Channel Interface Default Policy",
+				MarkdownDescription: "Port Channel Interface Default Policy",
+			},
+			"interface_vlan_default_policy": schema.StringAttribute{
+				Computed:            true,
+				Description:         "VLAN Interface Default Policy",
+				MarkdownDescription: "VLAN Interface Default Policy",
+			},
+			"intf_stat_load_interval": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Time in seconds (Min:5, Max:300)",
+				MarkdownDescription: "Time in seconds (Min:5, Max:300)",
 			},
 			"isis_auth_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable IS-IS Authentication",
+				MarkdownDescription: "Enable IS-IS Authentication",
 			},
 			"isis_auth_key": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Cisco Type 7 Encrypted",
 				MarkdownDescription: "Cisco Type 7 Encrypted",
 			},
 			"isis_auth_keychain_key_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "IS-IS Authentication Key ID (Min:0, Max:65535)",
+				MarkdownDescription: "IS-IS Authentication Key ID (Min:0, Max:65535)",
 			},
 			"isis_auth_keychain_name": schema.StringAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "IS-IS Authentication Keychain Name",
+				MarkdownDescription: "IS-IS Authentication Keychain Name",
 			},
 			"isis_level": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Supported IS types: level-1, level-2",
 				MarkdownDescription: "Supported IS types: level-1, level-2",
 				Validators: []validator.String{
@@ -186,16 +413,24 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"isis_p2p_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "This will enable network point-to-point on fabric interfaces which are numbered",
 				MarkdownDescription: "This will enable network point-to-point on fabric interfaces which are numbered",
 			},
 			"l2_host_intf_mtu": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Must be an even number",
 				MarkdownDescription: "Must be an even number",
 			},
+			"l2_host_intf_mtu_prev": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Previous state of Layer 2 Host Interface MTU",
+				MarkdownDescription: "Previous state of Layer 2 Host Interface MTU",
+			},
 			"link_state_routing": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Used for Spine-Leaf Connectivity",
 				MarkdownDescription: "Used for Spine-Leaf Connectivity",
 				Validators: []validator.String{
@@ -204,36 +439,80 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"link_state_routing_tag": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Routing process tag for the fabric",
 				MarkdownDescription: "Routing process tag for the fabric",
 			},
+			"link_state_routing_tag_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of Link State Routing Tag",
+				MarkdownDescription: "Previous state of Link State Routing Tag",
+			},
 			"loopback0_ip_range": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Routing Loopback IP Address Range",
 				MarkdownDescription: "Routing Loopback IP Address Range",
 			},
 			"mgmt_gw": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Gateway For Management VRF On The Switch",
 				MarkdownDescription: "Default Gateway For Management VRF On The Switch",
 			},
+			"mgmt_gw_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal Management Gateway",
+				MarkdownDescription: "Internal Management Gateway",
+			},
 			"mgmt_prefix": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Switch Mgmt IP Subnet Prefix (Min:8, Max:30)",
+				MarkdownDescription: "Switch Mgmt IP Subnet Prefix (Min:8, Max:30)",
+			},
+			"mgmt_prefix_internal": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Internal Management Prefix",
+				MarkdownDescription: "Internal Management Prefix",
+			},
+			"mgmt_v6prefix": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)",
+				MarkdownDescription: "Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)",
+			},
+			"mgmt_v6prefix_internal": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Internal Management IPv6 Prefix",
+				MarkdownDescription: "Internal Management IPv6 Prefix",
 			},
 			"ntp_server_ip_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Comma separated list of IP Addresses (v4/v6)",
 				MarkdownDescription: "Comma separated list of IP Addresses (v4/v6)",
 			},
 			"ntp_server_vrf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One VRF for all NTP servers or a comma separated list of VRFs, one per NTP server",
 				MarkdownDescription: "One VRF for all NTP servers or a comma separated list of VRFs, one per NTP server",
 			},
+			"nxapi_http_port": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "NX-API HTTP Port Number",
+				MarkdownDescription: "NX-API HTTP Port Number",
+			},
+			"nxapi_https_port": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "NX-API HTTPS Port Number",
+				MarkdownDescription: "NX-API HTTPS Port Number",
+			},
 			"nxapi_vrf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "VRF used for NX-API communication",
 				MarkdownDescription: "VRF used for NX-API communication",
 				Validators: []validator.String{
@@ -242,41 +521,54 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"ospf_area_id": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "OSPF Area Id in IP address format",
 				MarkdownDescription: "OSPF Area Id in IP address format",
 			},
 			"ospf_auth_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable OSPF Authentication",
+				MarkdownDescription: "Enable OSPF Authentication",
 			},
 			"ospf_auth_key": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "3DES Encrypted",
 				MarkdownDescription: "3DES Encrypted",
 			},
 			"ospf_auth_key_id": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
 			},
 			"pim_hello_auth_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable PIM Hello Authentication",
+				MarkdownDescription: "Enable PIM Hello Authentication",
 			},
 			"pim_hello_auth_key": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "3DES Encrypted",
 				MarkdownDescription: "3DES Encrypted",
 			},
 			"pm_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable Performance Monitoring",
+				MarkdownDescription: "Enable Performance Monitoring",
+			},
+			"pm_enable_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable Performance Monitoring",
+				MarkdownDescription: "Previous state of Enable Performance Monitoring",
 			},
 			"power_redundancy_mode": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default power supply mode for the fabric",
 				MarkdownDescription: "Default power supply mode for the fabric",
 				Validators: []validator.String{
@@ -285,54 +577,83 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"ptp_domain_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "Multiple Independent PTP Clocking Subdomains on a Single Network",
-				MarkdownDescription: "Multiple Independent PTP Clocking Subdomains on a Single Network",
+				Computed:            true,
+				Description:         "Multiple Independent PTP Clocking Subdomains on a Single Network (Min:0, Max:127)",
+				MarkdownDescription: "Multiple Independent PTP Clocking Subdomains on a Single Network (Min:0, Max:127)",
 			},
 			"ptp_lb_id": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
 			},
 			"ptp_profile": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enabled on ISL links only",
 				MarkdownDescription: "Enabled on ISL links only",
 				Validators: []validator.String{
 					stringvalidator.OneOf("IEEE-1588v2", "SMPTE-2059-2", "AES67-2015"),
 				},
 			},
+			"replication_mode": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Replication Mode",
+				MarkdownDescription: "Replication Mode",
+				Validators: []validator.String{
+					stringvalidator.OneOf("Multicast"),
+				},
+			},
 			"routing_lb_id": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
 			},
 			"rp_ip_range": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "RP Loopback IP Address Range",
 				MarkdownDescription: "RP Loopback IP Address Range",
 			},
+			"rp_ip_range_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal RP IP Range",
+				MarkdownDescription: "Internal RP IP Range",
+			},
 			"rp_lb_id": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "No description available",
 				MarkdownDescription: "No description available",
 			},
 			"snmp_server_host_trap": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Configure NDFC as a receiver for SNMP traps",
 				MarkdownDescription: "Configure NDFC as a receiver for SNMP traps",
 			},
+			"spine_count": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Spine Count",
+				MarkdownDescription: "Spine Count",
+			},
 			"static_underlay_ip_alloc": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Checking this will disable Dynamic Fabric IP Address Allocations",
 				MarkdownDescription: "Checking this will disable Dynamic Fabric IP Address Allocations",
 			},
 			"subnet_range": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Address range to assign Numbered IPs",
 				MarkdownDescription: "Address range to assign Numbered IPs",
 			},
 			"subnet_target_mask": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Mask for Fabric Subnet IP Range",
 				MarkdownDescription: "Mask for Fabric Subnet IP Range",
 				Validators: []validator.Int64{
@@ -341,86 +662,143 @@ func FabricIpfmResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"syslog_server_ip_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Comma separated list of IP Addresses (v4/v6)",
 				MarkdownDescription: "Comma separated list of IP Addresses (v4/v6)",
 			},
 			"syslog_server_vrf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One VRF for all Syslog servers or a comma separated list of VRFs, one per Syslog server",
 				MarkdownDescription: "One VRF for all Syslog servers or a comma separated list of VRFs, one per Syslog server",
 			},
 			"syslog_sev": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Comma separated list of Syslog severity values, one per Syslog server",
-				MarkdownDescription: "Comma separated list of Syslog severity values, one per Syslog server",
+				Computed:            true,
+				Description:         "Comma separated list of Syslog severity values, one per Syslog server (Min:0, Max:7)",
+				MarkdownDescription: "Comma separated list of Syslog severity values, one per Syslog server (Min:0, Max:7)",
+			},
+			"upgrade_from_version": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Upgrade From Version",
+				MarkdownDescription: "Upgrade From Version",
 			},
 		},
-		Description:         "Resource to configure and manage IP Fabric Media",
-		MarkdownDescription: "Resource to configure and manage IP Fabric Media",
+		Description:         "Resource to configure and manage IP Fabric Media.  Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.",
+		MarkdownDescription: "Resource to configure and manage IP Fabric Media.  Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.",
 	}
 }
 
 type FabricIpfmModel struct {
-	AaaRemoteIpEnabled    types.Bool   `tfsdk:"aaa_remote_ip_enabled"`
-	AaaServerConf         types.String `tfsdk:"aaa_server_conf"`
-	AsmGroupRanges        types.String `tfsdk:"asm_group_ranges"`
-	BootstrapConf         types.String `tfsdk:"bootstrap_conf"`
-	BootstrapEnable       types.Bool   `tfsdk:"bootstrap_enable"`
-	BootstrapMultisubnet  types.String `tfsdk:"bootstrap_multisubnet"`
-	CdpEnable             types.Bool   `tfsdk:"cdp_enable"`
-	Deploy                types.Bool   `tfsdk:"deploy"`
-	DeploymentStatus      types.String `tfsdk:"deployment_status"`
-	DhcpEnable            types.Bool   `tfsdk:"dhcp_enable"`
-	DhcpEnd               types.String `tfsdk:"dhcp_end"`
-	DhcpIpv6Enable        types.String `tfsdk:"dhcp_ipv6_enable"`
-	DhcpStart             types.String `tfsdk:"dhcp_start"`
-	DnsServerIpList       types.String `tfsdk:"dns_server_ip_list"`
-	DnsServerVrf          types.String `tfsdk:"dns_server_vrf"`
-	EnableAaa             types.Bool   `tfsdk:"enable_aaa"`
-	EnableAsm             types.Bool   `tfsdk:"enable_asm"`
-	EnableNbmPassive      types.Bool   `tfsdk:"enable_nbm_passive"`
-	ExtraConfIntraLinks   types.String `tfsdk:"extra_conf_intra_links"`
-	ExtraConfLeaf         types.String `tfsdk:"extra_conf_leaf"`
-	ExtraConfSpine        types.String `tfsdk:"extra_conf_spine"`
-	FabricInterfaceType   types.String `tfsdk:"fabric_interface_type"`
-	FabricMtu             types.Int64  `tfsdk:"fabric_mtu"`
-	FabricName            types.String `tfsdk:"fabric_name"`
-	FeaturePtp            types.Bool   `tfsdk:"feature_ptp"`
-	Id                    types.String `tfsdk:"id"`
-	IsisAuthEnable        types.Bool   `tfsdk:"isis_auth_enable"`
-	IsisAuthKey           types.String `tfsdk:"isis_auth_key"`
-	IsisAuthKeychainKeyId types.Int64  `tfsdk:"isis_auth_keychain_key_id"`
-	IsisAuthKeychainName  types.String `tfsdk:"isis_auth_keychain_name"`
-	IsisLevel             types.String `tfsdk:"isis_level"`
-	IsisP2pEnable         types.Bool   `tfsdk:"isis_p2p_enable"`
-	L2HostIntfMtu         types.Int64  `tfsdk:"l2_host_intf_mtu"`
-	LinkStateRouting      types.String `tfsdk:"link_state_routing"`
-	LinkStateRoutingTag   types.String `tfsdk:"link_state_routing_tag"`
-	Loopback0IpRange      types.String `tfsdk:"loopback0_ip_range"`
-	MgmtGw                types.String `tfsdk:"mgmt_gw"`
-	MgmtPrefix            types.Int64  `tfsdk:"mgmt_prefix"`
-	NtpServerIpList       types.String `tfsdk:"ntp_server_ip_list"`
-	NtpServerVrf          types.String `tfsdk:"ntp_server_vrf"`
-	NxapiVrf              types.String `tfsdk:"nxapi_vrf"`
-	OspfAreaId            types.String `tfsdk:"ospf_area_id"`
-	OspfAuthEnable        types.Bool   `tfsdk:"ospf_auth_enable"`
-	OspfAuthKey           types.String `tfsdk:"ospf_auth_key"`
-	OspfAuthKeyId         types.Int64  `tfsdk:"ospf_auth_key_id"`
-	PimHelloAuthEnable    types.Bool   `tfsdk:"pim_hello_auth_enable"`
-	PimHelloAuthKey       types.String `tfsdk:"pim_hello_auth_key"`
-	PmEnable              types.Bool   `tfsdk:"pm_enable"`
-	PowerRedundancyMode   types.String `tfsdk:"power_redundancy_mode"`
-	PtpDomainId           types.Int64  `tfsdk:"ptp_domain_id"`
-	PtpLbId               types.Int64  `tfsdk:"ptp_lb_id"`
-	PtpProfile            types.String `tfsdk:"ptp_profile"`
-	RoutingLbId           types.Int64  `tfsdk:"routing_lb_id"`
-	RpIpRange             types.String `tfsdk:"rp_ip_range"`
-	RpLbId                types.Int64  `tfsdk:"rp_lb_id"`
-	SnmpServerHostTrap    types.Bool   `tfsdk:"snmp_server_host_trap"`
-	StaticUnderlayIpAlloc types.Bool   `tfsdk:"static_underlay_ip_alloc"`
-	SubnetRange           types.String `tfsdk:"subnet_range"`
-	SubnetTargetMask      types.Int64  `tfsdk:"subnet_target_mask"`
-	SyslogServerIpList    types.String `tfsdk:"syslog_server_ip_list"`
-	SyslogServerVrf       types.String `tfsdk:"syslog_server_vrf"`
-	SyslogSev             types.String `tfsdk:"syslog_sev"`
+	AaaRemoteIpEnabled                types.Bool   `tfsdk:"aaa_remote_ip_enabled"`
+	AaaServerConf                     types.String `tfsdk:"aaa_server_conf"`
+	AbstractDhcp                      types.String `tfsdk:"abstract_dhcp"`
+	AbstractExtraConfigBootstrap      types.String `tfsdk:"abstract_extra_config_bootstrap"`
+	AbstractExtraConfigLeaf           types.String `tfsdk:"abstract_extra_config_leaf"`
+	AbstractExtraConfigSpine          types.String `tfsdk:"abstract_extra_config_spine"`
+	AbstractIsis                      types.String `tfsdk:"abstract_isis"`
+	AbstractIsisInterface             types.String `tfsdk:"abstract_isis_interface"`
+	AbstractLoopbackInterface         types.String `tfsdk:"abstract_loopback_interface"`
+	AbstractOspf                      types.String `tfsdk:"abstract_ospf"`
+	AbstractOspfInterface             types.String `tfsdk:"abstract_ospf_interface"`
+	AbstractPimInterface              types.String `tfsdk:"abstract_pim_interface"`
+	AbstractRoutedHost                types.String `tfsdk:"abstract_routed_host"`
+	ActiveMigration                   types.Bool   `tfsdk:"active_migration"`
+	AgentIntf                         types.String `tfsdk:"agent_intf"`
+	AsmGroupRanges                    types.String `tfsdk:"asm_group_ranges"`
+	BootstrapConf                     types.String `tfsdk:"bootstrap_conf"`
+	BootstrapEnable                   types.Bool   `tfsdk:"bootstrap_enable"`
+	BootstrapMultisubnet              types.String `tfsdk:"bootstrap_multisubnet"`
+	BootstrapMultisubnetInternal      types.String `tfsdk:"bootstrap_multisubnet_internal"`
+	BrfieldDebugFlag                  types.String `tfsdk:"brfield_debug_flag"`
+	CdpEnable                         types.Bool   `tfsdk:"cdp_enable"`
+	Deploy                            types.Bool   `tfsdk:"deploy"`
+	DeploymentFreeze                  types.Bool   `tfsdk:"deployment_freeze"`
+	DeploymentStatus                  types.String `tfsdk:"deployment_status"`
+	DhcpEnable                        types.Bool   `tfsdk:"dhcp_enable"`
+	DhcpEnd                           types.String `tfsdk:"dhcp_end"`
+	DhcpEndInternal                   types.String `tfsdk:"dhcp_end_internal"`
+	DhcpIpv6Enable                    types.String `tfsdk:"dhcp_ipv6_enable"`
+	DhcpIpv6EnableInternal            types.String `tfsdk:"dhcp_ipv6_enable_internal"`
+	DhcpStart                         types.String `tfsdk:"dhcp_start"`
+	DhcpStartInternal                 types.String `tfsdk:"dhcp_start_internal"`
+	DnsServerIpList                   types.String `tfsdk:"dns_server_ip_list"`
+	DnsServerVrf                      types.String `tfsdk:"dns_server_vrf"`
+	EnableAaa                         types.Bool   `tfsdk:"enable_aaa"`
+	EnableAgent                       types.Bool   `tfsdk:"enable_agent"`
+	EnableAsm                         types.Bool   `tfsdk:"enable_asm"`
+	EnableNbmPassive                  types.Bool   `tfsdk:"enable_nbm_passive"`
+	EnableNbmPassivePrev              types.Bool   `tfsdk:"enable_nbm_passive_prev"`
+	EnableNxapi                       types.Bool   `tfsdk:"enable_nxapi"`
+	EnableNxapiHttp                   types.Bool   `tfsdk:"enable_nxapi_http"`
+	EnableRtIntfStats                 types.Bool   `tfsdk:"enable_rt_intf_stats"`
+	ExtFabricType                     types.String `tfsdk:"ext_fabric_type"`
+	ExtraConfIntraLinks               types.String `tfsdk:"extra_conf_intra_links"`
+	ExtraConfLeaf                     types.String `tfsdk:"extra_conf_leaf"`
+	ExtraConfSpine                    types.String `tfsdk:"extra_conf_spine"`
+	FabricInterfaceType               types.String `tfsdk:"fabric_interface_type"`
+	FabricMtu                         types.Int64  `tfsdk:"fabric_mtu"`
+	FabricMtuPrev                     types.Int64  `tfsdk:"fabric_mtu_prev"`
+	FabricName                        types.String `tfsdk:"fabric_name"`
+	FabricTechnology                  types.String `tfsdk:"fabric_technology"`
+	FabricType                        types.String `tfsdk:"fabric_type"`
+	FeaturePtp                        types.Bool   `tfsdk:"feature_ptp"`
+	FeaturePtpInternal                types.Bool   `tfsdk:"feature_ptp_internal"`
+	Ff                                types.String `tfsdk:"ff"`
+	GrfieldDebugFlag                  types.String `tfsdk:"grfield_debug_flag"`
+	Id                                types.String `tfsdk:"id"`
+	InterfaceEthernetDefaultPolicy    types.String `tfsdk:"interface_ethernet_default_policy"`
+	InterfaceLoopbackDefaultPolicy    types.String `tfsdk:"interface_loopback_default_policy"`
+	InterfacePortChannelDefaultPolicy types.String `tfsdk:"interface_port_channel_default_policy"`
+	InterfaceVlanDefaultPolicy        types.String `tfsdk:"interface_vlan_default_policy"`
+	IntfStatLoadInterval              types.Int64  `tfsdk:"intf_stat_load_interval"`
+	IsisAuthEnable                    types.Bool   `tfsdk:"isis_auth_enable"`
+	IsisAuthKey                       types.String `tfsdk:"isis_auth_key"`
+	IsisAuthKeychainKeyId             types.Int64  `tfsdk:"isis_auth_keychain_key_id"`
+	IsisAuthKeychainName              types.String `tfsdk:"isis_auth_keychain_name"`
+	IsisLevel                         types.String `tfsdk:"isis_level"`
+	IsisP2pEnable                     types.Bool   `tfsdk:"isis_p2p_enable"`
+	L2HostIntfMtu                     types.Int64  `tfsdk:"l2_host_intf_mtu"`
+	L2HostIntfMtuPrev                 types.Int64  `tfsdk:"l2_host_intf_mtu_prev"`
+	LinkStateRouting                  types.String `tfsdk:"link_state_routing"`
+	LinkStateRoutingTag               types.String `tfsdk:"link_state_routing_tag"`
+	LinkStateRoutingTagPrev           types.String `tfsdk:"link_state_routing_tag_prev"`
+	Loopback0IpRange                  types.String `tfsdk:"loopback0_ip_range"`
+	MgmtGw                            types.String `tfsdk:"mgmt_gw"`
+	MgmtGwInternal                    types.String `tfsdk:"mgmt_gw_internal"`
+	MgmtPrefix                        types.Int64  `tfsdk:"mgmt_prefix"`
+	MgmtPrefixInternal                types.Int64  `tfsdk:"mgmt_prefix_internal"`
+	MgmtV6prefix                      types.Int64  `tfsdk:"mgmt_v6prefix"`
+	MgmtV6prefixInternal              types.Int64  `tfsdk:"mgmt_v6prefix_internal"`
+	NtpServerIpList                   types.String `tfsdk:"ntp_server_ip_list"`
+	NtpServerVrf                      types.String `tfsdk:"ntp_server_vrf"`
+	NxapiHttpPort                     types.Int64  `tfsdk:"nxapi_http_port"`
+	NxapiHttpsPort                    types.Int64  `tfsdk:"nxapi_https_port"`
+	NxapiVrf                          types.String `tfsdk:"nxapi_vrf"`
+	OspfAreaId                        types.String `tfsdk:"ospf_area_id"`
+	OspfAuthEnable                    types.Bool   `tfsdk:"ospf_auth_enable"`
+	OspfAuthKey                       types.String `tfsdk:"ospf_auth_key"`
+	OspfAuthKeyId                     types.Int64  `tfsdk:"ospf_auth_key_id"`
+	PimHelloAuthEnable                types.Bool   `tfsdk:"pim_hello_auth_enable"`
+	PimHelloAuthKey                   types.String `tfsdk:"pim_hello_auth_key"`
+	PmEnable                          types.Bool   `tfsdk:"pm_enable"`
+	PmEnablePrev                      types.Bool   `tfsdk:"pm_enable_prev"`
+	PowerRedundancyMode               types.String `tfsdk:"power_redundancy_mode"`
+	PtpDomainId                       types.Int64  `tfsdk:"ptp_domain_id"`
+	PtpLbId                           types.Int64  `tfsdk:"ptp_lb_id"`
+	PtpProfile                        types.String `tfsdk:"ptp_profile"`
+	ReplicationMode                   types.String `tfsdk:"replication_mode"`
+	RoutingLbId                       types.Int64  `tfsdk:"routing_lb_id"`
+	RpIpRange                         types.String `tfsdk:"rp_ip_range"`
+	RpIpRangeInternal                 types.String `tfsdk:"rp_ip_range_internal"`
+	RpLbId                            types.Int64  `tfsdk:"rp_lb_id"`
+	SnmpServerHostTrap                types.Bool   `tfsdk:"snmp_server_host_trap"`
+	SpineCount                        types.Int64  `tfsdk:"spine_count"`
+	StaticUnderlayIpAlloc             types.Bool   `tfsdk:"static_underlay_ip_alloc"`
+	SubnetRange                       types.String `tfsdk:"subnet_range"`
+	SubnetTargetMask                  types.Int64  `tfsdk:"subnet_target_mask"`
+	SyslogServerIpList                types.String `tfsdk:"syslog_server_ip_list"`
+	SyslogServerVrf                   types.String `tfsdk:"syslog_server_vrf"`
+	SyslogSev                         types.String `tfsdk:"syslog_sev"`
+	UpgradeFromVersion                types.String `tfsdk:"upgrade_from_version"`
 }

--- a/internal/provider/resources/resource_fabric_ipfm/resource_codec_gen.go
+++ b/internal/provider/resources/resource_fabric_ipfm/resource_codec_gen.go
@@ -43,6 +43,19 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.AaaServerConf = types.StringNull()
 	}
 
+	if jsonData.ActiveMigration != "" {
+		x, _ := strconv.ParseBool(jsonData.ActiveMigration)
+		v.ActiveMigration = types.BoolValue(x)
+	} else {
+		v.ActiveMigration = types.BoolNull()
+	}
+
+	if jsonData.AgentIntf != "" {
+		v.AgentIntf = types.StringValue(jsonData.AgentIntf)
+	} else {
+		v.AgentIntf = types.StringNull()
+	}
+
 	if jsonData.AsmGroupRanges != "" {
 		v.AsmGroupRanges = types.StringValue(jsonData.AsmGroupRanges)
 	} else {
@@ -68,11 +81,30 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.BootstrapMultisubnet = types.StringNull()
 	}
 
+	if jsonData.BootstrapMultisubnetInternal != "" {
+		v.BootstrapMultisubnetInternal = types.StringValue(jsonData.BootstrapMultisubnetInternal)
+	} else {
+		v.BootstrapMultisubnetInternal = types.StringNull()
+	}
+
+	if jsonData.BrfieldDebugFlag != "" {
+		v.BrfieldDebugFlag = types.StringValue(jsonData.BrfieldDebugFlag)
+	} else {
+		v.BrfieldDebugFlag = types.StringNull()
+	}
+
 	if jsonData.CdpEnable != "" {
 		x, _ := strconv.ParseBool(jsonData.CdpEnable)
 		v.CdpEnable = types.BoolValue(x)
 	} else {
 		v.CdpEnable = types.BoolNull()
+	}
+
+	if jsonData.DeploymentFreeze != "" {
+		x, _ := strconv.ParseBool(jsonData.DeploymentFreeze)
+		v.DeploymentFreeze = types.BoolValue(x)
+	} else {
+		v.DeploymentFreeze = types.BoolNull()
 	}
 
 	if jsonData.DhcpEnable != "" {
@@ -88,16 +120,34 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.DhcpEnd = types.StringNull()
 	}
 
+	if jsonData.DhcpEndInternal != "" {
+		v.DhcpEndInternal = types.StringValue(jsonData.DhcpEndInternal)
+	} else {
+		v.DhcpEndInternal = types.StringNull()
+	}
+
 	if jsonData.DhcpIpv6Enable != "" {
 		v.DhcpIpv6Enable = types.StringValue(jsonData.DhcpIpv6Enable)
 	} else {
 		v.DhcpIpv6Enable = types.StringNull()
 	}
 
+	if jsonData.DhcpIpv6EnableInternal != "" {
+		v.DhcpIpv6EnableInternal = types.StringValue(jsonData.DhcpIpv6EnableInternal)
+	} else {
+		v.DhcpIpv6EnableInternal = types.StringNull()
+	}
+
 	if jsonData.DhcpStart != "" {
 		v.DhcpStart = types.StringValue(jsonData.DhcpStart)
 	} else {
 		v.DhcpStart = types.StringNull()
+	}
+
+	if jsonData.DhcpStartInternal != "" {
+		v.DhcpStartInternal = types.StringValue(jsonData.DhcpStartInternal)
+	} else {
+		v.DhcpStartInternal = types.StringNull()
 	}
 
 	if jsonData.DnsServerIpList != "" {
@@ -119,6 +169,13 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.EnableAaa = types.BoolNull()
 	}
 
+	if jsonData.EnableAgent != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableAgent)
+		v.EnableAgent = types.BoolValue(x)
+	} else {
+		v.EnableAgent = types.BoolNull()
+	}
+
 	if jsonData.EnableAsm != "" {
 		x, _ := strconv.ParseBool(jsonData.EnableAsm)
 		v.EnableAsm = types.BoolValue(x)
@@ -131,6 +188,34 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.EnableNbmPassive = types.BoolValue(x)
 	} else {
 		v.EnableNbmPassive = types.BoolNull()
+	}
+
+	if jsonData.EnableNbmPassivePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableNbmPassivePrev)
+		v.EnableNbmPassivePrev = types.BoolValue(x)
+	} else {
+		v.EnableNbmPassivePrev = types.BoolNull()
+	}
+
+	if jsonData.EnableNxapi != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableNxapi)
+		v.EnableNxapi = types.BoolValue(x)
+	} else {
+		v.EnableNxapi = types.BoolNull()
+	}
+
+	if jsonData.EnableNxapiHttp != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableNxapiHttp)
+		v.EnableNxapiHttp = types.BoolValue(x)
+	} else {
+		v.EnableNxapiHttp = types.BoolNull()
+	}
+
+	if jsonData.EnableRtIntfStats != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableRtIntfStats)
+		v.EnableRtIntfStats = types.BoolValue(x)
+	} else {
+		v.EnableRtIntfStats = types.BoolNull()
 	}
 
 	if jsonData.ExtraConfIntraLinks != "" {
@@ -151,6 +236,12 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.ExtraConfSpine = types.StringNull()
 	}
 
+	if jsonData.ExtFabricType != "" {
+		v.ExtFabricType = types.StringValue(jsonData.ExtFabricType)
+	} else {
+		v.ExtFabricType = types.StringNull()
+	}
+
 	if jsonData.FabricInterfaceType != "" {
 		v.FabricInterfaceType = types.StringValue(jsonData.FabricInterfaceType)
 	} else {
@@ -167,11 +258,86 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.FabricMtu = types.Int64Null()
 	}
 
+	if jsonData.FabricMtuPrev != nil {
+		if jsonData.FabricMtuPrev.IsEmpty() {
+			v.FabricMtuPrev = types.Int64Null()
+		} else {
+			v.FabricMtuPrev = types.Int64Value(int64(*jsonData.FabricMtuPrev))
+		}
+	} else {
+		v.FabricMtuPrev = types.Int64Null()
+	}
+
+	if jsonData.FabricTechnology != "" {
+		v.FabricTechnology = types.StringValue(jsonData.FabricTechnology)
+	} else {
+		v.FabricTechnology = types.StringNull()
+	}
+
+	if jsonData.FabricType != "" {
+		v.FabricType = types.StringValue(jsonData.FabricType)
+	} else {
+		v.FabricType = types.StringNull()
+	}
+
 	if jsonData.FeaturePtp != "" {
 		x, _ := strconv.ParseBool(jsonData.FeaturePtp)
 		v.FeaturePtp = types.BoolValue(x)
 	} else {
 		v.FeaturePtp = types.BoolNull()
+	}
+
+	if jsonData.FeaturePtpInternal != "" {
+		x, _ := strconv.ParseBool(jsonData.FeaturePtpInternal)
+		v.FeaturePtpInternal = types.BoolValue(x)
+	} else {
+		v.FeaturePtpInternal = types.BoolNull()
+	}
+
+	if jsonData.Ff != "" {
+		v.Ff = types.StringValue(jsonData.Ff)
+	} else {
+		v.Ff = types.StringNull()
+	}
+
+	if jsonData.GrfieldDebugFlag != "" {
+		v.GrfieldDebugFlag = types.StringValue(jsonData.GrfieldDebugFlag)
+	} else {
+		v.GrfieldDebugFlag = types.StringNull()
+	}
+
+	if jsonData.InterfaceEthernetDefaultPolicy != "" {
+		v.InterfaceEthernetDefaultPolicy = types.StringValue(jsonData.InterfaceEthernetDefaultPolicy)
+	} else {
+		v.InterfaceEthernetDefaultPolicy = types.StringNull()
+	}
+
+	if jsonData.InterfaceLoopbackDefaultPolicy != "" {
+		v.InterfaceLoopbackDefaultPolicy = types.StringValue(jsonData.InterfaceLoopbackDefaultPolicy)
+	} else {
+		v.InterfaceLoopbackDefaultPolicy = types.StringNull()
+	}
+
+	if jsonData.InterfacePortChannelDefaultPolicy != "" {
+		v.InterfacePortChannelDefaultPolicy = types.StringValue(jsonData.InterfacePortChannelDefaultPolicy)
+	} else {
+		v.InterfacePortChannelDefaultPolicy = types.StringNull()
+	}
+
+	if jsonData.InterfaceVlanDefaultPolicy != "" {
+		v.InterfaceVlanDefaultPolicy = types.StringValue(jsonData.InterfaceVlanDefaultPolicy)
+	} else {
+		v.InterfaceVlanDefaultPolicy = types.StringNull()
+	}
+
+	if jsonData.IntfStatLoadInterval != nil {
+		if jsonData.IntfStatLoadInterval.IsEmpty() {
+			v.IntfStatLoadInterval = types.Int64Null()
+		} else {
+			v.IntfStatLoadInterval = types.Int64Value(int64(*jsonData.IntfStatLoadInterval))
+		}
+	} else {
+		v.IntfStatLoadInterval = types.Int64Null()
 	}
 
 	if jsonData.IsisAuthEnable != "" {
@@ -226,6 +392,16 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.L2HostIntfMtu = types.Int64Null()
 	}
 
+	if jsonData.L2HostIntfMtuPrev != nil {
+		if jsonData.L2HostIntfMtuPrev.IsEmpty() {
+			v.L2HostIntfMtuPrev = types.Int64Null()
+		} else {
+			v.L2HostIntfMtuPrev = types.Int64Value(int64(*jsonData.L2HostIntfMtuPrev))
+		}
+	} else {
+		v.L2HostIntfMtuPrev = types.Int64Null()
+	}
+
 	if jsonData.LinkStateRouting != "" {
 		v.LinkStateRouting = types.StringValue(jsonData.LinkStateRouting)
 	} else {
@@ -236,6 +412,12 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.LinkStateRoutingTag = types.StringValue(jsonData.LinkStateRoutingTag)
 	} else {
 		v.LinkStateRoutingTag = types.StringNull()
+	}
+
+	if jsonData.LinkStateRoutingTagPrev != "" {
+		v.LinkStateRoutingTagPrev = types.StringValue(jsonData.LinkStateRoutingTagPrev)
+	} else {
+		v.LinkStateRoutingTagPrev = types.StringNull()
 	}
 
 	if jsonData.Loopback0IpRange != "" {
@@ -250,6 +432,12 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.MgmtGw = types.StringNull()
 	}
 
+	if jsonData.MgmtGwInternal != "" {
+		v.MgmtGwInternal = types.StringValue(jsonData.MgmtGwInternal)
+	} else {
+		v.MgmtGwInternal = types.StringNull()
+	}
+
 	if jsonData.MgmtPrefix != nil {
 		if jsonData.MgmtPrefix.IsEmpty() {
 			v.MgmtPrefix = types.Int64Null()
@@ -258,6 +446,36 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		}
 	} else {
 		v.MgmtPrefix = types.Int64Null()
+	}
+
+	if jsonData.MgmtPrefixInternal != nil {
+		if jsonData.MgmtPrefixInternal.IsEmpty() {
+			v.MgmtPrefixInternal = types.Int64Null()
+		} else {
+			v.MgmtPrefixInternal = types.Int64Value(int64(*jsonData.MgmtPrefixInternal))
+		}
+	} else {
+		v.MgmtPrefixInternal = types.Int64Null()
+	}
+
+	if jsonData.MgmtV6prefix != nil {
+		if jsonData.MgmtV6prefix.IsEmpty() {
+			v.MgmtV6prefix = types.Int64Null()
+		} else {
+			v.MgmtV6prefix = types.Int64Value(int64(*jsonData.MgmtV6prefix))
+		}
+	} else {
+		v.MgmtV6prefix = types.Int64Null()
+	}
+
+	if jsonData.MgmtV6prefixInternal != nil {
+		if jsonData.MgmtV6prefixInternal.IsEmpty() {
+			v.MgmtV6prefixInternal = types.Int64Null()
+		} else {
+			v.MgmtV6prefixInternal = types.Int64Value(int64(*jsonData.MgmtV6prefixInternal))
+		}
+	} else {
+		v.MgmtV6prefixInternal = types.Int64Null()
 	}
 
 	if jsonData.NtpServerIpList != "" {
@@ -270,6 +488,26 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.NtpServerVrf = types.StringValue(jsonData.NtpServerVrf)
 	} else {
 		v.NtpServerVrf = types.StringNull()
+	}
+
+	if jsonData.NxapiHttpsPort != nil {
+		if jsonData.NxapiHttpsPort.IsEmpty() {
+			v.NxapiHttpsPort = types.Int64Null()
+		} else {
+			v.NxapiHttpsPort = types.Int64Value(int64(*jsonData.NxapiHttpsPort))
+		}
+	} else {
+		v.NxapiHttpsPort = types.Int64Null()
+	}
+
+	if jsonData.NxapiHttpPort != nil {
+		if jsonData.NxapiHttpPort.IsEmpty() {
+			v.NxapiHttpPort = types.Int64Null()
+		} else {
+			v.NxapiHttpPort = types.Int64Value(int64(*jsonData.NxapiHttpPort))
+		}
+	} else {
+		v.NxapiHttpPort = types.Int64Null()
 	}
 
 	if jsonData.NxapiVrf != "" {
@@ -327,6 +565,13 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.PmEnable = types.BoolNull()
 	}
 
+	if jsonData.PmEnablePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.PmEnablePrev)
+		v.PmEnablePrev = types.BoolValue(x)
+	} else {
+		v.PmEnablePrev = types.BoolNull()
+	}
+
 	if jsonData.PowerRedundancyMode != "" {
 		v.PowerRedundancyMode = types.StringValue(jsonData.PowerRedundancyMode)
 	} else {
@@ -359,6 +604,12 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.PtpProfile = types.StringNull()
 	}
 
+	if jsonData.ReplicationMode != "" {
+		v.ReplicationMode = types.StringValue(jsonData.ReplicationMode)
+	} else {
+		v.ReplicationMode = types.StringNull()
+	}
+
 	if jsonData.RoutingLbId != nil {
 		if jsonData.RoutingLbId.IsEmpty() {
 			v.RoutingLbId = types.Int64Null()
@@ -373,6 +624,12 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.RpIpRange = types.StringValue(jsonData.RpIpRange)
 	} else {
 		v.RpIpRange = types.StringNull()
+	}
+
+	if jsonData.RpIpRangeInternal != "" {
+		v.RpIpRangeInternal = types.StringValue(jsonData.RpIpRangeInternal)
+	} else {
+		v.RpIpRangeInternal = types.StringNull()
 	}
 
 	if jsonData.RpLbId != nil {
@@ -390,6 +647,16 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.SnmpServerHostTrap = types.BoolValue(x)
 	} else {
 		v.SnmpServerHostTrap = types.BoolNull()
+	}
+
+	if jsonData.SpineCount != nil {
+		if jsonData.SpineCount.IsEmpty() {
+			v.SpineCount = types.Int64Null()
+		} else {
+			v.SpineCount = types.Int64Value(int64(*jsonData.SpineCount))
+		}
+	} else {
+		v.SpineCount = types.Int64Null()
 	}
 
 	if jsonData.StaticUnderlayIpAlloc != "" {
@@ -433,6 +700,78 @@ func (v *FabricIpfmModel) SetModelData(jsonData *resource_fabric_common.NDFCFabr
 		v.SyslogSev = types.StringNull()
 	}
 
+	if jsonData.UpgradeFromVersion != "" {
+		v.UpgradeFromVersion = types.StringValue(jsonData.UpgradeFromVersion)
+	} else {
+		v.UpgradeFromVersion = types.StringNull()
+	}
+
+	if jsonData.AbstractDhcp != "" {
+		v.AbstractDhcp = types.StringValue(jsonData.AbstractDhcp)
+	} else {
+		v.AbstractDhcp = types.StringNull()
+	}
+
+	if jsonData.AbstractExtraConfigBootstrap != "" {
+		v.AbstractExtraConfigBootstrap = types.StringValue(jsonData.AbstractExtraConfigBootstrap)
+	} else {
+		v.AbstractExtraConfigBootstrap = types.StringNull()
+	}
+
+	if jsonData.AbstractExtraConfigLeaf != "" {
+		v.AbstractExtraConfigLeaf = types.StringValue(jsonData.AbstractExtraConfigLeaf)
+	} else {
+		v.AbstractExtraConfigLeaf = types.StringNull()
+	}
+
+	if jsonData.AbstractExtraConfigSpine != "" {
+		v.AbstractExtraConfigSpine = types.StringValue(jsonData.AbstractExtraConfigSpine)
+	} else {
+		v.AbstractExtraConfigSpine = types.StringNull()
+	}
+
+	if jsonData.AbstractIsis != "" {
+		v.AbstractIsis = types.StringValue(jsonData.AbstractIsis)
+	} else {
+		v.AbstractIsis = types.StringNull()
+	}
+
+	if jsonData.AbstractIsisInterface != "" {
+		v.AbstractIsisInterface = types.StringValue(jsonData.AbstractIsisInterface)
+	} else {
+		v.AbstractIsisInterface = types.StringNull()
+	}
+
+	if jsonData.AbstractLoopbackInterface != "" {
+		v.AbstractLoopbackInterface = types.StringValue(jsonData.AbstractLoopbackInterface)
+	} else {
+		v.AbstractLoopbackInterface = types.StringNull()
+	}
+
+	if jsonData.AbstractOspf != "" {
+		v.AbstractOspf = types.StringValue(jsonData.AbstractOspf)
+	} else {
+		v.AbstractOspf = types.StringNull()
+	}
+
+	if jsonData.AbstractOspfInterface != "" {
+		v.AbstractOspfInterface = types.StringValue(jsonData.AbstractOspfInterface)
+	} else {
+		v.AbstractOspfInterface = types.StringNull()
+	}
+
+	if jsonData.AbstractPimInterface != "" {
+		v.AbstractPimInterface = types.StringValue(jsonData.AbstractPimInterface)
+	} else {
+		v.AbstractPimInterface = types.StringNull()
+	}
+
+	if jsonData.AbstractRoutedHost != "" {
+		v.AbstractRoutedHost = types.StringValue(jsonData.AbstractRoutedHost)
+	} else {
+		v.AbstractRoutedHost = types.StringNull()
+	}
+
 	v.Deploy = types.BoolValue(jsonData.Deploy)
 	if jsonData.DeploymentStatus != "" {
 		v.DeploymentStatus = types.StringValue(jsonData.DeploymentStatus)
@@ -466,6 +805,18 @@ func (v FabricIpfmModel) GetModelData() *resource_fabric_common.NDFCFabricCommon
 		data.AaaServerConf = ""
 	}
 
+	if !v.ActiveMigration.IsNull() && !v.ActiveMigration.IsUnknown() {
+		data.ActiveMigration = strconv.FormatBool(v.ActiveMigration.ValueBool())
+	} else {
+		data.ActiveMigration = ""
+	}
+
+	if !v.AgentIntf.IsNull() && !v.AgentIntf.IsUnknown() {
+		data.AgentIntf = v.AgentIntf.ValueString()
+	} else {
+		data.AgentIntf = ""
+	}
+
 	if !v.AsmGroupRanges.IsNull() && !v.AsmGroupRanges.IsUnknown() {
 		data.AsmGroupRanges = v.AsmGroupRanges.ValueString()
 	} else {
@@ -490,10 +841,22 @@ func (v FabricIpfmModel) GetModelData() *resource_fabric_common.NDFCFabricCommon
 		data.BootstrapMultisubnet = ""
 	}
 
+	if !v.BrfieldDebugFlag.IsNull() && !v.BrfieldDebugFlag.IsUnknown() {
+		data.BrfieldDebugFlag = v.BrfieldDebugFlag.ValueString()
+	} else {
+		data.BrfieldDebugFlag = ""
+	}
+
 	if !v.CdpEnable.IsNull() && !v.CdpEnable.IsUnknown() {
 		data.CdpEnable = strconv.FormatBool(v.CdpEnable.ValueBool())
 	} else {
 		data.CdpEnable = ""
+	}
+
+	if !v.DeploymentFreeze.IsNull() && !v.DeploymentFreeze.IsUnknown() {
+		data.DeploymentFreeze = strconv.FormatBool(v.DeploymentFreeze.ValueBool())
+	} else {
+		data.DeploymentFreeze = ""
 	}
 
 	if !v.DhcpEnable.IsNull() && !v.DhcpEnable.IsUnknown() {
@@ -538,6 +901,12 @@ func (v FabricIpfmModel) GetModelData() *resource_fabric_common.NDFCFabricCommon
 		data.EnableAaa = ""
 	}
 
+	if !v.EnableAgent.IsNull() && !v.EnableAgent.IsUnknown() {
+		data.EnableAgent = strconv.FormatBool(v.EnableAgent.ValueBool())
+	} else {
+		data.EnableAgent = ""
+	}
+
 	if !v.EnableAsm.IsNull() && !v.EnableAsm.IsUnknown() {
 		data.EnableAsm = strconv.FormatBool(v.EnableAsm.ValueBool())
 	} else {
@@ -548,6 +917,24 @@ func (v FabricIpfmModel) GetModelData() *resource_fabric_common.NDFCFabricCommon
 		data.EnableNbmPassive = strconv.FormatBool(v.EnableNbmPassive.ValueBool())
 	} else {
 		data.EnableNbmPassive = ""
+	}
+
+	if !v.EnableNxapi.IsNull() && !v.EnableNxapi.IsUnknown() {
+		data.EnableNxapi = strconv.FormatBool(v.EnableNxapi.ValueBool())
+	} else {
+		data.EnableNxapi = ""
+	}
+
+	if !v.EnableNxapiHttp.IsNull() && !v.EnableNxapiHttp.IsUnknown() {
+		data.EnableNxapiHttp = strconv.FormatBool(v.EnableNxapiHttp.ValueBool())
+	} else {
+		data.EnableNxapiHttp = ""
+	}
+
+	if !v.EnableRtIntfStats.IsNull() && !v.EnableRtIntfStats.IsUnknown() {
+		data.EnableRtIntfStats = strconv.FormatBool(v.EnableRtIntfStats.ValueBool())
+	} else {
+		data.EnableRtIntfStats = ""
 	}
 
 	if !v.ExtraConfIntraLinks.IsNull() && !v.ExtraConfIntraLinks.IsUnknown() {
@@ -568,10 +955,10 @@ func (v FabricIpfmModel) GetModelData() *resource_fabric_common.NDFCFabricCommon
 		data.ExtraConfSpine = ""
 	}
 
-	if !v.FabricInterfaceType.IsNull() && !v.FabricInterfaceType.IsUnknown() {
-		data.FabricInterfaceType = v.FabricInterfaceType.ValueString()
+	if !v.ExtFabricType.IsNull() && !v.ExtFabricType.IsUnknown() {
+		data.ExtFabricType = v.ExtFabricType.ValueString()
 	} else {
-		data.FabricInterfaceType = ""
+		data.ExtFabricType = ""
 	}
 
 	if !v.FabricMtu.IsNull() && !v.FabricMtu.IsUnknown() {
@@ -585,6 +972,25 @@ func (v FabricIpfmModel) GetModelData() *resource_fabric_common.NDFCFabricCommon
 		data.FeaturePtp = strconv.FormatBool(v.FeaturePtp.ValueBool())
 	} else {
 		data.FeaturePtp = ""
+	}
+
+	if !v.Ff.IsNull() && !v.Ff.IsUnknown() {
+		data.Ff = v.Ff.ValueString()
+	} else {
+		data.Ff = ""
+	}
+
+	if !v.GrfieldDebugFlag.IsNull() && !v.GrfieldDebugFlag.IsUnknown() {
+		data.GrfieldDebugFlag = v.GrfieldDebugFlag.ValueString()
+	} else {
+		data.GrfieldDebugFlag = ""
+	}
+
+	if !v.IntfStatLoadInterval.IsNull() && !v.IntfStatLoadInterval.IsUnknown() {
+		data.IntfStatLoadInterval = new(Int64Custom)
+		*data.IntfStatLoadInterval = Int64Custom(v.IntfStatLoadInterval.ValueInt64())
+	} else {
+		data.IntfStatLoadInterval = nil
 	}
 
 	if !v.IsisAuthEnable.IsNull() && !v.IsisAuthEnable.IsUnknown() {
@@ -674,6 +1080,20 @@ func (v FabricIpfmModel) GetModelData() *resource_fabric_common.NDFCFabricCommon
 		data.NtpServerVrf = ""
 	}
 
+	if !v.NxapiHttpsPort.IsNull() && !v.NxapiHttpsPort.IsUnknown() {
+		data.NxapiHttpsPort = new(Int64Custom)
+		*data.NxapiHttpsPort = Int64Custom(v.NxapiHttpsPort.ValueInt64())
+	} else {
+		data.NxapiHttpsPort = nil
+	}
+
+	if !v.NxapiHttpPort.IsNull() && !v.NxapiHttpPort.IsUnknown() {
+		data.NxapiHttpPort = new(Int64Custom)
+		*data.NxapiHttpPort = Int64Custom(v.NxapiHttpPort.ValueInt64())
+	} else {
+		data.NxapiHttpPort = nil
+	}
+
 	if !v.NxapiVrf.IsNull() && !v.NxapiVrf.IsUnknown() {
 		data.NxapiVrf = v.NxapiVrf.ValueString()
 	} else {
@@ -747,6 +1167,12 @@ func (v FabricIpfmModel) GetModelData() *resource_fabric_common.NDFCFabricCommon
 		data.PtpProfile = v.PtpProfile.ValueString()
 	} else {
 		data.PtpProfile = ""
+	}
+
+	if !v.ReplicationMode.IsNull() && !v.ReplicationMode.IsUnknown() {
+		data.ReplicationMode = v.ReplicationMode.ValueString()
+	} else {
+		data.ReplicationMode = ""
 	}
 
 	if !v.RoutingLbId.IsNull() && !v.RoutingLbId.IsUnknown() {

--- a/internal/provider/resources/resource_fabric_lan_classic/fabric_lan_classic_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_lan_classic/fabric_lan_classic_resource_gen.go
@@ -18,38 +18,78 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"aaa_remote_ip_enabled": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable only, when IP Authorization is enabled in the AAA Server",
 				MarkdownDescription: "Enable only, when IP Authorization is enabled in the AAA Server",
 			},
 			"aaa_server_conf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "AAA Configurations",
 				MarkdownDescription: "AAA Configurations",
 			},
+			"allow_nxc": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Allow onboarding of this fabric to Nexus Cloud",
+				MarkdownDescription: "Allow onboarding of this fabric to Nexus Cloud",
+			},
+			"allow_nxc_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Allow onboarding of this fabric to Nexus Cloud",
+				MarkdownDescription: "Previous state of Allow onboarding of this fabric to Nexus Cloud",
+			},
 			"bootstrap_conf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional CLIs required during device bootup/login e.g. AAA/Radius",
 				MarkdownDescription: "Additional CLIs required during device bootup/login e.g. AAA/Radius",
 			},
 			"bootstrap_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "Automatic IP Assignment For POAP",
-				MarkdownDescription: "Automatic IP Assignment For POAP",
+				Computed:            true,
+				Description:         "Automatic IP Assignment For POAP (For NX-OS Switches Only)",
+				MarkdownDescription: "Automatic IP Assignment For POAP (For NX-OS Switches Only)",
 			},
 			"bootstrap_multisubnet": schema.StringAttribute{
 				Optional:            true,
-				Description:         "lines with # prefix are ignored here",
-				MarkdownDescription: "lines with # prefix are ignored here",
+				Computed:            true,
+				Description:         "DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here",
+				MarkdownDescription: "DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here",
+			},
+			"bootstrap_multisubnet_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal Bootstrap Multi Subnet Scope",
+				MarkdownDescription: "Internal Bootstrap Multi Subnet Scope",
 			},
 			"cdp_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable CDP on management interface",
 				MarkdownDescription: "Enable CDP on management interface",
+			},
+			"dci_subnet_range": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Address range to assign P2P DCI Links",
+				MarkdownDescription: "Address range to assign P2P DCI Links",
+			},
+			"dci_subnet_target_mask": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Target Mask for Subnet Range (Min:8, Max:31)",
+				MarkdownDescription: "Target Mask for Subnet Range (Min:8, Max:31)",
 			},
 			"deploy": schema.BoolAttribute{
 				Required:            true,
 				Description:         "This flag does configuration save and deploy",
 				MarkdownDescription: "This flag does configuration save and deploy",
+			},
+			"deployment_freeze": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Disable all deployments in this fabric",
+				MarkdownDescription: "Disable all deployments in this fabric",
 			},
 			"deployment_status": schema.StringAttribute{
 				Computed:            true,
@@ -58,74 +98,139 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"dhcp_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP From Local DHCP Server",
 				MarkdownDescription: "Automatic IP Assignment For POAP From Local DHCP Server",
 			},
 			"dhcp_end": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "End Address For Switch POAP",
 				MarkdownDescription: "End Address For Switch POAP",
 			},
+			"dhcp_end_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP End Address",
+				MarkdownDescription: "Internal DHCP End Address",
+			},
 			"dhcp_ipv6_enable": schema.StringAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "DHCP Version",
+				MarkdownDescription: "DHCP Version",
 				Validators: []validator.String{
 					stringvalidator.OneOf("DHCPv4", "DHCPv6"),
 				},
 			},
+			"dhcp_ipv6_enable_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP IPv6 Enable",
+				MarkdownDescription: "Internal DHCP IPv6 Enable",
+			},
 			"dhcp_start": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Start Address For Switch POAP",
 				MarkdownDescription: "Start Address For Switch POAP",
 			},
+			"dhcp_start_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP Start Address",
+				MarkdownDescription: "Internal DHCP Start Address",
+			},
 			"enable_aaa": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Include AAA configs from Advanced tab during device bootup",
 				MarkdownDescription: "Include AAA configs from Advanced tab during device bootup",
 			},
 			"enable_netflow": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable Netflow on VTEPs",
 				MarkdownDescription: "Enable Netflow on VTEPs",
 			},
+			"enable_netflow_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable Netflow on VTEPs",
+				MarkdownDescription: "Previous state of Enable Netflow on VTEPs",
+			},
 			"enable_nxapi": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable HTTPS NX-API",
 				MarkdownDescription: "Enable HTTPS NX-API",
 			},
 			"enable_nxapi_http": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable HTTP NX-API",
+				MarkdownDescription: "Enable HTTP NX-API",
 			},
 			"enable_real_time_backup": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Backup hourly only if there is any config deployment since last backup",
 				MarkdownDescription: "Backup hourly only if there is any config deployment since last backup",
 			},
+			"enable_rt_intf_stats": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Valid for NX-OS only",
+				MarkdownDescription: "Valid for NX-OS only",
+			},
 			"enable_scheduled_backup": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Backup at the specified time",
 				MarkdownDescription: "Backup at the specified time",
 			},
+			"ext_fabric_type": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "External Fabric Type",
+				MarkdownDescription: "External Fabric Type",
+			},
 			"fabric_freeform": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional supported CLIs for all same OS (e.g. all NxOS etc) switches",
 				MarkdownDescription: "Additional supported CLIs for all same OS (e.g. all NxOS etc) switches",
 			},
 			"fabric_name": schema.StringAttribute{
 				Required:            true,
-				Description:         "Fabric name to be created, updated or deleted (Max Size 64).",
-				MarkdownDescription: "Fabric name to be created, updated or deleted (Max Size 64).",
+				Description:         "Fabric name to be created, updated or deleted.",
+				MarkdownDescription: "Fabric name to be created, updated or deleted.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"fabric_technology": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Fabric Technology",
+				MarkdownDescription: "Fabric Technology",
+			},
+			"fabric_type": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Fabric Type",
+				MarkdownDescription: "Fabric Type",
+			},
 			"feature_ptp": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable Precision Time Protocol (PTP)",
+				MarkdownDescription: "Enable Precision Time Protocol (PTP)",
+			},
+			"feature_ptp_internal": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Internal Feature PTP",
+				MarkdownDescription: "Internal Feature PTP",
+			},
+			"ff": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Template Family",
+				MarkdownDescription: "Template Family",
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -134,86 +239,174 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"inband_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should be Enabled)",
 				MarkdownDescription: "Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should be Enabled)",
 			},
+			"inband_enable_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable POAP over Inband Interface",
+				MarkdownDescription: "Previous state of Enable POAP over Inband Interface",
+			},
 			"inband_mgmt": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Import switches with inband connectivity",
 				MarkdownDescription: "Import switches with inband connectivity",
 			},
+			"inband_mgmt_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Inband Management",
+				MarkdownDescription: "Previous state of Inband Management",
+			},
+			"intf_stat_load_interval": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Time in seconds (Min:5, Max:300)",
+				MarkdownDescription: "Time in seconds (Min:5, Max:300)",
+			},
 			"is_read_only": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "If enabled, fabric is only monitored. No configuration will be deployed",
 				MarkdownDescription: "If enabled, fabric is only monitored. No configuration will be deployed",
 			},
+			"loopback0_ip_range": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Underlay Routing Loopback IP Range",
+				MarkdownDescription: "Underlay Routing Loopback IP Range",
+			},
 			"mgmt_gw": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Gateway For Management VRF On The Switch",
 				MarkdownDescription: "Default Gateway For Management VRF On The Switch",
 			},
+			"mgmt_gw_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal Management Gateway",
+				MarkdownDescription: "Internal Management Gateway",
+			},
 			"mgmt_prefix": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Switch Mgmt IP Subnet Prefix (Min:8, Max:30)",
+				MarkdownDescription: "Switch Mgmt IP Subnet Prefix (Min:8, Max:30)",
+			},
+			"mgmt_prefix_internal": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Internal Management Prefix",
+				MarkdownDescription: "Internal Management Prefix",
 			},
 			"mgmt_v6prefix": schema.Int64Attribute{
-				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)",
+				MarkdownDescription: "Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)",
+			},
+			"mgmt_v6prefix_internal": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Internal Management IPv6 Prefix",
+				MarkdownDescription: "Internal Management IPv6 Prefix",
 			},
 			"mpls_handoff": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable MPLS Handoff",
+				MarkdownDescription: "Enable MPLS Handoff",
 			},
 			"mpls_lb_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "(Min:0, Max:1023)",
+				MarkdownDescription: "(Min:0, Max:1023)",
 			},
 			"mpls_loopback_ip_range": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "MPLS Loopback IP Address Range",
 				MarkdownDescription: "MPLS Loopback IP Address Range",
 			},
 			"netflow_exporter_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One or Multiple Netflow Exporters",
 				MarkdownDescription: "One or Multiple Netflow Exporters",
 			},
 			"netflow_monitor_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One or Multiple Netflow Monitors",
 				MarkdownDescription: "One or Multiple Netflow Monitors",
 			},
 			"netflow_record_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One or Multiple Netflow Records",
 				MarkdownDescription: "One or Multiple Netflow Records",
 			},
 			"netflow_sampler_list": schema.StringAttribute{
 				Optional:            true,
-				Description:         "One or multiple netflow Samplers. Applicable to N7K only",
-				MarkdownDescription: "One or multiple netflow Samplers. Applicable to N7K only",
+				Computed:            true,
+				Description:         "One or multiple Netflow Samplers. Applicable to N7K only",
+				MarkdownDescription: "One or multiple Netflow Samplers. Applicable to N7K only",
 			},
 			"nxapi_http_port": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "NX-API HTTP Port Number",
+				MarkdownDescription: "NX-API HTTP Port Number",
 			},
 			"nxapi_https_port": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "NX-API HTTPS Port Number",
+				MarkdownDescription: "NX-API HTTPS Port Number",
+			},
+			"nxc_dest_vrf": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "VRF to be used to reach Nexus Cloud, enter 'management' for management VRF and 'default' for default VRF",
+				MarkdownDescription: "VRF to be used to reach Nexus Cloud, enter 'management' for management VRF and 'default' for default VRF",
+			},
+			"nxc_proxy_port": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Proxy port number, default is 8080",
+				MarkdownDescription: "Proxy port number, default is 8080",
+			},
+			"nxc_proxy_server": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "IPv4 or IPv6 address, or DNS name of the proxy server",
+				MarkdownDescription: "IPv4 or IPv6 address, or DNS name of the proxy server",
+			},
+			"nxc_src_intf": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Source interface for communication to Nexus Cloud, mandatory if Destination VRF is not management",
+				MarkdownDescription: "Source interface for communication to Nexus Cloud, mandatory if Destination VRF is not management",
+			},
+			"overwrite_global_nxc": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "If enabled, Fabric NxCloud Settings will be used",
+				MarkdownDescription: "If enabled, Fabric NxCloud Settings will be used",
 			},
 			"pm_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable Performance Monitoring (For NX-OS Switches Only)",
+				MarkdownDescription: "Enable Performance Monitoring (For NX-OS Switches Only)",
+			},
+			"pm_enable_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable Performance Monitoring",
+				MarkdownDescription: "Previous state of Enable Performance Monitoring",
 			},
 			"power_redundancy_mode": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Power Supply Mode For Bootstrapped NX-OS Switches",
 				MarkdownDescription: "Default Power Supply Mode For Bootstrapped NX-OS Switches",
 				Validators: []validator.String{
@@ -222,78 +415,112 @@ func FabricLanClassicResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"ptp_domain_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "Multiple Independent PTP Clocking Subdomains on a Single Network",
-				MarkdownDescription: "Multiple Independent PTP Clocking Subdomains on a Single Network",
+				Computed:            true,
+				Description:         "Multiple Independent PTP Clocking Subdomains on a Single Network (Min:0, Max:127)",
+				MarkdownDescription: "Multiple Independent PTP Clocking Subdomains on a Single Network (Min:0, Max:127)",
 			},
 			"ptp_lb_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "(Min:0, Max:1023)",
+				MarkdownDescription: "(Min:0, Max:1023)",
 			},
 			"scheduled_time": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Time (UTC) in 24hr format. (00:00 to 23:59)",
 				MarkdownDescription: "Time (UTC) in 24hr format. (00:00 to 23:59)",
 			},
 			"snmp_server_host_trap": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Configure NDFC as a receiver for SNMP traps",
 				MarkdownDescription: "Configure NDFC as a receiver for SNMP traps",
 			},
 			"subinterface_range": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Per Border Dot1q Range For VRF Lite Connectivity",
-				MarkdownDescription: "Per Border Dot1q Range For VRF Lite Connectivity",
+				Computed:            true,
+				Description:         "Per Border Dot1q Range For VRF Lite Connectivity (Min:2, Max:4093)",
+				MarkdownDescription: "Per Border Dot1q Range For VRF Lite Connectivity (Min:2, Max:4093)",
 			},
 		},
-		Description:         "Resource to configure and manage a LAN Classic Fabric",
-		MarkdownDescription: "Resource to configure and manage a LAN Classic Fabric",
+		Description:         "Resource to configure and manage a LAN Classic Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.",
+		MarkdownDescription: "Resource to configure and manage a LAN Classic Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.",
 	}
 }
 
 type FabricLanClassicModel struct {
-	AaaRemoteIpEnabled    types.Bool   `tfsdk:"aaa_remote_ip_enabled"`
-	AaaServerConf         types.String `tfsdk:"aaa_server_conf"`
-	BootstrapConf         types.String `tfsdk:"bootstrap_conf"`
-	BootstrapEnable       types.Bool   `tfsdk:"bootstrap_enable"`
-	BootstrapMultisubnet  types.String `tfsdk:"bootstrap_multisubnet"`
-	CdpEnable             types.Bool   `tfsdk:"cdp_enable"`
-	Deploy                types.Bool   `tfsdk:"deploy"`
-	DeploymentStatus      types.String `tfsdk:"deployment_status"`
-	DhcpEnable            types.Bool   `tfsdk:"dhcp_enable"`
-	DhcpEnd               types.String `tfsdk:"dhcp_end"`
-	DhcpIpv6Enable        types.String `tfsdk:"dhcp_ipv6_enable"`
-	DhcpStart             types.String `tfsdk:"dhcp_start"`
-	EnableAaa             types.Bool   `tfsdk:"enable_aaa"`
-	EnableNetflow         types.Bool   `tfsdk:"enable_netflow"`
-	EnableNxapi           types.Bool   `tfsdk:"enable_nxapi"`
-	EnableNxapiHttp       types.Bool   `tfsdk:"enable_nxapi_http"`
-	EnableRealTimeBackup  types.Bool   `tfsdk:"enable_real_time_backup"`
-	EnableScheduledBackup types.Bool   `tfsdk:"enable_scheduled_backup"`
-	FabricFreeform        types.String `tfsdk:"fabric_freeform"`
-	FabricName            types.String `tfsdk:"fabric_name"`
-	FeaturePtp            types.Bool   `tfsdk:"feature_ptp"`
-	Id                    types.String `tfsdk:"id"`
-	InbandEnable          types.Bool   `tfsdk:"inband_enable"`
-	InbandMgmt            types.Bool   `tfsdk:"inband_mgmt"`
-	IsReadOnly            types.Bool   `tfsdk:"is_read_only"`
-	MgmtGw                types.String `tfsdk:"mgmt_gw"`
-	MgmtPrefix            types.Int64  `tfsdk:"mgmt_prefix"`
-	MgmtV6prefix          types.Int64  `tfsdk:"mgmt_v6prefix"`
-	MplsHandoff           types.Bool   `tfsdk:"mpls_handoff"`
-	MplsLbId              types.Int64  `tfsdk:"mpls_lb_id"`
-	MplsLoopbackIpRange   types.String `tfsdk:"mpls_loopback_ip_range"`
-	NetflowExporterList   types.String `tfsdk:"netflow_exporter_list"`
-	NetflowMonitorList    types.String `tfsdk:"netflow_monitor_list"`
-	NetflowRecordList     types.String `tfsdk:"netflow_record_list"`
-	NetflowSamplerList    types.String `tfsdk:"netflow_sampler_list"`
-	NxapiHttpPort         types.Int64  `tfsdk:"nxapi_http_port"`
-	NxapiHttpsPort        types.Int64  `tfsdk:"nxapi_https_port"`
-	PmEnable              types.Bool   `tfsdk:"pm_enable"`
-	PowerRedundancyMode   types.String `tfsdk:"power_redundancy_mode"`
-	PtpDomainId           types.Int64  `tfsdk:"ptp_domain_id"`
-	PtpLbId               types.Int64  `tfsdk:"ptp_lb_id"`
-	ScheduledTime         types.String `tfsdk:"scheduled_time"`
-	SnmpServerHostTrap    types.Bool   `tfsdk:"snmp_server_host_trap"`
-	SubinterfaceRange     types.String `tfsdk:"subinterface_range"`
+	AaaRemoteIpEnabled           types.Bool   `tfsdk:"aaa_remote_ip_enabled"`
+	AaaServerConf                types.String `tfsdk:"aaa_server_conf"`
+	AllowNxc                     types.Bool   `tfsdk:"allow_nxc"`
+	AllowNxcPrev                 types.Bool   `tfsdk:"allow_nxc_prev"`
+	BootstrapConf                types.String `tfsdk:"bootstrap_conf"`
+	BootstrapEnable              types.Bool   `tfsdk:"bootstrap_enable"`
+	BootstrapMultisubnet         types.String `tfsdk:"bootstrap_multisubnet"`
+	BootstrapMultisubnetInternal types.String `tfsdk:"bootstrap_multisubnet_internal"`
+	CdpEnable                    types.Bool   `tfsdk:"cdp_enable"`
+	DciSubnetRange               types.String `tfsdk:"dci_subnet_range"`
+	DciSubnetTargetMask          types.Int64  `tfsdk:"dci_subnet_target_mask"`
+	Deploy                       types.Bool   `tfsdk:"deploy"`
+	DeploymentFreeze             types.Bool   `tfsdk:"deployment_freeze"`
+	DeploymentStatus             types.String `tfsdk:"deployment_status"`
+	DhcpEnable                   types.Bool   `tfsdk:"dhcp_enable"`
+	DhcpEnd                      types.String `tfsdk:"dhcp_end"`
+	DhcpEndInternal              types.String `tfsdk:"dhcp_end_internal"`
+	DhcpIpv6Enable               types.String `tfsdk:"dhcp_ipv6_enable"`
+	DhcpIpv6EnableInternal       types.String `tfsdk:"dhcp_ipv6_enable_internal"`
+	DhcpStart                    types.String `tfsdk:"dhcp_start"`
+	DhcpStartInternal            types.String `tfsdk:"dhcp_start_internal"`
+	EnableAaa                    types.Bool   `tfsdk:"enable_aaa"`
+	EnableNetflow                types.Bool   `tfsdk:"enable_netflow"`
+	EnableNetflowPrev            types.Bool   `tfsdk:"enable_netflow_prev"`
+	EnableNxapi                  types.Bool   `tfsdk:"enable_nxapi"`
+	EnableNxapiHttp              types.Bool   `tfsdk:"enable_nxapi_http"`
+	EnableRealTimeBackup         types.Bool   `tfsdk:"enable_real_time_backup"`
+	EnableRtIntfStats            types.Bool   `tfsdk:"enable_rt_intf_stats"`
+	EnableScheduledBackup        types.Bool   `tfsdk:"enable_scheduled_backup"`
+	ExtFabricType                types.String `tfsdk:"ext_fabric_type"`
+	FabricFreeform               types.String `tfsdk:"fabric_freeform"`
+	FabricName                   types.String `tfsdk:"fabric_name"`
+	FabricTechnology             types.String `tfsdk:"fabric_technology"`
+	FabricType                   types.String `tfsdk:"fabric_type"`
+	FeaturePtp                   types.Bool   `tfsdk:"feature_ptp"`
+	FeaturePtpInternal           types.Bool   `tfsdk:"feature_ptp_internal"`
+	Ff                           types.String `tfsdk:"ff"`
+	Id                           types.String `tfsdk:"id"`
+	InbandEnable                 types.Bool   `tfsdk:"inband_enable"`
+	InbandEnablePrev             types.Bool   `tfsdk:"inband_enable_prev"`
+	InbandMgmt                   types.Bool   `tfsdk:"inband_mgmt"`
+	InbandMgmtPrev               types.Bool   `tfsdk:"inband_mgmt_prev"`
+	IntfStatLoadInterval         types.Int64  `tfsdk:"intf_stat_load_interval"`
+	IsReadOnly                   types.Bool   `tfsdk:"is_read_only"`
+	Loopback0IpRange             types.String `tfsdk:"loopback0_ip_range"`
+	MgmtGw                       types.String `tfsdk:"mgmt_gw"`
+	MgmtGwInternal               types.String `tfsdk:"mgmt_gw_internal"`
+	MgmtPrefix                   types.Int64  `tfsdk:"mgmt_prefix"`
+	MgmtPrefixInternal           types.Int64  `tfsdk:"mgmt_prefix_internal"`
+	MgmtV6prefix                 types.Int64  `tfsdk:"mgmt_v6prefix"`
+	MgmtV6prefixInternal         types.Int64  `tfsdk:"mgmt_v6prefix_internal"`
+	MplsHandoff                  types.Bool   `tfsdk:"mpls_handoff"`
+	MplsLbId                     types.Int64  `tfsdk:"mpls_lb_id"`
+	MplsLoopbackIpRange          types.String `tfsdk:"mpls_loopback_ip_range"`
+	NetflowExporterList          types.String `tfsdk:"netflow_exporter_list"`
+	NetflowMonitorList           types.String `tfsdk:"netflow_monitor_list"`
+	NetflowRecordList            types.String `tfsdk:"netflow_record_list"`
+	NetflowSamplerList           types.String `tfsdk:"netflow_sampler_list"`
+	NxapiHttpPort                types.Int64  `tfsdk:"nxapi_http_port"`
+	NxapiHttpsPort               types.Int64  `tfsdk:"nxapi_https_port"`
+	NxcDestVrf                   types.String `tfsdk:"nxc_dest_vrf"`
+	NxcProxyPort                 types.Int64  `tfsdk:"nxc_proxy_port"`
+	NxcProxyServer               types.String `tfsdk:"nxc_proxy_server"`
+	NxcSrcIntf                   types.String `tfsdk:"nxc_src_intf"`
+	OverwriteGlobalNxc           types.Bool   `tfsdk:"overwrite_global_nxc"`
+	PmEnable                     types.Bool   `tfsdk:"pm_enable"`
+	PmEnablePrev                 types.Bool   `tfsdk:"pm_enable_prev"`
+	PowerRedundancyMode          types.String `tfsdk:"power_redundancy_mode"`
+	PtpDomainId                  types.Int64  `tfsdk:"ptp_domain_id"`
+	PtpLbId                      types.Int64  `tfsdk:"ptp_lb_id"`
+	ScheduledTime                types.String `tfsdk:"scheduled_time"`
+	SnmpServerHostTrap           types.Bool   `tfsdk:"snmp_server_host_trap"`
+	SubinterfaceRange            types.String `tfsdk:"subinterface_range"`
 }

--- a/internal/provider/resources/resource_fabric_lan_classic/resource_codec_gen.go
+++ b/internal/provider/resources/resource_fabric_lan_classic/resource_codec_gen.go
@@ -43,6 +43,20 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.AaaServerConf = types.StringNull()
 	}
 
+	if jsonData.AllowNxc != "" {
+		x, _ := strconv.ParseBool(jsonData.AllowNxc)
+		v.AllowNxc = types.BoolValue(x)
+	} else {
+		v.AllowNxc = types.BoolNull()
+	}
+
+	if jsonData.AllowNxcPrev != "" {
+		x, _ := strconv.ParseBool(jsonData.AllowNxcPrev)
+		v.AllowNxcPrev = types.BoolValue(x)
+	} else {
+		v.AllowNxcPrev = types.BoolNull()
+	}
+
 	if jsonData.BootstrapConf != "" {
 		v.BootstrapConf = types.StringValue(jsonData.BootstrapConf)
 	} else {
@@ -62,11 +76,40 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.BootstrapMultisubnet = types.StringNull()
 	}
 
+	if jsonData.BootstrapMultisubnetInternal != "" {
+		v.BootstrapMultisubnetInternal = types.StringValue(jsonData.BootstrapMultisubnetInternal)
+	} else {
+		v.BootstrapMultisubnetInternal = types.StringNull()
+	}
+
 	if jsonData.CdpEnable != "" {
 		x, _ := strconv.ParseBool(jsonData.CdpEnable)
 		v.CdpEnable = types.BoolValue(x)
 	} else {
 		v.CdpEnable = types.BoolNull()
+	}
+
+	if jsonData.DciSubnetRange != "" {
+		v.DciSubnetRange = types.StringValue(jsonData.DciSubnetRange)
+	} else {
+		v.DciSubnetRange = types.StringNull()
+	}
+
+	if jsonData.DciSubnetTargetMask != nil {
+		if jsonData.DciSubnetTargetMask.IsEmpty() {
+			v.DciSubnetTargetMask = types.Int64Null()
+		} else {
+			v.DciSubnetTargetMask = types.Int64Value(int64(*jsonData.DciSubnetTargetMask))
+		}
+	} else {
+		v.DciSubnetTargetMask = types.Int64Null()
+	}
+
+	if jsonData.DeploymentFreeze != "" {
+		x, _ := strconv.ParseBool(jsonData.DeploymentFreeze)
+		v.DeploymentFreeze = types.BoolValue(x)
+	} else {
+		v.DeploymentFreeze = types.BoolNull()
 	}
 
 	if jsonData.DhcpEnable != "" {
@@ -82,16 +125,34 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.DhcpEnd = types.StringNull()
 	}
 
+	if jsonData.DhcpEndInternal != "" {
+		v.DhcpEndInternal = types.StringValue(jsonData.DhcpEndInternal)
+	} else {
+		v.DhcpEndInternal = types.StringNull()
+	}
+
 	if jsonData.DhcpIpv6Enable != "" {
 		v.DhcpIpv6Enable = types.StringValue(jsonData.DhcpIpv6Enable)
 	} else {
 		v.DhcpIpv6Enable = types.StringNull()
 	}
 
+	if jsonData.DhcpIpv6EnableInternal != "" {
+		v.DhcpIpv6EnableInternal = types.StringValue(jsonData.DhcpIpv6EnableInternal)
+	} else {
+		v.DhcpIpv6EnableInternal = types.StringNull()
+	}
+
 	if jsonData.DhcpStart != "" {
 		v.DhcpStart = types.StringValue(jsonData.DhcpStart)
 	} else {
 		v.DhcpStart = types.StringNull()
+	}
+
+	if jsonData.DhcpStartInternal != "" {
+		v.DhcpStartInternal = types.StringValue(jsonData.DhcpStartInternal)
+	} else {
+		v.DhcpStartInternal = types.StringNull()
 	}
 
 	if jsonData.EnableAaa != "" {
@@ -108,6 +169,13 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.EnableNetflow = types.BoolNull()
 	}
 
+	if jsonData.EnableNetflowPrev != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableNetflowPrev)
+		v.EnableNetflowPrev = types.BoolValue(x)
+	} else {
+		v.EnableNetflowPrev = types.BoolNull()
+	}
+
 	if jsonData.EnableNxapi != "" {
 		x, _ := strconv.ParseBool(jsonData.EnableNxapi)
 		v.EnableNxapi = types.BoolValue(x)
@@ -122,10 +190,35 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.EnableNxapiHttp = types.BoolNull()
 	}
 
+	if jsonData.EnableRtIntfStats != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableRtIntfStats)
+		v.EnableRtIntfStats = types.BoolValue(x)
+	} else {
+		v.EnableRtIntfStats = types.BoolNull()
+	}
+
+	if jsonData.ExtFabricType != "" {
+		v.ExtFabricType = types.StringValue(jsonData.ExtFabricType)
+	} else {
+		v.ExtFabricType = types.StringNull()
+	}
+
 	if jsonData.FabricFreeform != "" {
 		v.FabricFreeform = types.StringValue(jsonData.FabricFreeform)
 	} else {
 		v.FabricFreeform = types.StringNull()
+	}
+
+	if jsonData.FabricTechnology != "" {
+		v.FabricTechnology = types.StringValue(jsonData.FabricTechnology)
+	} else {
+		v.FabricTechnology = types.StringNull()
+	}
+
+	if jsonData.FabricType != "" {
+		v.FabricType = types.StringValue(jsonData.FabricType)
+	} else {
+		v.FabricType = types.StringNull()
 	}
 
 	if jsonData.FeaturePtp != "" {
@@ -135,11 +228,31 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.FeaturePtp = types.BoolNull()
 	}
 
+	if jsonData.FeaturePtpInternal != "" {
+		x, _ := strconv.ParseBool(jsonData.FeaturePtpInternal)
+		v.FeaturePtpInternal = types.BoolValue(x)
+	} else {
+		v.FeaturePtpInternal = types.BoolNull()
+	}
+
+	if jsonData.Ff != "" {
+		v.Ff = types.StringValue(jsonData.Ff)
+	} else {
+		v.Ff = types.StringNull()
+	}
+
 	if jsonData.InbandEnable != "" {
 		x, _ := strconv.ParseBool(jsonData.InbandEnable)
 		v.InbandEnable = types.BoolValue(x)
 	} else {
 		v.InbandEnable = types.BoolNull()
+	}
+
+	if jsonData.InbandEnablePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.InbandEnablePrev)
+		v.InbandEnablePrev = types.BoolValue(x)
+	} else {
+		v.InbandEnablePrev = types.BoolNull()
 	}
 
 	if jsonData.InbandMgmt != "" {
@@ -149,6 +262,23 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.InbandMgmt = types.BoolNull()
 	}
 
+	if jsonData.InbandMgmtPrev != "" {
+		x, _ := strconv.ParseBool(jsonData.InbandMgmtPrev)
+		v.InbandMgmtPrev = types.BoolValue(x)
+	} else {
+		v.InbandMgmtPrev = types.BoolNull()
+	}
+
+	if jsonData.IntfStatLoadInterval != nil {
+		if jsonData.IntfStatLoadInterval.IsEmpty() {
+			v.IntfStatLoadInterval = types.Int64Null()
+		} else {
+			v.IntfStatLoadInterval = types.Int64Value(int64(*jsonData.IntfStatLoadInterval))
+		}
+	} else {
+		v.IntfStatLoadInterval = types.Int64Null()
+	}
+
 	if jsonData.IsReadOnly != "" {
 		x, _ := strconv.ParseBool(jsonData.IsReadOnly)
 		v.IsReadOnly = types.BoolValue(x)
@@ -156,10 +286,22 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.IsReadOnly = types.BoolNull()
 	}
 
+	if jsonData.Loopback0IpRange != "" {
+		v.Loopback0IpRange = types.StringValue(jsonData.Loopback0IpRange)
+	} else {
+		v.Loopback0IpRange = types.StringNull()
+	}
+
 	if jsonData.MgmtGw != "" {
 		v.MgmtGw = types.StringValue(jsonData.MgmtGw)
 	} else {
 		v.MgmtGw = types.StringNull()
+	}
+
+	if jsonData.MgmtGwInternal != "" {
+		v.MgmtGwInternal = types.StringValue(jsonData.MgmtGwInternal)
+	} else {
+		v.MgmtGwInternal = types.StringNull()
 	}
 
 	if jsonData.MgmtPrefix != nil {
@@ -172,6 +314,16 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.MgmtPrefix = types.Int64Null()
 	}
 
+	if jsonData.MgmtPrefixInternal != nil {
+		if jsonData.MgmtPrefixInternal.IsEmpty() {
+			v.MgmtPrefixInternal = types.Int64Null()
+		} else {
+			v.MgmtPrefixInternal = types.Int64Value(int64(*jsonData.MgmtPrefixInternal))
+		}
+	} else {
+		v.MgmtPrefixInternal = types.Int64Null()
+	}
+
 	if jsonData.MgmtV6prefix != nil {
 		if jsonData.MgmtV6prefix.IsEmpty() {
 			v.MgmtV6prefix = types.Int64Null()
@@ -180,6 +332,16 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		}
 	} else {
 		v.MgmtV6prefix = types.Int64Null()
+	}
+
+	if jsonData.MgmtV6prefixInternal != nil {
+		if jsonData.MgmtV6prefixInternal.IsEmpty() {
+			v.MgmtV6prefixInternal = types.Int64Null()
+		} else {
+			v.MgmtV6prefixInternal = types.Int64Value(int64(*jsonData.MgmtV6prefixInternal))
+		}
+	} else {
+		v.MgmtV6prefixInternal = types.Int64Null()
 	}
 
 	if jsonData.MplsHandoff != "" {
@@ -249,11 +411,53 @@ func (v *FabricLanClassicModel) SetModelData(jsonData *resource_fabric_common.ND
 		v.NxapiHttpPort = types.Int64Null()
 	}
 
+	if jsonData.NxcDestVrf != "" {
+		v.NxcDestVrf = types.StringValue(jsonData.NxcDestVrf)
+	} else {
+		v.NxcDestVrf = types.StringNull()
+	}
+
+	if jsonData.NxcProxyPort != nil {
+		if jsonData.NxcProxyPort.IsEmpty() {
+			v.NxcProxyPort = types.Int64Null()
+		} else {
+			v.NxcProxyPort = types.Int64Value(int64(*jsonData.NxcProxyPort))
+		}
+	} else {
+		v.NxcProxyPort = types.Int64Null()
+	}
+
+	if jsonData.NxcProxyServer != "" {
+		v.NxcProxyServer = types.StringValue(jsonData.NxcProxyServer)
+	} else {
+		v.NxcProxyServer = types.StringNull()
+	}
+
+	if jsonData.NxcSrcIntf != "" {
+		v.NxcSrcIntf = types.StringValue(jsonData.NxcSrcIntf)
+	} else {
+		v.NxcSrcIntf = types.StringNull()
+	}
+
+	if jsonData.OverwriteGlobalNxc != "" {
+		x, _ := strconv.ParseBool(jsonData.OverwriteGlobalNxc)
+		v.OverwriteGlobalNxc = types.BoolValue(x)
+	} else {
+		v.OverwriteGlobalNxc = types.BoolNull()
+	}
+
 	if jsonData.PmEnable != "" {
 		x, _ := strconv.ParseBool(jsonData.PmEnable)
 		v.PmEnable = types.BoolValue(x)
 	} else {
 		v.PmEnable = types.BoolNull()
+	}
+
+	if jsonData.PmEnablePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.PmEnablePrev)
+		v.PmEnablePrev = types.BoolValue(x)
+	} else {
+		v.PmEnablePrev = types.BoolNull()
 	}
 
 	if jsonData.PowerRedundancyMode != "" {
@@ -348,6 +552,12 @@ func (v FabricLanClassicModel) GetModelData() *resource_fabric_common.NDFCFabric
 		data.AaaServerConf = ""
 	}
 
+	if !v.AllowNxc.IsNull() && !v.AllowNxc.IsUnknown() {
+		data.AllowNxc = strconv.FormatBool(v.AllowNxc.ValueBool())
+	} else {
+		data.AllowNxc = ""
+	}
+
 	if !v.BootstrapConf.IsNull() && !v.BootstrapConf.IsUnknown() {
 		data.BootstrapConf = v.BootstrapConf.ValueString()
 	} else {
@@ -370,6 +580,25 @@ func (v FabricLanClassicModel) GetModelData() *resource_fabric_common.NDFCFabric
 		data.CdpEnable = strconv.FormatBool(v.CdpEnable.ValueBool())
 	} else {
 		data.CdpEnable = ""
+	}
+
+	if !v.DciSubnetRange.IsNull() && !v.DciSubnetRange.IsUnknown() {
+		data.DciSubnetRange = v.DciSubnetRange.ValueString()
+	} else {
+		data.DciSubnetRange = ""
+	}
+
+	if !v.DciSubnetTargetMask.IsNull() && !v.DciSubnetTargetMask.IsUnknown() {
+		data.DciSubnetTargetMask = new(Int64Custom)
+		*data.DciSubnetTargetMask = Int64Custom(v.DciSubnetTargetMask.ValueInt64())
+	} else {
+		data.DciSubnetTargetMask = nil
+	}
+
+	if !v.DeploymentFreeze.IsNull() && !v.DeploymentFreeze.IsUnknown() {
+		data.DeploymentFreeze = strconv.FormatBool(v.DeploymentFreeze.ValueBool())
+	} else {
+		data.DeploymentFreeze = ""
 	}
 
 	if !v.DhcpEnable.IsNull() && !v.DhcpEnable.IsUnknown() {
@@ -420,6 +649,18 @@ func (v FabricLanClassicModel) GetModelData() *resource_fabric_common.NDFCFabric
 		data.EnableNxapiHttp = ""
 	}
 
+	if !v.EnableRtIntfStats.IsNull() && !v.EnableRtIntfStats.IsUnknown() {
+		data.EnableRtIntfStats = strconv.FormatBool(v.EnableRtIntfStats.ValueBool())
+	} else {
+		data.EnableRtIntfStats = ""
+	}
+
+	if !v.ExtFabricType.IsNull() && !v.ExtFabricType.IsUnknown() {
+		data.ExtFabricType = v.ExtFabricType.ValueString()
+	} else {
+		data.ExtFabricType = ""
+	}
+
 	if !v.FabricFreeform.IsNull() && !v.FabricFreeform.IsUnknown() {
 		data.FabricFreeform = v.FabricFreeform.ValueString()
 	} else {
@@ -430,6 +671,12 @@ func (v FabricLanClassicModel) GetModelData() *resource_fabric_common.NDFCFabric
 		data.FeaturePtp = strconv.FormatBool(v.FeaturePtp.ValueBool())
 	} else {
 		data.FeaturePtp = ""
+	}
+
+	if !v.Ff.IsNull() && !v.Ff.IsUnknown() {
+		data.Ff = v.Ff.ValueString()
+	} else {
+		data.Ff = ""
 	}
 
 	if !v.InbandEnable.IsNull() && !v.InbandEnable.IsUnknown() {
@@ -444,10 +691,23 @@ func (v FabricLanClassicModel) GetModelData() *resource_fabric_common.NDFCFabric
 		data.InbandMgmt = ""
 	}
 
+	if !v.IntfStatLoadInterval.IsNull() && !v.IntfStatLoadInterval.IsUnknown() {
+		data.IntfStatLoadInterval = new(Int64Custom)
+		*data.IntfStatLoadInterval = Int64Custom(v.IntfStatLoadInterval.ValueInt64())
+	} else {
+		data.IntfStatLoadInterval = nil
+	}
+
 	if !v.IsReadOnly.IsNull() && !v.IsReadOnly.IsUnknown() {
 		data.IsReadOnly = strconv.FormatBool(v.IsReadOnly.ValueBool())
 	} else {
 		data.IsReadOnly = ""
+	}
+
+	if !v.Loopback0IpRange.IsNull() && !v.Loopback0IpRange.IsUnknown() {
+		data.Loopback0IpRange = v.Loopback0IpRange.ValueString()
+	} else {
+		data.Loopback0IpRange = ""
 	}
 
 	if !v.MgmtGw.IsNull() && !v.MgmtGw.IsUnknown() {
@@ -461,13 +721,6 @@ func (v FabricLanClassicModel) GetModelData() *resource_fabric_common.NDFCFabric
 		*data.MgmtPrefix = Int64Custom(v.MgmtPrefix.ValueInt64())
 	} else {
 		data.MgmtPrefix = nil
-	}
-
-	if !v.MgmtV6prefix.IsNull() && !v.MgmtV6prefix.IsUnknown() {
-		data.MgmtV6prefix = new(Int64Custom)
-		*data.MgmtV6prefix = Int64Custom(v.MgmtV6prefix.ValueInt64())
-	} else {
-		data.MgmtV6prefix = nil
 	}
 
 	if !v.MplsHandoff.IsNull() && !v.MplsHandoff.IsUnknown() {
@@ -525,6 +778,37 @@ func (v FabricLanClassicModel) GetModelData() *resource_fabric_common.NDFCFabric
 		*data.NxapiHttpPort = Int64Custom(v.NxapiHttpPort.ValueInt64())
 	} else {
 		data.NxapiHttpPort = nil
+	}
+
+	if !v.NxcDestVrf.IsNull() && !v.NxcDestVrf.IsUnknown() {
+		data.NxcDestVrf = v.NxcDestVrf.ValueString()
+	} else {
+		data.NxcDestVrf = ""
+	}
+
+	if !v.NxcProxyPort.IsNull() && !v.NxcProxyPort.IsUnknown() {
+		data.NxcProxyPort = new(Int64Custom)
+		*data.NxcProxyPort = Int64Custom(v.NxcProxyPort.ValueInt64())
+	} else {
+		data.NxcProxyPort = nil
+	}
+
+	if !v.NxcProxyServer.IsNull() && !v.NxcProxyServer.IsUnknown() {
+		data.NxcProxyServer = v.NxcProxyServer.ValueString()
+	} else {
+		data.NxcProxyServer = ""
+	}
+
+	if !v.NxcSrcIntf.IsNull() && !v.NxcSrcIntf.IsUnknown() {
+		data.NxcSrcIntf = v.NxcSrcIntf.ValueString()
+	} else {
+		data.NxcSrcIntf = ""
+	}
+
+	if !v.OverwriteGlobalNxc.IsNull() && !v.OverwriteGlobalNxc.IsUnknown() {
+		data.OverwriteGlobalNxc = strconv.FormatBool(v.OverwriteGlobalNxc.ValueBool())
+	} else {
+		data.OverwriteGlobalNxc = ""
 	}
 
 	if !v.PmEnable.IsNull() && !v.PmEnable.IsUnknown() {

--- a/internal/provider/resources/resource_fabric_msite_ext_net/fabric_msite_ext_net_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_msite_ext_net/fabric_msite_ext_net_resource_gen.go
@@ -18,104 +18,181 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"aaa_remote_ip_enabled": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable only, when IP Authorization is enabled in the AAA Server",
 				MarkdownDescription: "Enable only, when IP Authorization is enabled in the AAA Server",
 			},
 			"aaa_server_conf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "AAA Configurations",
 				MarkdownDescription: "AAA Configurations",
 			},
+			"allow_nxc": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Allow onboarding of this fabric to Nexus Cloud",
+				MarkdownDescription: "Allow onboarding of this fabric to Nexus Cloud",
+			},
+			"allow_nxc_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Allow onboarding of this fabric to Nexus Cloud",
+				MarkdownDescription: "Previous state of Allow onboarding of this fabric to Nexus Cloud",
+			},
 			"bgp_as": schema.StringAttribute{
 				Required:            true,
-				Description:         "1-4294967295 | 1-65535.0-65535 It is a good practice to have a unique ASN for each Fabric.",
-				MarkdownDescription: "1-4294967295 | 1-65535.0-65535 It is a good practice to have a unique ASN for each Fabric.",
+				Description:         "1-4294967295 | 1-65535.0-65535. It is a good practice to have a unique ASN for each Fabric.",
+				MarkdownDescription: "1-4294967295 | 1-65535.0-65535. It is a good practice to have a unique ASN for each Fabric.",
 			},
 			"bootstrap_conf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional CLIs required during device bootup/login e.g. AAA/Radius",
 				MarkdownDescription: "Additional CLIs required during device bootup/login e.g. AAA/Radius",
 			},
 			"bootstrap_conf_xe": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional CLIs required during device bootup/login e.g. AAA/Radius",
 				MarkdownDescription: "Additional CLIs required during device bootup/login e.g. AAA/Radius",
 			},
 			"bootstrap_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "Automatic IP Assignment For POAP",
-				MarkdownDescription: "Automatic IP Assignment For POAP",
+				Computed:            true,
+				Description:         "Automatic IP Assignment For POAP (For NX-OS and IOS XE (Cat9K) Switches Only)",
+				MarkdownDescription: "Automatic IP Assignment For POAP (For NX-OS and IOS XE (Cat9K) Switches Only)",
 			},
 			"bootstrap_multisubnet": schema.StringAttribute{
 				Optional:            true,
-				Description:         "lines with # prefix are ignored here",
-				MarkdownDescription: "lines with # prefix are ignored here",
+				Computed:            true,
+				Description:         "\"DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here\"",
+				MarkdownDescription: "\"DHCPv4 Multi Subnet Scope - lines with # prefix are ignored here\"",
+			},
+			"bootstrap_multisubnet_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal Bootstrap Multi Subnet Scope",
+				MarkdownDescription: "Internal Bootstrap Multi Subnet Scope",
 			},
 			"cdp_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable CDP on management interface",
 				MarkdownDescription: "Enable CDP on management interface",
+			},
+			"dci_subnet_range": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Address range to assign P2P DCI Links",
+				MarkdownDescription: "Address range to assign P2P DCI Links",
+			},
+			"dci_subnet_target_mask": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Target Mask for Subnet Range (Min:8, Max:31)",
+				MarkdownDescription: "Target Mask for Subnet Range (Min:8, Max:31)",
 			},
 			"deploy": schema.BoolAttribute{
 				Required:            true,
 				Description:         "This flag does configuration save and deploy",
 				MarkdownDescription: "This flag does configuration save and deploy",
 			},
+			"deployment_freeze": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Disable all deployments in this fabric",
+				MarkdownDescription: "Disable all deployments in this fabric",
+			},
 			"deployment_status": schema.StringAttribute{
+				Optional:            true,
 				Computed:            true,
 				Description:         "This fields shows the actual status of the deployment. It can be one of the following: Deployment pending Deployment successful",
 				MarkdownDescription: "This fields shows the actual status of the deployment. It can be one of the following: Deployment pending Deployment successful",
 			},
 			"dhcp_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Automatic IP Assignment For POAP From Local DHCP Server",
 				MarkdownDescription: "Automatic IP Assignment For POAP From Local DHCP Server",
 			},
 			"dhcp_end": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "End Address For Switch POAP",
 				MarkdownDescription: "End Address For Switch POAP",
 			},
+			"dhcp_end_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP End Address",
+				MarkdownDescription: "Internal DHCP End Address",
+			},
 			"dhcp_ipv6_enable": schema.StringAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "DHCP Version",
+				MarkdownDescription: "DHCP Version",
 				Validators: []validator.String{
 					stringvalidator.OneOf("DHCPv4", "DHCPv6"),
 				},
 			},
+			"dhcp_ipv6_enable_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP IPv6 Enable",
+				MarkdownDescription: "Internal DHCP IPv6 Enable",
+			},
 			"dhcp_start": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Start Address For Switch POAP",
 				MarkdownDescription: "Start Address For Switch POAP",
 			},
+			"dhcp_start_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal DHCP Start Address",
+				MarkdownDescription: "Internal DHCP Start Address",
+			},
 			"domain_name": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Domain name for DHCP server PnP block",
 				MarkdownDescription: "Domain name for DHCP server PnP block",
 			},
+			"domain_name_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal Domain Name",
+				MarkdownDescription: "Internal Domain Name",
+			},
 			"enable_aaa": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Include AAA configs from Advanced tab during device bootup",
 				MarkdownDescription: "Include AAA configs from Advanced tab during device bootup",
 			},
 			"enable_netflow": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable Netflow on VTEPs",
 				MarkdownDescription: "Enable Netflow on VTEPs",
 			},
+			"enable_netflow_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable Netflow on VTEPs",
+				MarkdownDescription: "Previous state of Enable Netflow on VTEPs",
+			},
 			"enable_nxapi": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable HTTPS NX-API",
 				MarkdownDescription: "Enable HTTPS NX-API",
 			},
 			"enable_nxapi_http": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable HTTP NX-API",
+				MarkdownDescription: "Enable HTTP NX-API",
 			},
 			"enable_real_time_backup": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Backup hourly only if there is any config deployment since last backup",
 				MarkdownDescription: "Backup hourly only if there is any config deployment since last backup",
 			},
@@ -127,26 +204,51 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"enable_scheduled_backup": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Backup at the specified time",
 				MarkdownDescription: "Backup at the specified time",
 			},
+			"ext_fabric_type": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "External Fabric Type",
+				MarkdownDescription: "External Fabric Type",
+			},
 			"fabric_freeform": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Additional supported CLIs for all same OS (e.g. all NxOS or IOS-XE, etc) switches",
 				MarkdownDescription: "Additional supported CLIs for all same OS (e.g. all NxOS or IOS-XE, etc) switches",
 			},
 			"fabric_name": schema.StringAttribute{
 				Required:            true,
-				Description:         "Fabric name to be created, updated or deleted (Max Size 64).",
-				MarkdownDescription: "Fabric name to be created, updated or deleted (Max Size 64).",
+				Description:         "Fabric name to be created, updated or deleted.",
+				MarkdownDescription: "Fabric name to be created, updated or deleted.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"fabric_type": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Fabric Type",
+				MarkdownDescription: "Fabric Type",
+			},
 			"feature_ptp": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable Precision Time Protocol (PTP)",
+				MarkdownDescription: "Enable Precision Time Protocol (PTP)",
+			},
+			"feature_ptp_internal": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Internal Feature PTP",
+				MarkdownDescription: "Internal Feature PTP",
+			},
+			"ff": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Template Family",
+				MarkdownDescription: "Template Family",
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -155,182 +257,335 @@ func FabricMsiteExtNetResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"inband_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should be Enabled)",
 				MarkdownDescription: "Enable POAP over Inband Interface (Pre-req: Inband Mgmt Knob should be Enabled)",
 			},
+			"inband_enable_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable POAP over Inband Interface",
+				MarkdownDescription: "Previous state of Enable POAP over Inband Interface",
+			},
 			"inband_mgmt": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Import switches with inband connectivity",
 				MarkdownDescription: "Import switches with inband connectivity",
 			},
+			"inband_mgmt_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Inband Management",
+				MarkdownDescription: "Previous state of Inband Management",
+			},
 			"intf_stat_load_interval": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Time in seconds",
 				MarkdownDescription: "Time in seconds",
 			},
 			"is_read_only": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "If enabled, fabric is only monitored. No configuration will be deployed",
 				MarkdownDescription: "If enabled, fabric is only monitored. No configuration will be deployed",
 			},
+			"loopback0_ip_range": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Underlay Routing Loopback IP Range",
+				MarkdownDescription: "Underlay Routing Loopback IP Range",
+			},
 			"mgmt_gw": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Gateway For Management VRF On The Switch",
 				MarkdownDescription: "Default Gateway For Management VRF On The Switch",
 			},
+			"mgmt_gw_internal": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Internal Management Gateway",
+				MarkdownDescription: "Internal Management Gateway",
+			},
 			"mgmt_prefix": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Switch Mgmt IP Subnet Prefix",
+				MarkdownDescription: "Switch Mgmt IP Subnet Prefix",
+			},
+			"mgmt_prefix_internal": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Internal Management Prefix",
+				MarkdownDescription: "Internal Management Prefix",
 			},
 			"mgmt_v6prefix": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)",
+				MarkdownDescription: "Switch Mgmt IPv6 Subnet Prefix (Min:64, Max:126)",
+			},
+			"mgmt_v6prefix_internal": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Internal Management IPv6 Prefix",
+				MarkdownDescription: "Internal Management IPv6 Prefix",
 			},
 			"mpls_handoff": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable MPLS Handoff",
+				MarkdownDescription: "Enable MPLS Handoff",
 			},
 			"mpls_lb_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "(Min:0, Max:1023)",
+				MarkdownDescription: "(Min:0, Max:1023)",
 			},
 			"mpls_loopback_ip_range": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "MPLS Loopback IP Address Range",
 				MarkdownDescription: "MPLS Loopback IP Address Range",
 			},
+			"mso_connectivity_deployed": schema.StringAttribute{
+				Computed:            true,
+				Description:         "MSO Connectivity Deployed",
+				MarkdownDescription: "MSO Connectivity Deployed",
+			},
+			"mso_controler_id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "MSO Controller ID",
+				MarkdownDescription: "MSO Controller ID",
+			},
+			"mso_site_group_name": schema.StringAttribute{
+				Computed:            true,
+				Description:         "MSO Site Group Name",
+				MarkdownDescription: "MSO Site Group Name",
+			},
+			"mso_site_id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "MSO Site ID",
+				MarkdownDescription: "MSO Site ID",
+			},
 			"netflow_exporter_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One or Multiple Netflow Exporters",
 				MarkdownDescription: "One or Multiple Netflow Exporters",
 			},
 			"netflow_monitor_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One or Multiple Netflow Monitors",
 				MarkdownDescription: "One or Multiple Netflow Monitors",
 			},
 			"netflow_record_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One or Multiple Netflow Records",
 				MarkdownDescription: "One or Multiple Netflow Records",
 			},
 			"netflow_sampler_list": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "One or multiple netflow Samplers. Applicable to N7K only",
 				MarkdownDescription: "One or multiple netflow Samplers. Applicable to N7K only",
 			},
 			"nxapi_http_port": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "NX-API HTTP Port Number",
+				MarkdownDescription: "NX-API HTTP Port Number",
 			},
 			"nxapi_https_port": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "NX-API HTTPS Port Number",
+				MarkdownDescription: "NX-API HTTPS Port Number",
+			},
+			"nxc_dest_vrf": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "VRF to be used to reach Nexus Cloud, enter 'management' for management VRF and 'default' for default VRF",
+				MarkdownDescription: "VRF to be used to reach Nexus Cloud, enter 'management' for management VRF and 'default' for default VRF",
+			},
+			"nxc_proxy_port": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Proxy port number, default is 8080",
+				MarkdownDescription: "Proxy port number, default is 8080",
+			},
+			"nxc_proxy_server": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "IPv4 or IPv6 address, or DNS name of the proxy server",
+				MarkdownDescription: "IPv4 or IPv6 address, or DNS name of the proxy server",
+			},
+			"nxc_src_intf": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Source interface for communication to Nexus Cloud, mandatory if Destination VRF is not management",
+				MarkdownDescription: "Source interface for communication to Nexus Cloud, mandatory if Destination VRF is not management",
+			},
+			"overwrite_global_nxc": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "If enabled, Fabric NxCloud Settings will be used",
+				MarkdownDescription: "If enabled, Fabric NxCloud Settings will be used",
 			},
 			"pm_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Enable Performance Monitoring (For NX-OS and IOS XE Switches Only)",
+				MarkdownDescription: "Enable Performance Monitoring (For NX-OS and IOS XE Switches Only)",
+			},
+			"pm_enable_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable Performance Monitoring",
+				MarkdownDescription: "Previous state of Enable Performance Monitoring",
 			},
 			"pnp_enable": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable Plug n Play (Automatic IP Assignment) for Cat9K switches",
 				MarkdownDescription: "Enable Plug n Play (Automatic IP Assignment) for Cat9K switches",
 			},
+			"pnp_enable_internal": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Internal PnP Enable",
+				MarkdownDescription: "Internal PnP Enable",
+			},
 			"power_redundancy_mode": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Power Supply Mode For Bootstrapped NX-OS Switches",
 				MarkdownDescription: "Default Power Supply Mode For Bootstrapped NX-OS Switches",
 				Validators: []validator.String{
 					stringvalidator.OneOf("ps-redundant", "combined", "insrc-redundant"),
 				},
 			},
+			"premso_parent_fabric": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Pre-MSO Parent Fabric",
+				MarkdownDescription: "Pre-MSO Parent Fabric",
+			},
 			"ptp_domain_id": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Multiple Independent PTP Clocking Subdomains on a Single Network",
 				MarkdownDescription: "Multiple Independent PTP Clocking Subdomains on a Single Network",
 			},
 			"ptp_lb_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "(Min:0, Max:1023)",
+				MarkdownDescription: "(Min:0, Max:1023)",
 			},
 			"scheduled_time": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Time (UTC) in 24hr format. (00:00 to 23:59)",
 				MarkdownDescription: "Time (UTC) in 24hr format. (00:00 to 23:59)",
 			},
 			"snmp_server_host_trap": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Configure NDFC as a receiver for SNMP traps",
 				MarkdownDescription: "Configure NDFC as a receiver for SNMP traps",
 			},
 			"subinterface_range": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Per Border Dot1q Range For VRF Lite Connectivity",
-				MarkdownDescription: "Per Border Dot1q Range For VRF Lite Connectivity",
+				Computed:            true,
+				Description:         "Per Border Dot1q Range For VRF Lite Connectivity (Min:2, Max:4093)",
+				MarkdownDescription: "Per Border Dot1q Range For VRF Lite Connectivity (Min:2, Max:4093)",
 			},
 		},
-		Description:         "Resource to configure an Multi-Site Network Fabric",
-		MarkdownDescription: "Resource to configure an Multi-Site Network Fabric",
+		Description:         "Resource to configure an Multi-Site Network Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.",
+		MarkdownDescription: "Resource to configure an Multi-Site Network Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.",
 	}
 }
 
 type FabricMsiteExtNetModel struct {
-	AaaRemoteIpEnabled    types.Bool   `tfsdk:"aaa_remote_ip_enabled"`
-	AaaServerConf         types.String `tfsdk:"aaa_server_conf"`
-	BgpAs                 types.String `tfsdk:"bgp_as"`
-	BootstrapConf         types.String `tfsdk:"bootstrap_conf"`
-	BootstrapConfXe       types.String `tfsdk:"bootstrap_conf_xe"`
-	BootstrapEnable       types.Bool   `tfsdk:"bootstrap_enable"`
-	BootstrapMultisubnet  types.String `tfsdk:"bootstrap_multisubnet"`
-	CdpEnable             types.Bool   `tfsdk:"cdp_enable"`
-	Deploy                types.Bool   `tfsdk:"deploy"`
-	DeploymentStatus      types.String `tfsdk:"deployment_status"`
-	DhcpEnable            types.Bool   `tfsdk:"dhcp_enable"`
-	DhcpEnd               types.String `tfsdk:"dhcp_end"`
-	DhcpIpv6Enable        types.String `tfsdk:"dhcp_ipv6_enable"`
-	DhcpStart             types.String `tfsdk:"dhcp_start"`
-	DomainName            types.String `tfsdk:"domain_name"`
-	EnableAaa             types.Bool   `tfsdk:"enable_aaa"`
-	EnableNetflow         types.Bool   `tfsdk:"enable_netflow"`
-	EnableNxapi           types.Bool   `tfsdk:"enable_nxapi"`
-	EnableNxapiHttp       types.Bool   `tfsdk:"enable_nxapi_http"`
-	EnableRealTimeBackup  types.Bool   `tfsdk:"enable_real_time_backup"`
-	EnableRtIntfStats     types.Bool   `tfsdk:"enable_rt_intf_stats"`
-	EnableScheduledBackup types.Bool   `tfsdk:"enable_scheduled_backup"`
-	FabricFreeform        types.String `tfsdk:"fabric_freeform"`
-	FabricName            types.String `tfsdk:"fabric_name"`
-	FeaturePtp            types.Bool   `tfsdk:"feature_ptp"`
-	Id                    types.String `tfsdk:"id"`
-	InbandEnable          types.Bool   `tfsdk:"inband_enable"`
-	InbandMgmt            types.Bool   `tfsdk:"inband_mgmt"`
-	IntfStatLoadInterval  types.Int64  `tfsdk:"intf_stat_load_interval"`
-	IsReadOnly            types.Bool   `tfsdk:"is_read_only"`
-	MgmtGw                types.String `tfsdk:"mgmt_gw"`
-	MgmtPrefix            types.Int64  `tfsdk:"mgmt_prefix"`
-	MgmtV6prefix          types.Int64  `tfsdk:"mgmt_v6prefix"`
-	MplsHandoff           types.Bool   `tfsdk:"mpls_handoff"`
-	MplsLbId              types.Int64  `tfsdk:"mpls_lb_id"`
-	MplsLoopbackIpRange   types.String `tfsdk:"mpls_loopback_ip_range"`
-	NetflowExporterList   types.String `tfsdk:"netflow_exporter_list"`
-	NetflowMonitorList    types.String `tfsdk:"netflow_monitor_list"`
-	NetflowRecordList     types.String `tfsdk:"netflow_record_list"`
-	NetflowSamplerList    types.String `tfsdk:"netflow_sampler_list"`
-	NxapiHttpPort         types.Int64  `tfsdk:"nxapi_http_port"`
-	NxapiHttpsPort        types.Int64  `tfsdk:"nxapi_https_port"`
-	PmEnable              types.Bool   `tfsdk:"pm_enable"`
-	PnpEnable             types.Bool   `tfsdk:"pnp_enable"`
-	PowerRedundancyMode   types.String `tfsdk:"power_redundancy_mode"`
-	PtpDomainId           types.Int64  `tfsdk:"ptp_domain_id"`
-	PtpLbId               types.Int64  `tfsdk:"ptp_lb_id"`
-	ScheduledTime         types.String `tfsdk:"scheduled_time"`
-	SnmpServerHostTrap    types.Bool   `tfsdk:"snmp_server_host_trap"`
-	SubinterfaceRange     types.String `tfsdk:"subinterface_range"`
+	AaaRemoteIpEnabled           types.Bool   `tfsdk:"aaa_remote_ip_enabled"`
+	AaaServerConf                types.String `tfsdk:"aaa_server_conf"`
+	AllowNxc                     types.Bool   `tfsdk:"allow_nxc"`
+	AllowNxcPrev                 types.Bool   `tfsdk:"allow_nxc_prev"`
+	BgpAs                        types.String `tfsdk:"bgp_as"`
+	BootstrapConf                types.String `tfsdk:"bootstrap_conf"`
+	BootstrapConfXe              types.String `tfsdk:"bootstrap_conf_xe"`
+	BootstrapEnable              types.Bool   `tfsdk:"bootstrap_enable"`
+	BootstrapMultisubnet         types.String `tfsdk:"bootstrap_multisubnet"`
+	BootstrapMultisubnetInternal types.String `tfsdk:"bootstrap_multisubnet_internal"`
+	CdpEnable                    types.Bool   `tfsdk:"cdp_enable"`
+	DciSubnetRange               types.String `tfsdk:"dci_subnet_range"`
+	DciSubnetTargetMask          types.Int64  `tfsdk:"dci_subnet_target_mask"`
+	Deploy                       types.Bool   `tfsdk:"deploy"`
+	DeploymentFreeze             types.Bool   `tfsdk:"deployment_freeze"`
+	DeploymentStatus             types.String `tfsdk:"deployment_status"`
+	DhcpEnable                   types.Bool   `tfsdk:"dhcp_enable"`
+	DhcpEnd                      types.String `tfsdk:"dhcp_end"`
+	DhcpEndInternal              types.String `tfsdk:"dhcp_end_internal"`
+	DhcpIpv6Enable               types.String `tfsdk:"dhcp_ipv6_enable"`
+	DhcpIpv6EnableInternal       types.String `tfsdk:"dhcp_ipv6_enable_internal"`
+	DhcpStart                    types.String `tfsdk:"dhcp_start"`
+	DhcpStartInternal            types.String `tfsdk:"dhcp_start_internal"`
+	DomainName                   types.String `tfsdk:"domain_name"`
+	DomainNameInternal           types.String `tfsdk:"domain_name_internal"`
+	EnableAaa                    types.Bool   `tfsdk:"enable_aaa"`
+	EnableNetflow                types.Bool   `tfsdk:"enable_netflow"`
+	EnableNetflowPrev            types.Bool   `tfsdk:"enable_netflow_prev"`
+	EnableNxapi                  types.Bool   `tfsdk:"enable_nxapi"`
+	EnableNxapiHttp              types.Bool   `tfsdk:"enable_nxapi_http"`
+	EnableRealTimeBackup         types.Bool   `tfsdk:"enable_real_time_backup"`
+	EnableRtIntfStats            types.Bool   `tfsdk:"enable_rt_intf_stats"`
+	EnableScheduledBackup        types.Bool   `tfsdk:"enable_scheduled_backup"`
+	ExtFabricType                types.String `tfsdk:"ext_fabric_type"`
+	FabricFreeform               types.String `tfsdk:"fabric_freeform"`
+	FabricName                   types.String `tfsdk:"fabric_name"`
+	FabricType                   types.String `tfsdk:"fabric_type"`
+	FeaturePtp                   types.Bool   `tfsdk:"feature_ptp"`
+	FeaturePtpInternal           types.Bool   `tfsdk:"feature_ptp_internal"`
+	Ff                           types.String `tfsdk:"ff"`
+	Id                           types.String `tfsdk:"id"`
+	InbandEnable                 types.Bool   `tfsdk:"inband_enable"`
+	InbandEnablePrev             types.Bool   `tfsdk:"inband_enable_prev"`
+	InbandMgmt                   types.Bool   `tfsdk:"inband_mgmt"`
+	InbandMgmtPrev               types.Bool   `tfsdk:"inband_mgmt_prev"`
+	IntfStatLoadInterval         types.Int64  `tfsdk:"intf_stat_load_interval"`
+	IsReadOnly                   types.Bool   `tfsdk:"is_read_only"`
+	Loopback0IpRange             types.String `tfsdk:"loopback0_ip_range"`
+	MgmtGw                       types.String `tfsdk:"mgmt_gw"`
+	MgmtGwInternal               types.String `tfsdk:"mgmt_gw_internal"`
+	MgmtPrefix                   types.Int64  `tfsdk:"mgmt_prefix"`
+	MgmtPrefixInternal           types.Int64  `tfsdk:"mgmt_prefix_internal"`
+	MgmtV6prefix                 types.Int64  `tfsdk:"mgmt_v6prefix"`
+	MgmtV6prefixInternal         types.Int64  `tfsdk:"mgmt_v6prefix_internal"`
+	MplsHandoff                  types.Bool   `tfsdk:"mpls_handoff"`
+	MplsLbId                     types.Int64  `tfsdk:"mpls_lb_id"`
+	MplsLoopbackIpRange          types.String `tfsdk:"mpls_loopback_ip_range"`
+	MsoConnectivityDeployed      types.String `tfsdk:"mso_connectivity_deployed"`
+	MsoControlerId               types.String `tfsdk:"mso_controler_id"`
+	MsoSiteGroupName             types.String `tfsdk:"mso_site_group_name"`
+	MsoSiteId                    types.String `tfsdk:"mso_site_id"`
+	NetflowExporterList          types.String `tfsdk:"netflow_exporter_list"`
+	NetflowMonitorList           types.String `tfsdk:"netflow_monitor_list"`
+	NetflowRecordList            types.String `tfsdk:"netflow_record_list"`
+	NetflowSamplerList           types.String `tfsdk:"netflow_sampler_list"`
+	NxapiHttpPort                types.Int64  `tfsdk:"nxapi_http_port"`
+	NxapiHttpsPort               types.Int64  `tfsdk:"nxapi_https_port"`
+	NxcDestVrf                   types.String `tfsdk:"nxc_dest_vrf"`
+	NxcProxyPort                 types.Int64  `tfsdk:"nxc_proxy_port"`
+	NxcProxyServer               types.String `tfsdk:"nxc_proxy_server"`
+	NxcSrcIntf                   types.String `tfsdk:"nxc_src_intf"`
+	OverwriteGlobalNxc           types.Bool   `tfsdk:"overwrite_global_nxc"`
+	PmEnable                     types.Bool   `tfsdk:"pm_enable"`
+	PmEnablePrev                 types.Bool   `tfsdk:"pm_enable_prev"`
+	PnpEnable                    types.Bool   `tfsdk:"pnp_enable"`
+	PnpEnableInternal            types.Bool   `tfsdk:"pnp_enable_internal"`
+	PowerRedundancyMode          types.String `tfsdk:"power_redundancy_mode"`
+	PremsoParentFabric           types.String `tfsdk:"premso_parent_fabric"`
+	PtpDomainId                  types.Int64  `tfsdk:"ptp_domain_id"`
+	PtpLbId                      types.Int64  `tfsdk:"ptp_lb_id"`
+	ScheduledTime                types.String `tfsdk:"scheduled_time"`
+	SnmpServerHostTrap           types.Bool   `tfsdk:"snmp_server_host_trap"`
+	SubinterfaceRange            types.String `tfsdk:"subinterface_range"`
 }

--- a/internal/provider/resources/resource_fabric_msite_ext_net/resource_codec_gen.go
+++ b/internal/provider/resources/resource_fabric_msite_ext_net/resource_codec_gen.go
@@ -43,6 +43,20 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.AaaServerConf = types.StringNull()
 	}
 
+	if jsonData.AllowNxc != "" {
+		x, _ := strconv.ParseBool(jsonData.AllowNxc)
+		v.AllowNxc = types.BoolValue(x)
+	} else {
+		v.AllowNxc = types.BoolNull()
+	}
+
+	if jsonData.AllowNxcPrev != "" {
+		x, _ := strconv.ParseBool(jsonData.AllowNxcPrev)
+		v.AllowNxcPrev = types.BoolValue(x)
+	} else {
+		v.AllowNxcPrev = types.BoolNull()
+	}
+
 	if jsonData.BgpAs != "" {
 		v.BgpAs = types.StringValue(jsonData.BgpAs)
 	} else {
@@ -74,11 +88,40 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.BootstrapMultisubnet = types.StringNull()
 	}
 
+	if jsonData.BootstrapMultisubnetInternal != "" {
+		v.BootstrapMultisubnetInternal = types.StringValue(jsonData.BootstrapMultisubnetInternal)
+	} else {
+		v.BootstrapMultisubnetInternal = types.StringNull()
+	}
+
 	if jsonData.CdpEnable != "" {
 		x, _ := strconv.ParseBool(jsonData.CdpEnable)
 		v.CdpEnable = types.BoolValue(x)
 	} else {
 		v.CdpEnable = types.BoolNull()
+	}
+
+	if jsonData.DciSubnetRange != "" {
+		v.DciSubnetRange = types.StringValue(jsonData.DciSubnetRange)
+	} else {
+		v.DciSubnetRange = types.StringNull()
+	}
+
+	if jsonData.DciSubnetTargetMask != nil {
+		if jsonData.DciSubnetTargetMask.IsEmpty() {
+			v.DciSubnetTargetMask = types.Int64Null()
+		} else {
+			v.DciSubnetTargetMask = types.Int64Value(int64(*jsonData.DciSubnetTargetMask))
+		}
+	} else {
+		v.DciSubnetTargetMask = types.Int64Null()
+	}
+
+	if jsonData.DeploymentFreeze != "" {
+		x, _ := strconv.ParseBool(jsonData.DeploymentFreeze)
+		v.DeploymentFreeze = types.BoolValue(x)
+	} else {
+		v.DeploymentFreeze = types.BoolNull()
 	}
 
 	if jsonData.DhcpEnable != "" {
@@ -94,10 +137,22 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.DhcpEnd = types.StringNull()
 	}
 
+	if jsonData.DhcpEndInternal != "" {
+		v.DhcpEndInternal = types.StringValue(jsonData.DhcpEndInternal)
+	} else {
+		v.DhcpEndInternal = types.StringNull()
+	}
+
 	if jsonData.DhcpIpv6Enable != "" {
 		v.DhcpIpv6Enable = types.StringValue(jsonData.DhcpIpv6Enable)
 	} else {
 		v.DhcpIpv6Enable = types.StringNull()
+	}
+
+	if jsonData.DhcpIpv6EnableInternal != "" {
+		v.DhcpIpv6EnableInternal = types.StringValue(jsonData.DhcpIpv6EnableInternal)
+	} else {
+		v.DhcpIpv6EnableInternal = types.StringNull()
 	}
 
 	if jsonData.DhcpStart != "" {
@@ -106,10 +161,22 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.DhcpStart = types.StringNull()
 	}
 
+	if jsonData.DhcpStartInternal != "" {
+		v.DhcpStartInternal = types.StringValue(jsonData.DhcpStartInternal)
+	} else {
+		v.DhcpStartInternal = types.StringNull()
+	}
+
 	if jsonData.DomainName != "" {
 		v.DomainName = types.StringValue(jsonData.DomainName)
 	} else {
 		v.DomainName = types.StringNull()
+	}
+
+	if jsonData.DomainNameInternal != "" {
+		v.DomainNameInternal = types.StringValue(jsonData.DomainNameInternal)
+	} else {
+		v.DomainNameInternal = types.StringNull()
 	}
 
 	if jsonData.EnableAaa != "" {
@@ -124,6 +191,13 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.EnableNetflow = types.BoolValue(x)
 	} else {
 		v.EnableNetflow = types.BoolNull()
+	}
+
+	if jsonData.EnableNetflowPrev != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableNetflowPrev)
+		v.EnableNetflowPrev = types.BoolValue(x)
+	} else {
+		v.EnableNetflowPrev = types.BoolNull()
 	}
 
 	if jsonData.EnableNxapi != "" {
@@ -147,10 +221,22 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.EnableRtIntfStats = types.BoolNull()
 	}
 
+	if jsonData.ExtFabricType != "" {
+		v.ExtFabricType = types.StringValue(jsonData.ExtFabricType)
+	} else {
+		v.ExtFabricType = types.StringNull()
+	}
+
 	if jsonData.FabricFreeform != "" {
 		v.FabricFreeform = types.StringValue(jsonData.FabricFreeform)
 	} else {
 		v.FabricFreeform = types.StringNull()
+	}
+
+	if jsonData.FabricType != "" {
+		v.FabricType = types.StringValue(jsonData.FabricType)
+	} else {
+		v.FabricType = types.StringNull()
 	}
 
 	if jsonData.FeaturePtp != "" {
@@ -160,6 +246,19 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.FeaturePtp = types.BoolNull()
 	}
 
+	if jsonData.FeaturePtpInternal != "" {
+		x, _ := strconv.ParseBool(jsonData.FeaturePtpInternal)
+		v.FeaturePtpInternal = types.BoolValue(x)
+	} else {
+		v.FeaturePtpInternal = types.BoolNull()
+	}
+
+	if jsonData.Ff != "" {
+		v.Ff = types.StringValue(jsonData.Ff)
+	} else {
+		v.Ff = types.StringNull()
+	}
+
 	if jsonData.InbandEnable != "" {
 		x, _ := strconv.ParseBool(jsonData.InbandEnable)
 		v.InbandEnable = types.BoolValue(x)
@@ -167,11 +266,25 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.InbandEnable = types.BoolNull()
 	}
 
+	if jsonData.InbandEnablePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.InbandEnablePrev)
+		v.InbandEnablePrev = types.BoolValue(x)
+	} else {
+		v.InbandEnablePrev = types.BoolNull()
+	}
+
 	if jsonData.InbandMgmt != "" {
 		x, _ := strconv.ParseBool(jsonData.InbandMgmt)
 		v.InbandMgmt = types.BoolValue(x)
 	} else {
 		v.InbandMgmt = types.BoolNull()
+	}
+
+	if jsonData.InbandMgmtPrev != "" {
+		x, _ := strconv.ParseBool(jsonData.InbandMgmtPrev)
+		v.InbandMgmtPrev = types.BoolValue(x)
+	} else {
+		v.InbandMgmtPrev = types.BoolNull()
 	}
 
 	if jsonData.IntfStatLoadInterval != nil {
@@ -191,10 +304,22 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.IsReadOnly = types.BoolNull()
 	}
 
+	if jsonData.Loopback0IpRange != "" {
+		v.Loopback0IpRange = types.StringValue(jsonData.Loopback0IpRange)
+	} else {
+		v.Loopback0IpRange = types.StringNull()
+	}
+
 	if jsonData.MgmtGw != "" {
 		v.MgmtGw = types.StringValue(jsonData.MgmtGw)
 	} else {
 		v.MgmtGw = types.StringNull()
+	}
+
+	if jsonData.MgmtGwInternal != "" {
+		v.MgmtGwInternal = types.StringValue(jsonData.MgmtGwInternal)
+	} else {
+		v.MgmtGwInternal = types.StringNull()
 	}
 
 	if jsonData.MgmtPrefix != nil {
@@ -207,6 +332,16 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.MgmtPrefix = types.Int64Null()
 	}
 
+	if jsonData.MgmtPrefixInternal != nil {
+		if jsonData.MgmtPrefixInternal.IsEmpty() {
+			v.MgmtPrefixInternal = types.Int64Null()
+		} else {
+			v.MgmtPrefixInternal = types.Int64Value(int64(*jsonData.MgmtPrefixInternal))
+		}
+	} else {
+		v.MgmtPrefixInternal = types.Int64Null()
+	}
+
 	if jsonData.MgmtV6prefix != nil {
 		if jsonData.MgmtV6prefix.IsEmpty() {
 			v.MgmtV6prefix = types.Int64Null()
@@ -215,6 +350,16 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		}
 	} else {
 		v.MgmtV6prefix = types.Int64Null()
+	}
+
+	if jsonData.MgmtV6prefixInternal != nil {
+		if jsonData.MgmtV6prefixInternal.IsEmpty() {
+			v.MgmtV6prefixInternal = types.Int64Null()
+		} else {
+			v.MgmtV6prefixInternal = types.Int64Value(int64(*jsonData.MgmtV6prefixInternal))
+		}
+	} else {
+		v.MgmtV6prefixInternal = types.Int64Null()
 	}
 
 	if jsonData.MplsHandoff != "" {
@@ -238,6 +383,30 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.MplsLoopbackIpRange = types.StringValue(jsonData.MplsLoopbackIpRange)
 	} else {
 		v.MplsLoopbackIpRange = types.StringNull()
+	}
+
+	if jsonData.MsoConnectivityDeployed != "" {
+		v.MsoConnectivityDeployed = types.StringValue(jsonData.MsoConnectivityDeployed)
+	} else {
+		v.MsoConnectivityDeployed = types.StringNull()
+	}
+
+	if jsonData.MsoControlerId != "" {
+		v.MsoControlerId = types.StringValue(jsonData.MsoControlerId)
+	} else {
+		v.MsoControlerId = types.StringNull()
+	}
+
+	if jsonData.MsoSiteGroupName != "" {
+		v.MsoSiteGroupName = types.StringValue(jsonData.MsoSiteGroupName)
+	} else {
+		v.MsoSiteGroupName = types.StringNull()
+	}
+
+	if jsonData.MsoSiteId != "" {
+		v.MsoSiteId = types.StringValue(jsonData.MsoSiteId)
+	} else {
+		v.MsoSiteId = types.StringNull()
 	}
 
 	if jsonData.NetflowExporterList != "" {
@@ -284,11 +453,53 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.NxapiHttpPort = types.Int64Null()
 	}
 
+	if jsonData.NxcDestVrf != "" {
+		v.NxcDestVrf = types.StringValue(jsonData.NxcDestVrf)
+	} else {
+		v.NxcDestVrf = types.StringNull()
+	}
+
+	if jsonData.NxcProxyPort != nil {
+		if jsonData.NxcProxyPort.IsEmpty() {
+			v.NxcProxyPort = types.Int64Null()
+		} else {
+			v.NxcProxyPort = types.Int64Value(int64(*jsonData.NxcProxyPort))
+		}
+	} else {
+		v.NxcProxyPort = types.Int64Null()
+	}
+
+	if jsonData.NxcProxyServer != "" {
+		v.NxcProxyServer = types.StringValue(jsonData.NxcProxyServer)
+	} else {
+		v.NxcProxyServer = types.StringNull()
+	}
+
+	if jsonData.NxcSrcIntf != "" {
+		v.NxcSrcIntf = types.StringValue(jsonData.NxcSrcIntf)
+	} else {
+		v.NxcSrcIntf = types.StringNull()
+	}
+
+	if jsonData.OverwriteGlobalNxc != "" {
+		x, _ := strconv.ParseBool(jsonData.OverwriteGlobalNxc)
+		v.OverwriteGlobalNxc = types.BoolValue(x)
+	} else {
+		v.OverwriteGlobalNxc = types.BoolNull()
+	}
+
 	if jsonData.PmEnable != "" {
 		x, _ := strconv.ParseBool(jsonData.PmEnable)
 		v.PmEnable = types.BoolValue(x)
 	} else {
 		v.PmEnable = types.BoolNull()
+	}
+
+	if jsonData.PmEnablePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.PmEnablePrev)
+		v.PmEnablePrev = types.BoolValue(x)
+	} else {
+		v.PmEnablePrev = types.BoolNull()
 	}
 
 	if jsonData.PnpEnable != "" {
@@ -298,10 +509,23 @@ func (v *FabricMsiteExtNetModel) SetModelData(jsonData *resource_fabric_common.N
 		v.PnpEnable = types.BoolNull()
 	}
 
+	if jsonData.PnpEnableInternal != "" {
+		x, _ := strconv.ParseBool(jsonData.PnpEnableInternal)
+		v.PnpEnableInternal = types.BoolValue(x)
+	} else {
+		v.PnpEnableInternal = types.BoolNull()
+	}
+
 	if jsonData.PowerRedundancyMode != "" {
 		v.PowerRedundancyMode = types.StringValue(jsonData.PowerRedundancyMode)
 	} else {
 		v.PowerRedundancyMode = types.StringNull()
+	}
+
+	if jsonData.PremsoParentFabric != "" {
+		v.PremsoParentFabric = types.StringValue(jsonData.PremsoParentFabric)
+	} else {
+		v.PremsoParentFabric = types.StringNull()
 	}
 
 	if jsonData.PtpDomainId != nil {
@@ -390,6 +614,12 @@ func (v FabricMsiteExtNetModel) GetModelData() *resource_fabric_common.NDFCFabri
 		data.AaaServerConf = ""
 	}
 
+	if !v.AllowNxc.IsNull() && !v.AllowNxc.IsUnknown() {
+		data.AllowNxc = strconv.FormatBool(v.AllowNxc.ValueBool())
+	} else {
+		data.AllowNxc = ""
+	}
+
 	if !v.BgpAs.IsNull() && !v.BgpAs.IsUnknown() {
 		data.BgpAs = v.BgpAs.ValueString()
 	} else {
@@ -424,6 +654,25 @@ func (v FabricMsiteExtNetModel) GetModelData() *resource_fabric_common.NDFCFabri
 		data.CdpEnable = strconv.FormatBool(v.CdpEnable.ValueBool())
 	} else {
 		data.CdpEnable = ""
+	}
+
+	if !v.DciSubnetRange.IsNull() && !v.DciSubnetRange.IsUnknown() {
+		data.DciSubnetRange = v.DciSubnetRange.ValueString()
+	} else {
+		data.DciSubnetRange = ""
+	}
+
+	if !v.DciSubnetTargetMask.IsNull() && !v.DciSubnetTargetMask.IsUnknown() {
+		data.DciSubnetTargetMask = new(Int64Custom)
+		*data.DciSubnetTargetMask = Int64Custom(v.DciSubnetTargetMask.ValueInt64())
+	} else {
+		data.DciSubnetTargetMask = nil
+	}
+
+	if !v.DeploymentFreeze.IsNull() && !v.DeploymentFreeze.IsUnknown() {
+		data.DeploymentFreeze = strconv.FormatBool(v.DeploymentFreeze.ValueBool())
+	} else {
+		data.DeploymentFreeze = ""
 	}
 
 	if !v.DhcpEnable.IsNull() && !v.DhcpEnable.IsUnknown() {
@@ -486,6 +735,12 @@ func (v FabricMsiteExtNetModel) GetModelData() *resource_fabric_common.NDFCFabri
 		data.EnableRtIntfStats = ""
 	}
 
+	if !v.ExtFabricType.IsNull() && !v.ExtFabricType.IsUnknown() {
+		data.ExtFabricType = v.ExtFabricType.ValueString()
+	} else {
+		data.ExtFabricType = ""
+	}
+
 	if !v.FabricFreeform.IsNull() && !v.FabricFreeform.IsUnknown() {
 		data.FabricFreeform = v.FabricFreeform.ValueString()
 	} else {
@@ -496,6 +751,12 @@ func (v FabricMsiteExtNetModel) GetModelData() *resource_fabric_common.NDFCFabri
 		data.FeaturePtp = strconv.FormatBool(v.FeaturePtp.ValueBool())
 	} else {
 		data.FeaturePtp = ""
+	}
+
+	if !v.Ff.IsNull() && !v.Ff.IsUnknown() {
+		data.Ff = v.Ff.ValueString()
+	} else {
+		data.Ff = ""
 	}
 
 	if !v.InbandEnable.IsNull() && !v.InbandEnable.IsUnknown() {
@@ -521,6 +782,12 @@ func (v FabricMsiteExtNetModel) GetModelData() *resource_fabric_common.NDFCFabri
 		data.IsReadOnly = strconv.FormatBool(v.IsReadOnly.ValueBool())
 	} else {
 		data.IsReadOnly = ""
+	}
+
+	if !v.Loopback0IpRange.IsNull() && !v.Loopback0IpRange.IsUnknown() {
+		data.Loopback0IpRange = v.Loopback0IpRange.ValueString()
+	} else {
+		data.Loopback0IpRange = ""
 	}
 
 	if !v.MgmtGw.IsNull() && !v.MgmtGw.IsUnknown() {
@@ -600,6 +867,37 @@ func (v FabricMsiteExtNetModel) GetModelData() *resource_fabric_common.NDFCFabri
 		data.NxapiHttpPort = nil
 	}
 
+	if !v.NxcDestVrf.IsNull() && !v.NxcDestVrf.IsUnknown() {
+		data.NxcDestVrf = v.NxcDestVrf.ValueString()
+	} else {
+		data.NxcDestVrf = ""
+	}
+
+	if !v.NxcProxyPort.IsNull() && !v.NxcProxyPort.IsUnknown() {
+		data.NxcProxyPort = new(Int64Custom)
+		*data.NxcProxyPort = Int64Custom(v.NxcProxyPort.ValueInt64())
+	} else {
+		data.NxcProxyPort = nil
+	}
+
+	if !v.NxcProxyServer.IsNull() && !v.NxcProxyServer.IsUnknown() {
+		data.NxcProxyServer = v.NxcProxyServer.ValueString()
+	} else {
+		data.NxcProxyServer = ""
+	}
+
+	if !v.NxcSrcIntf.IsNull() && !v.NxcSrcIntf.IsUnknown() {
+		data.NxcSrcIntf = v.NxcSrcIntf.ValueString()
+	} else {
+		data.NxcSrcIntf = ""
+	}
+
+	if !v.OverwriteGlobalNxc.IsNull() && !v.OverwriteGlobalNxc.IsUnknown() {
+		data.OverwriteGlobalNxc = strconv.FormatBool(v.OverwriteGlobalNxc.ValueBool())
+	} else {
+		data.OverwriteGlobalNxc = ""
+	}
+
 	if !v.PmEnable.IsNull() && !v.PmEnable.IsUnknown() {
 		data.PmEnable = strconv.FormatBool(v.PmEnable.ValueBool())
 	} else {
@@ -664,6 +962,12 @@ func (v FabricMsiteExtNetModel) GetModelData() *resource_fabric_common.NDFCFabri
 
 	if !v.Deploy.IsNull() && !v.Deploy.IsUnknown() {
 		data.Deploy = v.Deploy.ValueBool()
+	}
+
+	if !v.DeploymentStatus.IsNull() && !v.DeploymentStatus.IsUnknown() {
+		data.DeploymentStatus = v.DeploymentStatus.ValueString()
+	} else {
+		data.DeploymentStatus = ""
 	}
 
 	return data

--- a/internal/provider/resources/resource_fabric_vxlan_msd/fabric_vxlan_msd_resource_gen.go
+++ b/internal/provider/resources/resource_fabric_vxlan_msd/fabric_vxlan_msd_resource_gen.go
@@ -19,21 +19,30 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"anycast_gw_mac": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Shared MAC address for all leaves",
-				MarkdownDescription: "Shared MAC address for all leaves",
+				Computed:            true,
+				Description:         "Shared MAC address for all leafs",
+				MarkdownDescription: "Shared MAC address for all leafs",
 			},
 			"bgp_rp_asn": schema.StringAttribute{
 				Optional:            true,
-				Description:         "1-4294967295 | 1-65535.0-65535, e.g. 65000, 65001",
-				MarkdownDescription: "1-4294967295 | 1-65535.0-65535, e.g. 65000, 65001",
+				Computed:            true,
+				Description:         "1-4294967295 | 1-65535[.0-65535], e.g. 65000, 65001",
+				MarkdownDescription: "1-4294967295 | 1-65535[.0-65535], e.g. 65000, 65001",
 			},
 			"bgw_routing_tag": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Routing tag associated with IP address of loopback and DCI interfaces",
 				MarkdownDescription: "Routing tag associated with IP address of loopback and DCI interfaces",
 			},
+			"bgw_routing_tag_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of Border Gateway Routing Tag",
+				MarkdownDescription: "Previous state of Border Gateway Routing Tag",
+			},
 			"border_gwy_connections": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Manual, Auto Overlay EVPN Peering to Route Servers, Auto Overlay EVPN Direct Peering to Border Gateways",
 				MarkdownDescription: "Manual, Auto Overlay EVPN Peering to Route Servers, Auto Overlay EVPN Direct Peering to Border Gateways",
 				Validators: []validator.String{
@@ -42,41 +51,60 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"cloudsec_algorithm": schema.StringAttribute{
 				Optional:            true,
-				Description:         "AES_128_CMAC or AES_256_CMAC",
-				MarkdownDescription: "AES_128_CMAC or AES_256_CMAC",
+				Computed:            true,
+				Description:         "CloudSec Cryptographic Algorithm",
+				MarkdownDescription: "CloudSec Cryptographic Algorithm",
+				Validators: []validator.String{
+					stringvalidator.OneOf("AES_128_CMAC", "AES_256_CMAC"),
+				},
 			},
 			"cloudsec_autoconfig": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Auto Config CloudSec on Border Gateways",
 				MarkdownDescription: "Auto Config CloudSec on Border Gateways",
 			},
 			"cloudsec_enforcement": schema.StringAttribute{
 				Optional:            true,
-				Description:         "If set to strict, data across site must be encrypted.",
-				MarkdownDescription: "If set to strict, data across site must be encrypted.",
+				Computed:            true,
+				Description:         "If set to 'strict', data across site must be encrypted.",
+				MarkdownDescription: "If set to 'strict', data across site must be encrypted.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("strict", "loose"),
+				},
 			},
 			"cloudsec_key_string": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Cisco Type 7 Encrypted Octet String",
 				MarkdownDescription: "Cisco Type 7 Encrypted Octet String",
 			},
 			"cloudsec_report_timer": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "CloudSec Operational Status periodic report timer in minutes",
 				MarkdownDescription: "CloudSec Operational Status periodic report timer in minutes",
 			},
 			"dci_subnet_range": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Address range to assign P2P DCI Links",
 				MarkdownDescription: "Address range to assign P2P DCI Links",
 			},
 			"dci_subnet_target_mask": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "Target Mask for Subnet Range",
-				MarkdownDescription: "Target Mask for Subnet Range",
+				Computed:            true,
+				Description:         "Target Mask for Subnet Range (Min:8, Max:31)",
+				MarkdownDescription: "Target Mask for Subnet Range (Min:8, Max:31)",
+			},
+			"dcnm_id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "DCNM ID",
+				MarkdownDescription: "DCNM ID",
 			},
 			"default_network": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Overlay Network Template For Leafs",
 				MarkdownDescription: "Default Overlay Network Template For Leafs",
 				Validators: []validator.String{
@@ -85,16 +113,19 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"default_pvlan_sec_network": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default PVLAN Secondary Network Template",
 				MarkdownDescription: "Default PVLAN Secondary Network Template",
 			},
 			"default_vrf": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Overlay VRF Template For Leafs",
 				MarkdownDescription: "Default Overlay VRF Template For Leafs",
 			},
 			"delay_restore": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Multi-Site underlay and overlay control plane convergence time in seconds",
 				MarkdownDescription: "Multi-Site underlay and overlay control plane convergence time in seconds",
 			},
@@ -110,41 +141,97 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"enable_bgp_bfd": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "For auto-created Multi-Site Underlay IFCs",
-				MarkdownDescription: "For auto-created Multi-Site Underlay IFCs",
+				Computed:            true,
+				Description:         "BGP BFD on Multi-Site Underlay IFCs",
+				MarkdownDescription: "BGP BFD on Multi-Site Underlay IFCs",
 			},
 			"enable_bgp_log_neighbor_change": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "For auto-created Multi-Site Underlay IFCs",
-				MarkdownDescription: "For auto-created Multi-Site Underlay IFCs",
+				Computed:            true,
+				Description:         "BGP log neighbor change on Multi-Site Underlay IFCs",
+				MarkdownDescription: "BGP log neighbor change on Multi-Site Underlay IFCs",
 			},
 			"enable_bgp_send_comm": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "For auto-created Multi-Site Underlay IFCs",
-				MarkdownDescription: "For auto-created Multi-Site Underlay IFCs",
+				Computed:            true,
+				Description:         "BGP Send-community on Multi-Site Underlay IFCs",
+				MarkdownDescription: "BGP Send-community on Multi-Site Underlay IFCs",
 			},
 			"enable_pvlan": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enable PVLAN on MSD and its child fabrics",
 				MarkdownDescription: "Enable PVLAN on MSD and its child fabrics",
 			},
+			"enable_pvlan_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable PVLAN",
+				MarkdownDescription: "Previous state of Enable PVLAN",
+			},
 			"enable_rs_redist_direct": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "For auto-created Multi-Site overlay IFCs in Route Servers. Applicable only when Multi-Site Overlay IFC Deployment Method is Centralized_To_Route_Server.",
 				MarkdownDescription: "For auto-created Multi-Site overlay IFCs in Route Servers. Applicable only when Multi-Site Overlay IFC Deployment Method is Centralized_To_Route_Server.",
 			},
 			"enable_scheduled_backup": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Backup at the specified time. Note: Fabric Backup/Restore functionality is being deprecated for MSD fabrics. Recommendation is to use NDFC Backup & Restore",
 				MarkdownDescription: "Backup at the specified time. Note: Fabric Backup/Restore functionality is being deprecated for MSD fabrics. Recommendation is to use NDFC Backup & Restore",
 			},
+			"enable_sgt": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Enable Security Groups",
+				MarkdownDescription: "Enable Security Groups",
+				Validators: []validator.String{
+					stringvalidator.OneOf("off", "strict"),
+				},
+			},
+			"enable_sgt_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable Security Groups",
+				MarkdownDescription: "Previous state of Enable Security Groups",
+				Validators: []validator.String{
+					stringvalidator.OneOf("off", "strict"),
+				},
+			},
+			"enable_trm_trmv6": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites",
+				MarkdownDescription: "Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites",
+			},
+			"enable_trm_trmv6_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites",
+				MarkdownDescription: "Previous state of Enable IPv4 and/or IPv6 Tenant Routed Multicast across sites",
+			},
+			"ext_fabric_type": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "External Fabric Type",
+				MarkdownDescription: "External Fabric Type",
+			},
 			"fabric_name": schema.StringAttribute{
 				Required:            true,
-				Description:         "Fabric name to be created, updated or deleted (Max Size 64).",
-				MarkdownDescription: "Fabric name to be created, updated or deleted (Max Size 64).",
+				Description:         "Fabric name to be created, updated or deleted.",
+				MarkdownDescription: "Fabric name to be created, updated or deleted.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"fabric_type": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Fabric Type",
+				MarkdownDescription: "Fabric Type",
+			},
+			"ff": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Template Family",
+				MarkdownDescription: "Template Family",
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -153,80 +240,210 @@ func FabricVxlanMsdResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"l2_segment_id_range": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Overlay Network Identifier Range",
 				MarkdownDescription: "Overlay Network Identifier Range",
 			},
 			"l3_partition_id_range": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Overlay VRF Identifier Range",
 				MarkdownDescription: "Overlay VRF Identifier Range",
 			},
 			"loopback100_ip_range": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Typically Loopback100 IP Address Range",
-				MarkdownDescription: "Typically Loopback100 IP Address Range",
+				Computed:            true,
+				Description:         "Multi-Site VTEP VIP Loopback IP Range",
+				MarkdownDescription: "Multi-Site VTEP VIP Loopback IP Range",
+			},
+			"loopback100_ipv6_range": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Multi-Site VTEP VIP Loopback IPv6 Range",
+				MarkdownDescription: "Multi-Site VTEP VIP Loopback IPv6 Range",
 			},
 			"ms_ifc_bgp_auth_key_type": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "BGP Key Encryption Type: 3 - 3DES, 7 - Cisco",
 				MarkdownDescription: "BGP Key Encryption Type: 3 - 3DES, 7 - Cisco",
 				Validators: []validator.Int64{
 					int64validator.OneOf(3, 7),
 				},
 			},
+			"ms_ifc_bgp_auth_key_type_prev": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "BGP Key Encryption Type: 3 - 3DES, 7 - Cisco",
+				MarkdownDescription: "BGP Key Encryption Type: 3 - 3DES, 7 - Cisco",
+			},
 			"ms_ifc_bgp_password": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Encrypted eBGP Password Hex String",
 				MarkdownDescription: "Encrypted eBGP Password Hex String",
 			},
 			"ms_ifc_bgp_password_enable": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "eBGP password for Multi-Site underlay/overlay IFCs",
-				MarkdownDescription: "eBGP password for Multi-Site underlay/overlay IFCs",
+				Computed:            true,
+				Description:         "Enable Multi-Site eBGP Password",
+				MarkdownDescription: "Enable Multi-Site eBGP Password",
+			},
+			"ms_ifc_bgp_password_enable_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Enable Multi-Site eBGP Password",
+				MarkdownDescription: "Previous state of Enable Multi-Site eBGP Password",
+			},
+			"ms_ifc_bgp_password_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of eBGP Password",
+				MarkdownDescription: "Previous state of eBGP Password",
 			},
 			"ms_loopback_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Multi-Site VTEP VIP Loopback ID",
+				MarkdownDescription: "Multi-Site VTEP VIP Loopback ID",
 			},
 			"ms_underlay_autoconfig": schema.BoolAttribute{
 				Optional:            true,
-				Description:         "No description available",
-				MarkdownDescription: "No description available",
+				Computed:            true,
+				Description:         "Multi-Site Underlay IFC Auto Deployment Flag",
+				MarkdownDescription: "Multi-Site Underlay IFC Auto Deployment Flag",
+			},
+			"mso_controler_id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "MSO Controller ID",
+				MarkdownDescription: "MSO Controller ID",
+			},
+			"mso_site_group_name": schema.StringAttribute{
+				Computed:            true,
+				Description:         "MSO Site Group Name",
+				MarkdownDescription: "MSO Site Group Name",
 			},
 			"network_extension_template": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Overlay Network Template For Borders",
 				MarkdownDescription: "Default Overlay Network Template For Borders",
 			},
+			"parent_onemanage_fabric": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Parent OneManage Fabric",
+				MarkdownDescription: "Parent OneManage Fabric",
+			},
+			"premso_parent_fabric": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Pre-MSO Parent Fabric",
+				MarkdownDescription: "Pre-MSO Parent Fabric",
+			},
 			"rp_server_ip": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Multi-Site Route-Server peer list (typically loopback IP address on Route-Server for Multi-Site EVPN peering with BGWs), e.g. 128.89.0.1, 128.89.0.2",
 				MarkdownDescription: "Multi-Site Route-Server peer list (typically loopback IP address on Route-Server for Multi-Site EVPN peering with BGWs), e.g. 128.89.0.1, 128.89.0.2",
 			},
 			"rs_routing_tag": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Routing tag associated with Route Server IP for redistribute direct. This is the IP used in eBGP EVPN peering.",
 				MarkdownDescription: "Routing tag associated with Route Server IP for redistribute direct. This is the IP used in eBGP EVPN peering.",
 			},
 			"scheduled_time": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Time (UTC) in 24hr format. (00:00 to 23:59)",
 				MarkdownDescription: "Time (UTC) in 24hr format. (00:00 to 23:59)",
 			},
+			"sgt_id_range": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Security Group Tag (SGT) ID Range",
+				MarkdownDescription: "Security Group Tag (SGT) ID Range",
+			},
+			"sgt_id_range_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of Security Group Tag (SGT) ID Range",
+				MarkdownDescription: "Previous state of Security Group Tag (SGT) ID Range",
+			},
+			"sgt_name_prefix": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Prefix to be used when a new Security Group is created.",
+				MarkdownDescription: "Prefix to be used when a new Security Group is created.",
+			},
+			"sgt_name_prefix_prev": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Previous state of Security Group Name Prefix",
+				MarkdownDescription: "Previous state of Security Group Name Prefix",
+			},
+			"sgt_oper_status": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Operational status for Security Groups",
+				MarkdownDescription: "Operational status for Security Groups",
+				Validators: []validator.String{
+					stringvalidator.OneOf("on", "off"),
+				},
+			},
+			"sgt_preprov_recalc_status": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Recalculation status for Security Groups Pre-provision",
+				MarkdownDescription: "Recalculation status for Security Groups Pre-provision",
+				Validators: []validator.String{
+					stringvalidator.OneOf("start", "empty", "completed"),
+				},
+			},
+			"sgt_preprovision": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Generate security groups configuration for non-enforced VRFs",
+				MarkdownDescription: "Generate security groups configuration for non-enforced VRFs",
+			},
+			"sgt_preprovision_prev": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Previous state of Security Groups Pre-provision",
+				MarkdownDescription: "Previous state of Security Groups Pre-provision",
+			},
+			"sgt_recalc_status": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Recalculation status for Security Groups",
+				MarkdownDescription: "Recalculation status for Security Groups",
+				Validators: []validator.String{
+					stringvalidator.OneOf("start", "empty", "completed"),
+				},
+			},
 			"tor_auto_deploy": schema.BoolAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Enables Overlay VLANs on uplink between ToRs and Leafs",
 				MarkdownDescription: "Enables Overlay VLANs on uplink between ToRs and Leafs",
 			},
+			"v6_dci_subnet_range": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Address range to assign P2P DCI Links",
+				MarkdownDescription: "Address range to assign P2P DCI Links",
+			},
+			"v6_dci_subnet_target_mask": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Target IPv6 Mask for Subnet Range (Min:120, Max:127)",
+				MarkdownDescription: "Target IPv6 Mask for Subnet Range (Min:120, Max:127)",
+			},
 			"vrf_extension_template": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Default Overlay VRF Template For Borders",
 				MarkdownDescription: "Default Overlay VRF Template For Borders",
 			},
+			"vxlan_underlay_is_v6": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "If not enabled, IPv4 underlay is used in child VXLAN fabric",
+				MarkdownDescription: "If not enabled, IPv4 underlay is used in child VXLAN fabric",
+			},
 		},
-		Description:         "Resource to configure and manage a VXLAN MSD Fabric",
-		MarkdownDescription: "Resource to configure and manage a VXLAN MSD Fabric",
+		Description:         "Resource to configure and manage a VXLAN MSD Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.",
+		MarkdownDescription: "Resource to configure and manage a VXLAN MSD Fabric. Only creation/updation/deletion of the fabric is supported, resources on top of the fabric are not supported yet.",
 	}
 }
 
@@ -234,6 +451,7 @@ type FabricVxlanMsdModel struct {
 	AnycastGwMac               types.String `tfsdk:"anycast_gw_mac"`
 	BgpRpAsn                   types.String `tfsdk:"bgp_rp_asn"`
 	BgwRoutingTag              types.Int64  `tfsdk:"bgw_routing_tag"`
+	BgwRoutingTagPrev          types.String `tfsdk:"bgw_routing_tag_prev"`
 	BorderGwyConnections       types.String `tfsdk:"border_gwy_connections"`
 	CloudsecAlgorithm          types.String `tfsdk:"cloudsec_algorithm"`
 	CloudsecAutoconfig         types.Bool   `tfsdk:"cloudsec_autoconfig"`
@@ -242,6 +460,7 @@ type FabricVxlanMsdModel struct {
 	CloudsecReportTimer        types.Int64  `tfsdk:"cloudsec_report_timer"`
 	DciSubnetRange             types.String `tfsdk:"dci_subnet_range"`
 	DciSubnetTargetMask        types.Int64  `tfsdk:"dci_subnet_target_mask"`
+	DcnmId                     types.String `tfsdk:"dcnm_id"`
 	DefaultNetwork             types.String `tfsdk:"default_network"`
 	DefaultPvlanSecNetwork     types.String `tfsdk:"default_pvlan_sec_network"`
 	DefaultVrf                 types.String `tfsdk:"default_vrf"`
@@ -252,22 +471,50 @@ type FabricVxlanMsdModel struct {
 	EnableBgpLogNeighborChange types.Bool   `tfsdk:"enable_bgp_log_neighbor_change"`
 	EnableBgpSendComm          types.Bool   `tfsdk:"enable_bgp_send_comm"`
 	EnablePvlan                types.Bool   `tfsdk:"enable_pvlan"`
+	EnablePvlanPrev            types.Bool   `tfsdk:"enable_pvlan_prev"`
 	EnableRsRedistDirect       types.Bool   `tfsdk:"enable_rs_redist_direct"`
 	EnableScheduledBackup      types.Bool   `tfsdk:"enable_scheduled_backup"`
+	EnableSgt                  types.String `tfsdk:"enable_sgt"`
+	EnableSgtPrev              types.String `tfsdk:"enable_sgt_prev"`
+	EnableTrmTrmv6             types.Bool   `tfsdk:"enable_trm_trmv6"`
+	EnableTrmTrmv6Prev         types.Bool   `tfsdk:"enable_trm_trmv6_prev"`
+	ExtFabricType              types.String `tfsdk:"ext_fabric_type"`
 	FabricName                 types.String `tfsdk:"fabric_name"`
+	FabricType                 types.String `tfsdk:"fabric_type"`
+	Ff                         types.String `tfsdk:"ff"`
 	Id                         types.String `tfsdk:"id"`
 	L2SegmentIdRange           types.String `tfsdk:"l2_segment_id_range"`
 	L3PartitionIdRange         types.String `tfsdk:"l3_partition_id_range"`
 	Loopback100IpRange         types.String `tfsdk:"loopback100_ip_range"`
+	Loopback100Ipv6Range       types.String `tfsdk:"loopback100_ipv6_range"`
 	MsIfcBgpAuthKeyType        types.Int64  `tfsdk:"ms_ifc_bgp_auth_key_type"`
+	MsIfcBgpAuthKeyTypePrev    types.Int64  `tfsdk:"ms_ifc_bgp_auth_key_type_prev"`
 	MsIfcBgpPassword           types.String `tfsdk:"ms_ifc_bgp_password"`
 	MsIfcBgpPasswordEnable     types.Bool   `tfsdk:"ms_ifc_bgp_password_enable"`
+	MsIfcBgpPasswordEnablePrev types.Bool   `tfsdk:"ms_ifc_bgp_password_enable_prev"`
+	MsIfcBgpPasswordPrev       types.String `tfsdk:"ms_ifc_bgp_password_prev"`
 	MsLoopbackId               types.Int64  `tfsdk:"ms_loopback_id"`
 	MsUnderlayAutoconfig       types.Bool   `tfsdk:"ms_underlay_autoconfig"`
+	MsoControlerId             types.String `tfsdk:"mso_controler_id"`
+	MsoSiteGroupName           types.String `tfsdk:"mso_site_group_name"`
 	NetworkExtensionTemplate   types.String `tfsdk:"network_extension_template"`
+	ParentOnemanageFabric      types.String `tfsdk:"parent_onemanage_fabric"`
+	PremsoParentFabric         types.String `tfsdk:"premso_parent_fabric"`
 	RpServerIp                 types.String `tfsdk:"rp_server_ip"`
 	RsRoutingTag               types.Int64  `tfsdk:"rs_routing_tag"`
 	ScheduledTime              types.String `tfsdk:"scheduled_time"`
+	SgtIdRange                 types.String `tfsdk:"sgt_id_range"`
+	SgtIdRangePrev             types.String `tfsdk:"sgt_id_range_prev"`
+	SgtNamePrefix              types.String `tfsdk:"sgt_name_prefix"`
+	SgtNamePrefixPrev          types.String `tfsdk:"sgt_name_prefix_prev"`
+	SgtOperStatus              types.String `tfsdk:"sgt_oper_status"`
+	SgtPreprovRecalcStatus     types.String `tfsdk:"sgt_preprov_recalc_status"`
+	SgtPreprovision            types.Bool   `tfsdk:"sgt_preprovision"`
+	SgtPreprovisionPrev        types.Bool   `tfsdk:"sgt_preprovision_prev"`
+	SgtRecalcStatus            types.String `tfsdk:"sgt_recalc_status"`
 	TorAutoDeploy              types.Bool   `tfsdk:"tor_auto_deploy"`
+	V6DciSubnetRange           types.String `tfsdk:"v6_dci_subnet_range"`
+	V6DciSubnetTargetMask      types.Int64  `tfsdk:"v6_dci_subnet_target_mask"`
 	VrfExtensionTemplate       types.String `tfsdk:"vrf_extension_template"`
+	VxlanUnderlayIsV6          types.Bool   `tfsdk:"vxlan_underlay_is_v6"`
 }

--- a/internal/provider/resources/resource_fabric_vxlan_msd/resource_codec_gen.go
+++ b/internal/provider/resources/resource_fabric_vxlan_msd/resource_codec_gen.go
@@ -52,6 +52,12 @@ func (v *FabricVxlanMsdModel) SetModelData(jsonData *resource_fabric_common.NDFC
 		v.BgwRoutingTag = types.Int64Null()
 	}
 
+	if jsonData.BgwRoutingTagPrev != "" {
+		v.BgwRoutingTagPrev = types.StringValue(jsonData.BgwRoutingTagPrev)
+	} else {
+		v.BgwRoutingTagPrev = types.StringNull()
+	}
+
 	if jsonData.BorderGwyConnections != "" {
 		v.BorderGwyConnections = types.StringValue(jsonData.BorderGwyConnections)
 	} else {
@@ -109,6 +115,12 @@ func (v *FabricVxlanMsdModel) SetModelData(jsonData *resource_fabric_common.NDFC
 		v.DciSubnetTargetMask = types.Int64Null()
 	}
 
+	if jsonData.DcnmId != "" {
+		v.DcnmId = types.StringValue(jsonData.DcnmId)
+	} else {
+		v.DcnmId = types.StringNull()
+	}
+
 	if jsonData.DelayRestore != nil {
 		if jsonData.DelayRestore.IsEmpty() {
 			v.DelayRestore = types.Int64Null()
@@ -147,11 +159,62 @@ func (v *FabricVxlanMsdModel) SetModelData(jsonData *resource_fabric_common.NDFC
 		v.EnablePvlan = types.BoolNull()
 	}
 
+	if jsonData.EnablePvlanPrev != "" {
+		x, _ := strconv.ParseBool(jsonData.EnablePvlanPrev)
+		v.EnablePvlanPrev = types.BoolValue(x)
+	} else {
+		v.EnablePvlanPrev = types.BoolNull()
+	}
+
 	if jsonData.EnableRsRedistDirect != "" {
 		x, _ := strconv.ParseBool(jsonData.EnableRsRedistDirect)
 		v.EnableRsRedistDirect = types.BoolValue(x)
 	} else {
 		v.EnableRsRedistDirect = types.BoolNull()
+	}
+
+	if jsonData.EnableSgt != "" {
+		v.EnableSgt = types.StringValue(jsonData.EnableSgt)
+	} else {
+		v.EnableSgt = types.StringNull()
+	}
+
+	if jsonData.EnableSgtPrev != "" {
+		v.EnableSgtPrev = types.StringValue(jsonData.EnableSgtPrev)
+	} else {
+		v.EnableSgtPrev = types.StringNull()
+	}
+
+	if jsonData.EnableTrmTrmv6 != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableTrmTrmv6)
+		v.EnableTrmTrmv6 = types.BoolValue(x)
+	} else {
+		v.EnableTrmTrmv6 = types.BoolNull()
+	}
+
+	if jsonData.EnableTrmTrmv6Prev != "" {
+		x, _ := strconv.ParseBool(jsonData.EnableTrmTrmv6Prev)
+		v.EnableTrmTrmv6Prev = types.BoolValue(x)
+	} else {
+		v.EnableTrmTrmv6Prev = types.BoolNull()
+	}
+
+	if jsonData.ExtFabricType != "" {
+		v.ExtFabricType = types.StringValue(jsonData.ExtFabricType)
+	} else {
+		v.ExtFabricType = types.StringNull()
+	}
+
+	if jsonData.FabricType != "" {
+		v.FabricType = types.StringValue(jsonData.FabricType)
+	} else {
+		v.FabricType = types.StringNull()
+	}
+
+	if jsonData.Ff != "" {
+		v.Ff = types.StringValue(jsonData.Ff)
+	} else {
+		v.Ff = types.StringNull()
 	}
 
 	if jsonData.L2SegmentIdRange != "" {
@@ -166,10 +229,28 @@ func (v *FabricVxlanMsdModel) SetModelData(jsonData *resource_fabric_common.NDFC
 		v.L3PartitionIdRange = types.StringNull()
 	}
 
+	if jsonData.Loopback100Ipv6Range != "" {
+		v.Loopback100Ipv6Range = types.StringValue(jsonData.Loopback100Ipv6Range)
+	} else {
+		v.Loopback100Ipv6Range = types.StringNull()
+	}
+
 	if jsonData.Loopback100IpRange != "" {
 		v.Loopback100IpRange = types.StringValue(jsonData.Loopback100IpRange)
 	} else {
 		v.Loopback100IpRange = types.StringNull()
+	}
+
+	if jsonData.MsoControlerId != "" {
+		v.MsoControlerId = types.StringValue(jsonData.MsoControlerId)
+	} else {
+		v.MsoControlerId = types.StringNull()
+	}
+
+	if jsonData.MsoSiteGroupName != "" {
+		v.MsoSiteGroupName = types.StringValue(jsonData.MsoSiteGroupName)
+	} else {
+		v.MsoSiteGroupName = types.StringNull()
 	}
 
 	if jsonData.MsIfcBgpAuthKeyType != nil {
@@ -180,6 +261,16 @@ func (v *FabricVxlanMsdModel) SetModelData(jsonData *resource_fabric_common.NDFC
 		}
 	} else {
 		v.MsIfcBgpAuthKeyType = types.Int64Null()
+	}
+
+	if jsonData.MsIfcBgpAuthKeyTypePrev != nil {
+		if jsonData.MsIfcBgpAuthKeyTypePrev.IsEmpty() {
+			v.MsIfcBgpAuthKeyTypePrev = types.Int64Null()
+		} else {
+			v.MsIfcBgpAuthKeyTypePrev = types.Int64Value(int64(*jsonData.MsIfcBgpAuthKeyTypePrev))
+		}
+	} else {
+		v.MsIfcBgpAuthKeyTypePrev = types.Int64Null()
 	}
 
 	if jsonData.MsIfcBgpPassword != "" {
@@ -193,6 +284,19 @@ func (v *FabricVxlanMsdModel) SetModelData(jsonData *resource_fabric_common.NDFC
 		v.MsIfcBgpPasswordEnable = types.BoolValue(x)
 	} else {
 		v.MsIfcBgpPasswordEnable = types.BoolNull()
+	}
+
+	if jsonData.MsIfcBgpPasswordEnablePrev != "" {
+		x, _ := strconv.ParseBool(jsonData.MsIfcBgpPasswordEnablePrev)
+		v.MsIfcBgpPasswordEnablePrev = types.BoolValue(x)
+	} else {
+		v.MsIfcBgpPasswordEnablePrev = types.BoolNull()
+	}
+
+	if jsonData.MsIfcBgpPasswordPrev != "" {
+		v.MsIfcBgpPasswordPrev = types.StringValue(jsonData.MsIfcBgpPasswordPrev)
+	} else {
+		v.MsIfcBgpPasswordPrev = types.StringNull()
 	}
 
 	if jsonData.MsLoopbackId != nil {
@@ -212,6 +316,18 @@ func (v *FabricVxlanMsdModel) SetModelData(jsonData *resource_fabric_common.NDFC
 		v.MsUnderlayAutoconfig = types.BoolNull()
 	}
 
+	if jsonData.ParentOnemanageFabric != "" {
+		v.ParentOnemanageFabric = types.StringValue(jsonData.ParentOnemanageFabric)
+	} else {
+		v.ParentOnemanageFabric = types.StringNull()
+	}
+
+	if jsonData.PremsoParentFabric != "" {
+		v.PremsoParentFabric = types.StringValue(jsonData.PremsoParentFabric)
+	} else {
+		v.PremsoParentFabric = types.StringNull()
+	}
+
 	if jsonData.RpServerIp != "" {
 		v.RpServerIp = types.StringValue(jsonData.RpServerIp)
 	} else {
@@ -228,11 +344,90 @@ func (v *FabricVxlanMsdModel) SetModelData(jsonData *resource_fabric_common.NDFC
 		v.RsRoutingTag = types.Int64Null()
 	}
 
+	if jsonData.SgtIdRange != "" {
+		v.SgtIdRange = types.StringValue(jsonData.SgtIdRange)
+	} else {
+		v.SgtIdRange = types.StringNull()
+	}
+
+	if jsonData.SgtIdRangePrev != "" {
+		v.SgtIdRangePrev = types.StringValue(jsonData.SgtIdRangePrev)
+	} else {
+		v.SgtIdRangePrev = types.StringNull()
+	}
+
+	if jsonData.SgtNamePrefix != "" {
+		v.SgtNamePrefix = types.StringValue(jsonData.SgtNamePrefix)
+	} else {
+		v.SgtNamePrefix = types.StringNull()
+	}
+
+	if jsonData.SgtNamePrefixPrev != "" {
+		v.SgtNamePrefixPrev = types.StringValue(jsonData.SgtNamePrefixPrev)
+	} else {
+		v.SgtNamePrefixPrev = types.StringNull()
+	}
+
+	if jsonData.SgtOperStatus != "" {
+		v.SgtOperStatus = types.StringValue(jsonData.SgtOperStatus)
+	} else {
+		v.SgtOperStatus = types.StringNull()
+	}
+
+	if jsonData.SgtPreprovision != "" {
+		x, _ := strconv.ParseBool(jsonData.SgtPreprovision)
+		v.SgtPreprovision = types.BoolValue(x)
+	} else {
+		v.SgtPreprovision = types.BoolNull()
+	}
+
+	if jsonData.SgtPreprovisionPrev != "" {
+		x, _ := strconv.ParseBool(jsonData.SgtPreprovisionPrev)
+		v.SgtPreprovisionPrev = types.BoolValue(x)
+	} else {
+		v.SgtPreprovisionPrev = types.BoolNull()
+	}
+
+	if jsonData.SgtPreprovRecalcStatus != "" {
+		v.SgtPreprovRecalcStatus = types.StringValue(jsonData.SgtPreprovRecalcStatus)
+	} else {
+		v.SgtPreprovRecalcStatus = types.StringNull()
+	}
+
+	if jsonData.SgtRecalcStatus != "" {
+		v.SgtRecalcStatus = types.StringValue(jsonData.SgtRecalcStatus)
+	} else {
+		v.SgtRecalcStatus = types.StringNull()
+	}
+
 	if jsonData.TorAutoDeploy != "" {
 		x, _ := strconv.ParseBool(jsonData.TorAutoDeploy)
 		v.TorAutoDeploy = types.BoolValue(x)
 	} else {
 		v.TorAutoDeploy = types.BoolNull()
+	}
+
+	if jsonData.V6DciSubnetRange != "" {
+		v.V6DciSubnetRange = types.StringValue(jsonData.V6DciSubnetRange)
+	} else {
+		v.V6DciSubnetRange = types.StringNull()
+	}
+
+	if jsonData.V6DciSubnetTargetMask != nil {
+		if jsonData.V6DciSubnetTargetMask.IsEmpty() {
+			v.V6DciSubnetTargetMask = types.Int64Null()
+		} else {
+			v.V6DciSubnetTargetMask = types.Int64Value(int64(*jsonData.V6DciSubnetTargetMask))
+		}
+	} else {
+		v.V6DciSubnetTargetMask = types.Int64Null()
+	}
+
+	if jsonData.VxlanUnderlayIsV6 != "" {
+		x, _ := strconv.ParseBool(jsonData.VxlanUnderlayIsV6)
+		v.VxlanUnderlayIsV6 = types.BoolValue(x)
+	} else {
+		v.VxlanUnderlayIsV6 = types.BoolNull()
 	}
 
 	if jsonData.DefaultNetwork != "" {
@@ -405,6 +600,30 @@ func (v FabricVxlanMsdModel) GetModelData() *resource_fabric_common.NDFCFabricCo
 		data.EnableRsRedistDirect = ""
 	}
 
+	if !v.EnableSgt.IsNull() && !v.EnableSgt.IsUnknown() {
+		data.EnableSgt = v.EnableSgt.ValueString()
+	} else {
+		data.EnableSgt = ""
+	}
+
+	if !v.EnableTrmTrmv6.IsNull() && !v.EnableTrmTrmv6.IsUnknown() {
+		data.EnableTrmTrmv6 = strconv.FormatBool(v.EnableTrmTrmv6.ValueBool())
+	} else {
+		data.EnableTrmTrmv6 = ""
+	}
+
+	if !v.ExtFabricType.IsNull() && !v.ExtFabricType.IsUnknown() {
+		data.ExtFabricType = v.ExtFabricType.ValueString()
+	} else {
+		data.ExtFabricType = ""
+	}
+
+	if !v.Ff.IsNull() && !v.Ff.IsUnknown() {
+		data.Ff = v.Ff.ValueString()
+	} else {
+		data.Ff = ""
+	}
+
 	if !v.L2SegmentIdRange.IsNull() && !v.L2SegmentIdRange.IsUnknown() {
 		data.L2SegmentIdRange = v.L2SegmentIdRange.ValueString()
 	} else {
@@ -415,6 +634,12 @@ func (v FabricVxlanMsdModel) GetModelData() *resource_fabric_common.NDFCFabricCo
 		data.L3PartitionIdRange = v.L3PartitionIdRange.ValueString()
 	} else {
 		data.L3PartitionIdRange = ""
+	}
+
+	if !v.Loopback100Ipv6Range.IsNull() && !v.Loopback100Ipv6Range.IsUnknown() {
+		data.Loopback100Ipv6Range = v.Loopback100Ipv6Range.ValueString()
+	} else {
+		data.Loopback100Ipv6Range = ""
 	}
 
 	if !v.Loopback100IpRange.IsNull() && !v.Loopback100IpRange.IsUnknown() {
@@ -468,10 +693,47 @@ func (v FabricVxlanMsdModel) GetModelData() *resource_fabric_common.NDFCFabricCo
 		data.RsRoutingTag = nil
 	}
 
+	if !v.SgtIdRange.IsNull() && !v.SgtIdRange.IsUnknown() {
+		data.SgtIdRange = v.SgtIdRange.ValueString()
+	} else {
+		data.SgtIdRange = ""
+	}
+
+	if !v.SgtNamePrefix.IsNull() && !v.SgtNamePrefix.IsUnknown() {
+		data.SgtNamePrefix = v.SgtNamePrefix.ValueString()
+	} else {
+		data.SgtNamePrefix = ""
+	}
+
+	if !v.SgtPreprovision.IsNull() && !v.SgtPreprovision.IsUnknown() {
+		data.SgtPreprovision = strconv.FormatBool(v.SgtPreprovision.ValueBool())
+	} else {
+		data.SgtPreprovision = ""
+	}
+
 	if !v.TorAutoDeploy.IsNull() && !v.TorAutoDeploy.IsUnknown() {
 		data.TorAutoDeploy = strconv.FormatBool(v.TorAutoDeploy.ValueBool())
 	} else {
 		data.TorAutoDeploy = ""
+	}
+
+	if !v.V6DciSubnetRange.IsNull() && !v.V6DciSubnetRange.IsUnknown() {
+		data.V6DciSubnetRange = v.V6DciSubnetRange.ValueString()
+	} else {
+		data.V6DciSubnetRange = ""
+	}
+
+	if !v.V6DciSubnetTargetMask.IsNull() && !v.V6DciSubnetTargetMask.IsUnknown() {
+		data.V6DciSubnetTargetMask = new(Int64Custom)
+		*data.V6DciSubnetTargetMask = Int64Custom(v.V6DciSubnetTargetMask.ValueInt64())
+	} else {
+		data.V6DciSubnetTargetMask = nil
+	}
+
+	if !v.VxlanUnderlayIsV6.IsNull() && !v.VxlanUnderlayIsV6.IsUnknown() {
+		data.VxlanUnderlayIsV6 = strconv.FormatBool(v.VxlanUnderlayIsV6.ValueBool())
+	} else {
+		data.VxlanUnderlayIsV6 = ""
 	}
 
 	if !v.DefaultNetwork.IsNull() && !v.DefaultNetwork.IsUnknown() {

--- a/internal/provider/test_utils_fabric_ipfm_test.go
+++ b/internal/provider/test_utils_fabric_ipfm_test.go
@@ -30,6 +30,12 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.AaaServerConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_server_conf").String(), c.AaaServerConf))
 	}
+	if c.ActiveMigration != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("active_migration").String(), c.ActiveMigration))
+	}
+	if c.AgentIntf != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("agent_intf").String(), c.AgentIntf))
+	}
 	if c.AsmGroupRanges != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("asm_group_ranges").String(), c.AsmGroupRanges))
 	}
@@ -42,8 +48,17 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.BootstrapMultisubnet != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), c.BootstrapMultisubnet))
 	}
+	if c.BootstrapMultisubnetInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet_internal").String(), c.BootstrapMultisubnetInternal))
+	}
+	if c.BrfieldDebugFlag != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("brfield_debug_flag").String(), c.BrfieldDebugFlag))
+	}
 	if c.CdpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), c.CdpEnable))
+	}
+	if c.DeploymentFreeze != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deployment_freeze").String(), c.DeploymentFreeze))
 	}
 	if c.DhcpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), c.DhcpEnable))
@@ -51,11 +66,20 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.DhcpEnd != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end").String(), c.DhcpEnd))
 	}
+	if c.DhcpEndInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end_internal").String(), c.DhcpEndInternal))
+	}
 	if c.DhcpIpv6Enable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_ipv6_enable").String(), c.DhcpIpv6Enable))
 	}
+	if c.DhcpIpv6EnableInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_ipv6_enable_internal").String(), c.DhcpIpv6EnableInternal))
+	}
 	if c.DhcpStart != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_start").String(), c.DhcpStart))
+	}
+	if c.DhcpStartInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_start_internal").String(), c.DhcpStartInternal))
 	}
 	if c.DnsServerIpList != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dns_server_ip_list").String(), c.DnsServerIpList))
@@ -66,11 +90,26 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.EnableAaa != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_aaa").String(), c.EnableAaa))
 	}
+	if c.EnableAgent != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_agent").String(), c.EnableAgent))
+	}
 	if c.EnableAsm != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_asm").String(), c.EnableAsm))
 	}
 	if c.EnableNbmPassive != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nbm_passive").String(), c.EnableNbmPassive))
+	}
+	if c.EnableNbmPassivePrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nbm_passive_prev").String(), c.EnableNbmPassivePrev))
+	}
+	if c.EnableNxapi != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), c.EnableNxapi))
+	}
+	if c.EnableNxapiHttp != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi_http").String(), c.EnableNxapiHttp))
+	}
+	if c.EnableRtIntfStats != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_rt_intf_stats").String(), c.EnableRtIntfStats))
 	}
 	if c.ExtraConfIntraLinks != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("extra_conf_intra_links").String(), c.ExtraConfIntraLinks))
@@ -81,14 +120,50 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.ExtraConfSpine != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("extra_conf_spine").String(), c.ExtraConfSpine))
 	}
+	if c.ExtFabricType != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ext_fabric_type").String(), c.ExtFabricType))
+	}
 	if c.FabricInterfaceType != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_interface_type").String(), c.FabricInterfaceType))
 	}
 	if c.FabricMtu != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_mtu").String(), strconv.Itoa(int(*c.FabricMtu))))
 	}
+	if c.FabricMtuPrev != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_mtu_prev").String(), strconv.Itoa(int(*c.FabricMtuPrev))))
+	}
+	if c.FabricTechnology != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_technology").String(), c.FabricTechnology))
+	}
+	if c.FabricType != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_type").String(), c.FabricType))
+	}
 	if c.FeaturePtp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), c.FeaturePtp))
+	}
+	if c.FeaturePtpInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp_internal").String(), c.FeaturePtpInternal))
+	}
+	if c.Ff != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ff").String(), c.Ff))
+	}
+	if c.GrfieldDebugFlag != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("grfield_debug_flag").String(), c.GrfieldDebugFlag))
+	}
+	if c.InterfaceEthernetDefaultPolicy != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("interface_ethernet_default_policy").String(), c.InterfaceEthernetDefaultPolicy))
+	}
+	if c.InterfaceLoopbackDefaultPolicy != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("interface_loopback_default_policy").String(), c.InterfaceLoopbackDefaultPolicy))
+	}
+	if c.InterfacePortChannelDefaultPolicy != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("interface_port_channel_default_policy").String(), c.InterfacePortChannelDefaultPolicy))
+	}
+	if c.InterfaceVlanDefaultPolicy != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("interface_vlan_default_policy").String(), c.InterfaceVlanDefaultPolicy))
+	}
+	if c.IntfStatLoadInterval != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("intf_stat_load_interval").String(), strconv.Itoa(int(*c.IntfStatLoadInterval))))
 	}
 	if c.IsisAuthEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("isis_auth_enable").String(), c.IsisAuthEnable))
@@ -111,11 +186,17 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.L2HostIntfMtu != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_host_intf_mtu").String(), strconv.Itoa(int(*c.L2HostIntfMtu))))
 	}
+	if c.L2HostIntfMtuPrev != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_host_intf_mtu_prev").String(), strconv.Itoa(int(*c.L2HostIntfMtuPrev))))
+	}
 	if c.LinkStateRouting != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing").String(), c.LinkStateRouting))
 	}
 	if c.LinkStateRoutingTag != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing_tag").String(), c.LinkStateRoutingTag))
+	}
+	if c.LinkStateRoutingTagPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("link_state_routing_tag_prev").String(), c.LinkStateRoutingTagPrev))
 	}
 	if c.Loopback0IpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback0_ip_range").String(), c.Loopback0IpRange))
@@ -123,14 +204,32 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.MgmtGw != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw").String(), c.MgmtGw))
 	}
+	if c.MgmtGwInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw_internal").String(), c.MgmtGwInternal))
+	}
 	if c.MgmtPrefix != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_prefix").String(), strconv.Itoa(int(*c.MgmtPrefix))))
+	}
+	if c.MgmtPrefixInternal != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_prefix_internal").String(), strconv.Itoa(int(*c.MgmtPrefixInternal))))
+	}
+	if c.MgmtV6prefix != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_v6prefix").String(), strconv.Itoa(int(*c.MgmtV6prefix))))
+	}
+	if c.MgmtV6prefixInternal != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_v6prefix_internal").String(), strconv.Itoa(int(*c.MgmtV6prefixInternal))))
 	}
 	if c.NtpServerIpList != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ntp_server_ip_list").String(), c.NtpServerIpList))
 	}
 	if c.NtpServerVrf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ntp_server_vrf").String(), c.NtpServerVrf))
+	}
+	if c.NxapiHttpsPort != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_https_port").String(), strconv.Itoa(int(*c.NxapiHttpsPort))))
+	}
+	if c.NxapiHttpPort != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), strconv.Itoa(int(*c.NxapiHttpPort))))
 	}
 	if c.NxapiVrf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_vrf").String(), c.NxapiVrf))
@@ -156,6 +255,9 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.PmEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), c.PmEnable))
 	}
+	if c.PmEnablePrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable_prev").String(), c.PmEnablePrev))
+	}
 	if c.PowerRedundancyMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), c.PowerRedundancyMode))
 	}
@@ -168,17 +270,26 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	if c.PtpProfile != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ptp_profile").String(), c.PtpProfile))
 	}
+	if c.ReplicationMode != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("replication_mode").String(), c.ReplicationMode))
+	}
 	if c.RoutingLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("routing_lb_id").String(), strconv.Itoa(int(*c.RoutingLbId))))
 	}
 	if c.RpIpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_ip_range").String(), c.RpIpRange))
 	}
+	if c.RpIpRangeInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_ip_range_internal").String(), c.RpIpRangeInternal))
+	}
 	if c.RpLbId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_lb_id").String(), strconv.Itoa(int(*c.RpLbId))))
 	}
 	if c.SnmpServerHostTrap != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("snmp_server_host_trap").String(), c.SnmpServerHostTrap))
+	}
+	if c.SpineCount != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("spine_count").String(), strconv.Itoa(int(*c.SpineCount))))
 	}
 	if c.StaticUnderlayIpAlloc != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("static_underlay_ip_alloc").String(), c.StaticUnderlayIpAlloc))
@@ -197,6 +308,42 @@ func FabricIpfmModelHelperStateCheck(RscName string, c resource_fabric_common.ND
 	}
 	if c.SyslogSev != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("syslog_sev").String(), c.SyslogSev))
+	}
+	if c.UpgradeFromVersion != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("upgrade_from_version").String(), c.UpgradeFromVersion))
+	}
+	if c.AbstractDhcp != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_dhcp").String(), c.AbstractDhcp))
+	}
+	if c.AbstractExtraConfigBootstrap != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_extra_config_bootstrap").String(), c.AbstractExtraConfigBootstrap))
+	}
+	if c.AbstractExtraConfigLeaf != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_extra_config_leaf").String(), c.AbstractExtraConfigLeaf))
+	}
+	if c.AbstractExtraConfigSpine != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_extra_config_spine").String(), c.AbstractExtraConfigSpine))
+	}
+	if c.AbstractIsis != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_isis").String(), c.AbstractIsis))
+	}
+	if c.AbstractIsisInterface != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_isis_interface").String(), c.AbstractIsisInterface))
+	}
+	if c.AbstractLoopbackInterface != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_loopback_interface").String(), c.AbstractLoopbackInterface))
+	}
+	if c.AbstractOspf != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_ospf").String(), c.AbstractOspf))
+	}
+	if c.AbstractOspfInterface != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_ospf_interface").String(), c.AbstractOspfInterface))
+	}
+	if c.AbstractPimInterface != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_pim_interface").String(), c.AbstractPimInterface))
+	}
+	if c.AbstractRoutedHost != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("abstract_routed_host").String(), c.AbstractRoutedHost))
 	}
 	if c.Deploy {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy").String(), "true"))

--- a/internal/provider/test_utils_fabric_lan_classic_test.go
+++ b/internal/provider/test_utils_fabric_lan_classic_test.go
@@ -30,6 +30,12 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	if c.AaaServerConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_server_conf").String(), c.AaaServerConf))
 	}
+	if c.AllowNxc != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("allow_nxc").String(), c.AllowNxc))
+	}
+	if c.AllowNxcPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("allow_nxc_prev").String(), c.AllowNxcPrev))
+	}
 	if c.BootstrapConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_conf").String(), c.BootstrapConf))
 	}
@@ -39,8 +45,20 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	if c.BootstrapMultisubnet != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), c.BootstrapMultisubnet))
 	}
+	if c.BootstrapMultisubnetInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet_internal").String(), c.BootstrapMultisubnetInternal))
+	}
 	if c.CdpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), c.CdpEnable))
+	}
+	if c.DciSubnetRange != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_range").String(), c.DciSubnetRange))
+	}
+	if c.DciSubnetTargetMask != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_target_mask").String(), strconv.Itoa(int(*c.DciSubnetTargetMask))))
+	}
+	if c.DeploymentFreeze != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deployment_freeze").String(), c.DeploymentFreeze))
 	}
 	if c.DhcpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), c.DhcpEnable))
@@ -48,11 +66,20 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	if c.DhcpEnd != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end").String(), c.DhcpEnd))
 	}
+	if c.DhcpEndInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end_internal").String(), c.DhcpEndInternal))
+	}
 	if c.DhcpIpv6Enable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_ipv6_enable").String(), c.DhcpIpv6Enable))
 	}
+	if c.DhcpIpv6EnableInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_ipv6_enable_internal").String(), c.DhcpIpv6EnableInternal))
+	}
 	if c.DhcpStart != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_start").String(), c.DhcpStart))
+	}
+	if c.DhcpStartInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_start_internal").String(), c.DhcpStartInternal))
 	}
 	if c.EnableAaa != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_aaa").String(), c.EnableAaa))
@@ -60,35 +87,77 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	if c.EnableNetflow != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow").String(), c.EnableNetflow))
 	}
+	if c.EnableNetflowPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow_prev").String(), c.EnableNetflowPrev))
+	}
 	if c.EnableNxapi != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), c.EnableNxapi))
 	}
 	if c.EnableNxapiHttp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi_http").String(), c.EnableNxapiHttp))
 	}
+	if c.EnableRtIntfStats != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_rt_intf_stats").String(), c.EnableRtIntfStats))
+	}
+	if c.ExtFabricType != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ext_fabric_type").String(), c.ExtFabricType))
+	}
 	if c.FabricFreeform != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_freeform").String(), c.FabricFreeform))
+	}
+	if c.FabricTechnology != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_technology").String(), c.FabricTechnology))
+	}
+	if c.FabricType != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_type").String(), c.FabricType))
 	}
 	if c.FeaturePtp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), c.FeaturePtp))
 	}
+	if c.FeaturePtpInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp_internal").String(), c.FeaturePtpInternal))
+	}
+	if c.Ff != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ff").String(), c.Ff))
+	}
 	if c.InbandEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_enable").String(), c.InbandEnable))
+	}
+	if c.InbandEnablePrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_enable_prev").String(), c.InbandEnablePrev))
 	}
 	if c.InbandMgmt != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt").String(), c.InbandMgmt))
 	}
+	if c.InbandMgmtPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt_prev").String(), c.InbandMgmtPrev))
+	}
+	if c.IntfStatLoadInterval != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("intf_stat_load_interval").String(), strconv.Itoa(int(*c.IntfStatLoadInterval))))
+	}
 	if c.IsReadOnly != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_read_only").String(), c.IsReadOnly))
+	}
+	if c.Loopback0IpRange != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback0_ip_range").String(), c.Loopback0IpRange))
 	}
 	if c.MgmtGw != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw").String(), c.MgmtGw))
 	}
+	if c.MgmtGwInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw_internal").String(), c.MgmtGwInternal))
+	}
 	if c.MgmtPrefix != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_prefix").String(), strconv.Itoa(int(*c.MgmtPrefix))))
 	}
+	if c.MgmtPrefixInternal != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_prefix_internal").String(), strconv.Itoa(int(*c.MgmtPrefixInternal))))
+	}
 	if c.MgmtV6prefix != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_v6prefix").String(), strconv.Itoa(int(*c.MgmtV6prefix))))
+	}
+	if c.MgmtV6prefixInternal != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_v6prefix_internal").String(), strconv.Itoa(int(*c.MgmtV6prefixInternal))))
 	}
 	if c.MplsHandoff != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_handoff").String(), c.MplsHandoff))
@@ -117,8 +186,26 @@ func FabricLanClassicModelHelperStateCheck(RscName string, c resource_fabric_com
 	if c.NxapiHttpPort != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), strconv.Itoa(int(*c.NxapiHttpPort))))
 	}
+	if c.NxcDestVrf != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxc_dest_vrf").String(), c.NxcDestVrf))
+	}
+	if c.NxcProxyPort != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxc_proxy_port").String(), strconv.Itoa(int(*c.NxcProxyPort))))
+	}
+	if c.NxcProxyServer != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxc_proxy_server").String(), c.NxcProxyServer))
+	}
+	if c.NxcSrcIntf != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxc_src_intf").String(), c.NxcSrcIntf))
+	}
+	if c.OverwriteGlobalNxc != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("overwrite_global_nxc").String(), c.OverwriteGlobalNxc))
+	}
 	if c.PmEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), c.PmEnable))
+	}
+	if c.PmEnablePrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable_prev").String(), c.PmEnablePrev))
 	}
 	if c.PowerRedundancyMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), c.PowerRedundancyMode))

--- a/internal/provider/test_utils_fabric_msite_ext_net_test.go
+++ b/internal/provider/test_utils_fabric_msite_ext_net_test.go
@@ -30,6 +30,12 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	if c.AaaServerConf != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("aaa_server_conf").String(), c.AaaServerConf))
 	}
+	if c.AllowNxc != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("allow_nxc").String(), c.AllowNxc))
+	}
+	if c.AllowNxcPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("allow_nxc_prev").String(), c.AllowNxcPrev))
+	}
 	if c.BgpAs != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgp_as").String(), c.BgpAs))
 	}
@@ -45,8 +51,20 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	if c.BootstrapMultisubnet != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet").String(), c.BootstrapMultisubnet))
 	}
+	if c.BootstrapMultisubnetInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bootstrap_multisubnet_internal").String(), c.BootstrapMultisubnetInternal))
+	}
 	if c.CdpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("cdp_enable").String(), c.CdpEnable))
+	}
+	if c.DciSubnetRange != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_range").String(), c.DciSubnetRange))
+	}
+	if c.DciSubnetTargetMask != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_target_mask").String(), strconv.Itoa(int(*c.DciSubnetTargetMask))))
+	}
+	if c.DeploymentFreeze != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deployment_freeze").String(), c.DeploymentFreeze))
 	}
 	if c.DhcpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_enable").String(), c.DhcpEnable))
@@ -54,20 +72,35 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	if c.DhcpEnd != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end").String(), c.DhcpEnd))
 	}
+	if c.DhcpEndInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_end_internal").String(), c.DhcpEndInternal))
+	}
 	if c.DhcpIpv6Enable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_ipv6_enable").String(), c.DhcpIpv6Enable))
+	}
+	if c.DhcpIpv6EnableInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_ipv6_enable_internal").String(), c.DhcpIpv6EnableInternal))
 	}
 	if c.DhcpStart != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_start").String(), c.DhcpStart))
 	}
+	if c.DhcpStartInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dhcp_start_internal").String(), c.DhcpStartInternal))
+	}
 	if c.DomainName != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("domain_name").String(), c.DomainName))
+	}
+	if c.DomainNameInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("domain_name_internal").String(), c.DomainNameInternal))
 	}
 	if c.EnableAaa != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_aaa").String(), c.EnableAaa))
 	}
 	if c.EnableNetflow != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow").String(), c.EnableNetflow))
+	}
+	if c.EnableNetflowPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_netflow_prev").String(), c.EnableNetflowPrev))
 	}
 	if c.EnableNxapi != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_nxapi").String(), c.EnableNxapi))
@@ -78,17 +111,35 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	if c.EnableRtIntfStats != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_rt_intf_stats").String(), c.EnableRtIntfStats))
 	}
+	if c.ExtFabricType != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ext_fabric_type").String(), c.ExtFabricType))
+	}
 	if c.FabricFreeform != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_freeform").String(), c.FabricFreeform))
+	}
+	if c.FabricType != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_type").String(), c.FabricType))
 	}
 	if c.FeaturePtp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp").String(), c.FeaturePtp))
 	}
+	if c.FeaturePtpInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("feature_ptp_internal").String(), c.FeaturePtpInternal))
+	}
+	if c.Ff != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ff").String(), c.Ff))
+	}
 	if c.InbandEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_enable").String(), c.InbandEnable))
 	}
+	if c.InbandEnablePrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_enable_prev").String(), c.InbandEnablePrev))
+	}
 	if c.InbandMgmt != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt").String(), c.InbandMgmt))
+	}
+	if c.InbandMgmtPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("inband_mgmt_prev").String(), c.InbandMgmtPrev))
 	}
 	if c.IntfStatLoadInterval != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("intf_stat_load_interval").String(), strconv.Itoa(int(*c.IntfStatLoadInterval))))
@@ -96,14 +147,26 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	if c.IsReadOnly != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("is_read_only").String(), c.IsReadOnly))
 	}
+	if c.Loopback0IpRange != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback0_ip_range").String(), c.Loopback0IpRange))
+	}
 	if c.MgmtGw != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw").String(), c.MgmtGw))
+	}
+	if c.MgmtGwInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_gw_internal").String(), c.MgmtGwInternal))
 	}
 	if c.MgmtPrefix != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_prefix").String(), strconv.Itoa(int(*c.MgmtPrefix))))
 	}
+	if c.MgmtPrefixInternal != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_prefix_internal").String(), strconv.Itoa(int(*c.MgmtPrefixInternal))))
+	}
 	if c.MgmtV6prefix != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_v6prefix").String(), strconv.Itoa(int(*c.MgmtV6prefix))))
+	}
+	if c.MgmtV6prefixInternal != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mgmt_v6prefix_internal").String(), strconv.Itoa(int(*c.MgmtV6prefixInternal))))
 	}
 	if c.MplsHandoff != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_handoff").String(), c.MplsHandoff))
@@ -113,6 +176,18 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	}
 	if c.MplsLoopbackIpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mpls_loopback_ip_range").String(), c.MplsLoopbackIpRange))
+	}
+	if c.MsoConnectivityDeployed != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mso_connectivity_deployed").String(), c.MsoConnectivityDeployed))
+	}
+	if c.MsoControlerId != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mso_controler_id").String(), c.MsoControlerId))
+	}
+	if c.MsoSiteGroupName != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mso_site_group_name").String(), c.MsoSiteGroupName))
+	}
+	if c.MsoSiteId != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mso_site_id").String(), c.MsoSiteId))
 	}
 	if c.NetflowExporterList != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("netflow_exporter_list").String(), c.NetflowExporterList))
@@ -132,14 +207,38 @@ func FabricMsiteExtNetModelHelperStateCheck(RscName string, c resource_fabric_co
 	if c.NxapiHttpPort != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxapi_http_port").String(), strconv.Itoa(int(*c.NxapiHttpPort))))
 	}
+	if c.NxcDestVrf != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxc_dest_vrf").String(), c.NxcDestVrf))
+	}
+	if c.NxcProxyPort != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxc_proxy_port").String(), strconv.Itoa(int(*c.NxcProxyPort))))
+	}
+	if c.NxcProxyServer != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxc_proxy_server").String(), c.NxcProxyServer))
+	}
+	if c.NxcSrcIntf != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("nxc_src_intf").String(), c.NxcSrcIntf))
+	}
+	if c.OverwriteGlobalNxc != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("overwrite_global_nxc").String(), c.OverwriteGlobalNxc))
+	}
 	if c.PmEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable").String(), c.PmEnable))
+	}
+	if c.PmEnablePrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pm_enable_prev").String(), c.PmEnablePrev))
 	}
 	if c.PnpEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pnp_enable").String(), c.PnpEnable))
 	}
+	if c.PnpEnableInternal != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("pnp_enable_internal").String(), c.PnpEnableInternal))
+	}
 	if c.PowerRedundancyMode != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("power_redundancy_mode").String(), c.PowerRedundancyMode))
+	}
+	if c.PremsoParentFabric != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("premso_parent_fabric").String(), c.PremsoParentFabric))
 	}
 	if c.PtpDomainId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ptp_domain_id").String(), strconv.Itoa(int(*c.PtpDomainId))))

--- a/internal/provider/test_utils_fabric_vxlan_msd_test.go
+++ b/internal/provider/test_utils_fabric_vxlan_msd_test.go
@@ -33,6 +33,9 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	if c.BgwRoutingTag != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgw_routing_tag").String(), strconv.Itoa(int(*c.BgwRoutingTag))))
 	}
+	if c.BgwRoutingTagPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("bgw_routing_tag_prev").String(), c.BgwRoutingTagPrev))
+	}
 	if c.BorderGwyConnections != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("border_gwy_connections").String(), c.BorderGwyConnections))
 	}
@@ -57,6 +60,9 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	if c.DciSubnetTargetMask != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dci_subnet_target_mask").String(), strconv.Itoa(int(*c.DciSubnetTargetMask))))
 	}
+	if c.DcnmId != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("dcnm_id").String(), c.DcnmId))
+	}
 	if c.DelayRestore != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("delay_restore").String(), strconv.Itoa(int(*c.DelayRestore))))
 	}
@@ -72,8 +78,32 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	if c.EnablePvlan != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_pvlan").String(), c.EnablePvlan))
 	}
+	if c.EnablePvlanPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_pvlan_prev").String(), c.EnablePvlanPrev))
+	}
 	if c.EnableRsRedistDirect != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_rs_redist_direct").String(), c.EnableRsRedistDirect))
+	}
+	if c.EnableSgt != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_sgt").String(), c.EnableSgt))
+	}
+	if c.EnableSgtPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_sgt_prev").String(), c.EnableSgtPrev))
+	}
+	if c.EnableTrmTrmv6 != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_trm_trmv6").String(), c.EnableTrmTrmv6))
+	}
+	if c.EnableTrmTrmv6Prev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("enable_trm_trmv6_prev").String(), c.EnableTrmTrmv6Prev))
+	}
+	if c.ExtFabricType != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ext_fabric_type").String(), c.ExtFabricType))
+	}
+	if c.FabricType != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("fabric_type").String(), c.FabricType))
+	}
+	if c.Ff != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ff").String(), c.Ff))
 	}
 	if c.L2SegmentIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l2_segment_id_range").String(), c.L2SegmentIdRange))
@@ -81,11 +111,23 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	if c.L3PartitionIdRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("l3_partition_id_range").String(), c.L3PartitionIdRange))
 	}
+	if c.Loopback100Ipv6Range != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback100_ipv6_range").String(), c.Loopback100Ipv6Range))
+	}
 	if c.Loopback100IpRange != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("loopback100_ip_range").String(), c.Loopback100IpRange))
 	}
+	if c.MsoControlerId != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mso_controler_id").String(), c.MsoControlerId))
+	}
+	if c.MsoSiteGroupName != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("mso_site_group_name").String(), c.MsoSiteGroupName))
+	}
 	if c.MsIfcBgpAuthKeyType != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_auth_key_type").String(), strconv.Itoa(int(*c.MsIfcBgpAuthKeyType))))
+	}
+	if c.MsIfcBgpAuthKeyTypePrev != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_auth_key_type_prev").String(), strconv.Itoa(int(*c.MsIfcBgpAuthKeyTypePrev))))
 	}
 	if c.MsIfcBgpPassword != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_password").String(), c.MsIfcBgpPassword))
@@ -93,11 +135,23 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	if c.MsIfcBgpPasswordEnable != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_password_enable").String(), c.MsIfcBgpPasswordEnable))
 	}
+	if c.MsIfcBgpPasswordEnablePrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_password_enable_prev").String(), c.MsIfcBgpPasswordEnablePrev))
+	}
+	if c.MsIfcBgpPasswordPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_ifc_bgp_password_prev").String(), c.MsIfcBgpPasswordPrev))
+	}
 	if c.MsLoopbackId != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_loopback_id").String(), strconv.Itoa(int(*c.MsLoopbackId))))
 	}
 	if c.MsUnderlayAutoconfig != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("ms_underlay_autoconfig").String(), c.MsUnderlayAutoconfig))
+	}
+	if c.ParentOnemanageFabric != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("parent_onemanage_fabric").String(), c.ParentOnemanageFabric))
+	}
+	if c.PremsoParentFabric != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("premso_parent_fabric").String(), c.PremsoParentFabric))
 	}
 	if c.RpServerIp != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rp_server_ip").String(), c.RpServerIp))
@@ -105,8 +159,44 @@ func FabricVxlanMsdModelHelperStateCheck(RscName string, c resource_fabric_commo
 	if c.RsRoutingTag != nil {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("rs_routing_tag").String(), strconv.Itoa(int(*c.RsRoutingTag))))
 	}
+	if c.SgtIdRange != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_id_range").String(), c.SgtIdRange))
+	}
+	if c.SgtIdRangePrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_id_range_prev").String(), c.SgtIdRangePrev))
+	}
+	if c.SgtNamePrefix != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_name_prefix").String(), c.SgtNamePrefix))
+	}
+	if c.SgtNamePrefixPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_name_prefix_prev").String(), c.SgtNamePrefixPrev))
+	}
+	if c.SgtOperStatus != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_oper_status").String(), c.SgtOperStatus))
+	}
+	if c.SgtPreprovision != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_preprovision").String(), c.SgtPreprovision))
+	}
+	if c.SgtPreprovisionPrev != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_preprovision_prev").String(), c.SgtPreprovisionPrev))
+	}
+	if c.SgtPreprovRecalcStatus != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_preprov_recalc_status").String(), c.SgtPreprovRecalcStatus))
+	}
+	if c.SgtRecalcStatus != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("sgt_recalc_status").String(), c.SgtRecalcStatus))
+	}
 	if c.TorAutoDeploy != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("tor_auto_deploy").String(), c.TorAutoDeploy))
+	}
+	if c.V6DciSubnetRange != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("v6_dci_subnet_range").String(), c.V6DciSubnetRange))
+	}
+	if c.V6DciSubnetTargetMask != nil {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("v6_dci_subnet_target_mask").String(), strconv.Itoa(int(*c.V6DciSubnetTargetMask))))
+	}
+	if c.VxlanUnderlayIsV6 != "" {
+		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("vxlan_underlay_is_v6").String(), c.VxlanUnderlayIsV6))
 	}
 	if c.DefaultNetwork != "" {
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("default_network").String(), c.DefaultNetwork))


### PR DESCRIPTION
All fields part of non-evpn-vxlan fabric types in Ndfc Fabric Controller Version 12.2.2.241 are added based on the templates.
