### PR TITLE
Fix for issue #199 [BUG] vPC pair destroy/deletion fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module terraform-provider-ndfc
 
-go 1.23.0
+go 1.23.6
 
-toolchain go1.23.6
+toolchain go1.24.2
 
 require (
 	github.com/hashicorp/hcl/v2 v2.23.0
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
 	github.com/looplab/fsm v1.0.2
-	github.com/netascode/go-nd v0.1.2
+	github.com/netascode/go-nd v0.1.3
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
 	github.com/zclconf/go-cty v1.16.2

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/netascode/go-nd v0.1.2 h1:6CY87/b0Ru2Z4PCYLWBt6HTXohVtewXLNeWMqBjV/gE=
-github.com/netascode/go-nd v0.1.2/go.mod h1:mqXhtTUcDJ15C7T4Du7xtPXDl/pAHD0nOHgrfeTu3pU=
+github.com/netascode/go-nd v0.1.3 h1:3d7h3fLP+eDUgH5KaQb5EcN/9gwMB+5qdEuxsAdYiCg=
+github.com/netascode/go-nd v0.1.3/go.mod h1:6yqn3s1ZqpxnQghp9JwEEbgKQEfzbEkIlb64TT04cx4=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/provider/inventory_devices_resource.go
+++ b/internal/provider/inventory_devices_resource.go
@@ -257,7 +257,7 @@ func (r *InventoryDevicesResource) Create(ctx context.Context, req resource.Crea
 
 	deployAndSave(ctx, r.client, &resp.Diagnostics, &planData)
 	if resp.Diagnostics.HasError() {
-		tflog.Debug(ctx, "Create failed, deleting devices from inventory")
+		tflog.Debug(ctx, "Save and Deploy failed, deleting devices from inventory")
 		deleteDevicesFromInventory(ctx, r.client, &resp.Diagnostics, &planData)
 		return
 	}

--- a/internal/provider/testing/vpc_pair.gotmpl
+++ b/internal/provider/testing/vpc_pair.gotmpl
@@ -1,13 +1,32 @@
 {{define "NDFC_VPCPAIR_RSC"}}
-resource "ndfc_{{.RscType}}" "{{.RscName}}" {
+resource "ndfc_{{.RscType}}" "{{.RscName}}_1" {
     {{ with .VpcPair }}
         serial_numbers =  [
-        {{- range .SerialNumbers }}
-            "{{.}}",
+        {{- $start := 0 }}
+        {{- $end := 1 }}
+        {{- range $index, $element := .SerialNumbers }}
+            {{- if and (ge $index $start) (le $index $end) }}
+            "{{$element}}",
+            {{- end }}
         {{- end}}
         ]
         use_virtual_peerlink  = {{deref_bool .UseVirtualPeerlink}}
         deploy = {{.Deploy}}
     {{end}}
 }
+#resource "ndfc_{{.RscType}}" "{{.RscName}}_2" {
+#    {{ with .VpcPair }}
+#        serial_numbers =  [
+#        {{- $start := 2 }}
+#        {{- $end := 3 }}
+#        {{- range $index, $element := .SerialNumbers }}
+#            {{- if and (ge $index $start) (le $index $end) }}
+#            "{{$element}}",
+#            {{- end }}
+#        {{- end}}
+#        ]
+#        use_virtual_peerlink  = {{deref_bool .UseVirtualPeerlink}}
+#        deploy = {{.Deploy}}
+#    {{end}}
+#}
 {{end}}

--- a/internal/provider/vpc_pair_test.go
+++ b/internal/provider/vpc_pair_test.go
@@ -53,24 +53,33 @@ func TestAccVPCPairResourceCreateVpcPair(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t, "vpc_pair") },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-
-			{ // Create vpc pair and check resource state
+			{
 				Config: func() string {
 					tName := fmt.Sprintf("%s_%d", t.Name(), 1)
 					helper.GenerateVpcPairResource(&vpcPairRsc, helper.GetConfig("vpc_pair").NDFC.VpcPair, false, true)
-					helper.GetTFConfigWithSingleResource(tName, *x, []interface{}{vpcPairRsc}, &tf_config)
+					helper.GetTFConfigWithSingleResource(tName, *x, []any{vpcPairRsc}, &tf_config)
 					return *tf_config
 				}(),
-				Check: resource.ComposeTestCheckFunc(VpcPairModelHelperStateCheck("ndfc_vpc_pair.test_vpc_pair", *vpcPairRsc, path.Empty())...),
+				Check: func() resource.TestCheckFunc {
+					funcs1 := VpcPairModelHelperStateCheck("ndfc_vpc_pair.test_vpc_pair_1", *vpcPairRsc, path.Empty())
+					//funcs2 := VpcPairModelHelperStateCheck("ndfc_vpc_pair.test_vpc_pair_2", *vpcPairRsc, path.Empty())
+					//allFuncs := append(funcs1, funcs2...)
+					return resource.ComposeTestCheckFunc(funcs1...)
+				}(),
 			},
-			{ // create with virtual link true
+			{
 				Config: func() string {
 					tName := fmt.Sprintf("%s_%d", t.Name(), 1)
 					helper.GenerateVpcPairResource(&vpcPairRsc, helper.GetConfig("vpc_pair").NDFC.VpcPair, true, true)
-					helper.GetTFConfigWithSingleResource(tName, *x, []interface{}{vpcPairRsc}, &tf_config)
+					helper.GetTFConfigWithSingleResource(tName, *x, []any{vpcPairRsc}, &tf_config)
 					return *tf_config
 				}(),
-				Check:       resource.ComposeTestCheckFunc(VpcPairModelHelperStateCheck("ndfc_vpc_pair.test_vpc_pair", *vpcPairRsc, path.Empty())...),
+				Check: func() resource.TestCheckFunc {
+					funcs1 := VpcPairModelHelperStateCheck("ndfc_vpc_pair.test_vpc_pair_1", *vpcPairRsc, path.Empty())
+					// funcs2 := VpcPairModelHelperStateCheck("ndfc_vpc_pair.test_vpc_pair_2", *vpcPairRsc, path.Empty())
+					//allFuncs := append(funcs1, funcs2...)
+					return resource.ComposeTestCheckFunc(funcs1...)
+				}(),
 				ExpectError: regexp.MustCompile(".*doesn't support Virtual Fabric.*"),
 			},
 		},


### PR DESCRIPTION
Issue:

Vpc pair get is not part of a single fabric; it is across fabrics. If we delete the only vpc pair in one fabric, the get command would still return vpc pair info if it is present in other fabrics. During deletion, we retrieve vpc pair info to verify if the vpc pair has been deleted properly. There is a logic mismatch in this case, which is causing the delete operation to fail.

Fix:
Check if vpc pair given in config is not seen in  vpc pair get after delete.

Added cases to acceptance testing.