### PR TITLE
Fix for #194 : [BUG] Importing networks fail because of json encoded strings in ndfc_networks resource 

### DIFF
--- a/docs/data-sources/networks.md
+++ b/docs/data-sources/networks.md
@@ -78,7 +78,7 @@ Read-Only:
 - `attached` (Boolean) The state of the attachment
 - `display_name` (String) The name of the switch
 - `freeform_config` (String) This field covers any configuration not included in overlay templates which is needed as part of this VRF attachment
-- `instance_values` (String) Instance values
+- `instance_values` (Map of String) Instance values
 - `serial_number` (String) Serial number of a switch
 - `switch_name` (String) The name of the switch
 - `switch_ports` (Set of String) List of switch ports

--- a/docs/resources/networks.md
+++ b/docs/resources/networks.md
@@ -130,7 +130,7 @@ Optional:
 - `deploy_this_attachment` (Boolean) If set to `true`, deploys this attachment. This cannot be set to `true` if `deploy_all_attachments` at resource level is set to `true` or `deploy_attachments` in the corresponding `network` is set to `true`
 - `display_name` (String) The name of the switch
 - `freeform_config` (String) This field covers any configuration not included in overlay templates which is needed as part of this VRF attachment
-- `instance_values` (String) Instance values
+- `instance_values` (Map of String) Instance values
 - `switch_ports` (Set of String) List of switch ports
 - `tor_ports` (Set of String) List of TOR ports
 - `vlan` (Number) VLAN ID

--- a/examples/resources/ndfc_vrf_bulk/import.sh
+++ b/examples/resources/ndfc_vrf_bulk/import.sh
@@ -1,5 +1,0 @@
-
-# Format of ID used for import:
-# fabric_name/[comma separated list of vrfs to be imported]
-terraform import ndfc_vrf_bulk.test_resource_vrf_bulk fabric_cml/[vrf1,vrf2,vrf3,vrf4]
-

--- a/generator/defs/network-attachments.yaml
+++ b/generator/defs/network-attachments.yaml
@@ -161,7 +161,8 @@ resource:
               ndfc_type: csv
             - model_name: instanceValues
               tf_name: instance_values
-              type: String
+              type: Map:String
+              ndfc_type: customMap
               optional: true
               computed: true
               description: Instance values

--- a/generator/defs/networks.yaml
+++ b/generator/defs/networks.yaml
@@ -551,7 +551,8 @@ datasource:
               example: "[Ethernet1/1, Ethernet1/2]"
             - model_name: instanceValues
               tf_name: instance_values
-              type: String
+              type: Map:String
+              ndfc_type: customMap
               optional: false
               computed: true
               description: Instance values

--- a/internal/provider/datasources/datasource_networks/datasource_codec_gen.go
+++ b/internal/provider/datasources/datasource_networks/datasource_codec_gen.go
@@ -46,19 +46,19 @@ type NDFCNetworksValue struct {
 type NDFCAttachmentsValues []NDFCAttachmentsValue
 
 type NDFCAttachmentsValue struct {
-	SerialNumber   string       `json:"serialNumber,omitempty"`
-	SwitchSerialNo string       `json:"switchSerialNo,omitempty"`
-	SwitchName     string       `json:"switchName,omitempty"`
-	DisplayName    string       `json:"displayName,omitempty"`
-	Vlan           *Int64Custom `json:"vlan,omitempty"`
-	VlanId         *Int64Custom `json:"vlanId,omitempty"`
-	AttachState    string       `json:"lanAttachState,omitempty"`
-	Attached       *bool        `json:"isLanAttached,omitempty"`
-	FreeformConfig string       `json:"freeformconfig,omitempty"`
-	SwitchPorts    CSVString    `json:"switchPorts,omitempty"`
-	PortNames      string       `json:"portNames,omitempty"`
-	TorPorts       CSVString    `json:"torPorts,omitempty"`
-	InstanceValues string       `json:"instanceValues,omitempty"`
+	SerialNumber   string          `json:"serialNumber,omitempty"`
+	SwitchSerialNo string          `json:"switchSerialNo,omitempty"`
+	SwitchName     string          `json:"switchName,omitempty"`
+	DisplayName    string          `json:"displayName,omitempty"`
+	Vlan           *Int64Custom    `json:"vlan,omitempty"`
+	VlanId         *Int64Custom    `json:"vlanId,omitempty"`
+	AttachState    string          `json:"lanAttachState,omitempty"`
+	Attached       *bool           `json:"isLanAttached,omitempty"`
+	FreeformConfig string          `json:"freeformconfig,omitempty"`
+	SwitchPorts    CSVString       `json:"switchPorts,omitempty"`
+	PortNames      string          `json:"portNames,omitempty"`
+	TorPorts       CSVString       `json:"torPorts,omitempty"`
+	InstanceValues CustomMapString `json:"instanceValues,omitempty"`
 }
 
 type NDFCNetworkTemplateConfigValue struct {
@@ -522,10 +522,20 @@ func (v *AttachmentsValue) SetValue(jsonData *NDFCAttachmentsValue) diag.Diagnos
 			return err
 		}
 	}
-	if jsonData.InstanceValues != "" {
-		v.InstanceValues = types.StringValue(jsonData.InstanceValues)
+
+	if len(jsonData.InstanceValues) == 0 {
+		log.Printf("v.InstanceValues is empty")
+		v.InstanceValues = types.MapNull(types.StringType)
 	} else {
-		v.InstanceValues = types.StringNull()
+		mapData := make(map[string]attr.Value)
+		for key, item := range jsonData.InstanceValues {
+			mapData[key] = types.StringValue(item)
+		}
+		v.InstanceValues, err = types.MapValue(types.StringType, mapData)
+		if err != nil {
+			log.Printf("Error in converting map[string]string to  Map")
+			return err
+		}
 	}
 
 	return err

--- a/internal/provider/datasources/datasource_networks/networks_data_source_gen.go
+++ b/internal/provider/datasources/datasource_networks/networks_data_source_gen.go
@@ -54,7 +54,8 @@ func NetworksDataSourceSchema(ctx context.Context) schema.Schema {
 										Description:         "This field covers any configuration not included in overlay templates which is needed as part of this VRF attachment",
 										MarkdownDescription: "This field covers any configuration not included in overlay templates which is needed as part of this VRF attachment",
 									},
-									"instance_values": schema.StringAttribute{
+									"instance_values": schema.MapAttribute{
+										ElementType:         types.StringType,
 										Computed:            true,
 										Description:         "Instance values",
 										MarkdownDescription: "Instance values",
@@ -2612,12 +2613,12 @@ func (t AttachmentsType) ValueFromObject(ctx context.Context, in basetypes.Objec
 		return nil, diags
 	}
 
-	instanceValuesVal, ok := instanceValuesAttribute.(basetypes.StringValue)
+	instanceValuesVal, ok := instanceValuesAttribute.(basetypes.MapValue)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`instance_values expected to be basetypes.StringValue, was: %T`, instanceValuesAttribute))
+			fmt.Sprintf(`instance_values expected to be basetypes.MapValue, was: %T`, instanceValuesAttribute))
 	}
 
 	serialNumberAttribute, ok := attributes["serial_number"]
@@ -2874,12 +2875,12 @@ func NewAttachmentsValue(attributeTypes map[string]attr.Type, attributes map[str
 		return NewAttachmentsValueUnknown(), diags
 	}
 
-	instanceValuesVal, ok := instanceValuesAttribute.(basetypes.StringValue)
+	instanceValuesVal, ok := instanceValuesAttribute.(basetypes.MapValue)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`instance_values expected to be basetypes.StringValue, was: %T`, instanceValuesAttribute))
+			fmt.Sprintf(`instance_values expected to be basetypes.MapValue, was: %T`, instanceValuesAttribute))
 	}
 
 	serialNumberAttribute, ok := attributes["serial_number"]
@@ -3063,7 +3064,7 @@ type AttachmentsValue struct {
 	Attached       basetypes.BoolValue   `tfsdk:"attached"`
 	DisplayName    basetypes.StringValue `tfsdk:"display_name"`
 	FreeformConfig basetypes.StringValue `tfsdk:"freeform_config"`
-	InstanceValues basetypes.StringValue `tfsdk:"instance_values"`
+	InstanceValues basetypes.MapValue    `tfsdk:"instance_values"`
 	SerialNumber   basetypes.StringValue `tfsdk:"serial_number"`
 	SwitchName     basetypes.StringValue `tfsdk:"switch_name"`
 	SwitchPorts    basetypes.SetValue    `tfsdk:"switch_ports"`
@@ -3082,7 +3083,9 @@ func (v AttachmentsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 	attrTypes["attached"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["display_name"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["freeform_config"] = basetypes.StringType{}.TerraformType(ctx)
-	attrTypes["instance_values"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["instance_values"] = basetypes.MapType{
+		ElemType: types.StringType,
+	}.TerraformType(ctx)
 	attrTypes["serial_number"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["switch_name"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["switch_ports"] = basetypes.SetType{
@@ -3208,6 +3211,39 @@ func (v AttachmentsValue) String() string {
 func (v AttachmentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	var instanceValuesVal basetypes.MapValue
+	switch {
+	case v.InstanceValues.IsUnknown():
+		instanceValuesVal = types.MapUnknown(types.StringType)
+	case v.InstanceValues.IsNull():
+		instanceValuesVal = types.MapNull(types.StringType)
+	default:
+		var d diag.Diagnostics
+		instanceValuesVal, d = types.MapValue(types.StringType, v.InstanceValues.Elements())
+		diags.Append(d...)
+	}
+
+	if diags.HasError() {
+		return types.ObjectUnknown(map[string]attr.Type{
+			"attach_state":    basetypes.StringType{},
+			"attached":        basetypes.BoolType{},
+			"display_name":    basetypes.StringType{},
+			"freeform_config": basetypes.StringType{},
+			"instance_values": basetypes.MapType{
+				ElemType: types.StringType,
+			},
+			"serial_number": basetypes.StringType{},
+			"switch_name":   basetypes.StringType{},
+			"switch_ports": basetypes.SetType{
+				ElemType: types.StringType,
+			},
+			"tor_ports": basetypes.SetType{
+				ElemType: types.StringType,
+			},
+			"vlan": basetypes.Int64Type{},
+		}), diags
+	}
+
 	var switchPortsVal basetypes.SetValue
 	switch {
 	case v.SwitchPorts.IsUnknown():
@@ -3226,9 +3262,11 @@ func (v AttachmentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 			"attached":        basetypes.BoolType{},
 			"display_name":    basetypes.StringType{},
 			"freeform_config": basetypes.StringType{},
-			"instance_values": basetypes.StringType{},
-			"serial_number":   basetypes.StringType{},
-			"switch_name":     basetypes.StringType{},
+			"instance_values": basetypes.MapType{
+				ElemType: types.StringType,
+			},
+			"serial_number": basetypes.StringType{},
+			"switch_name":   basetypes.StringType{},
 			"switch_ports": basetypes.SetType{
 				ElemType: types.StringType,
 			},
@@ -3257,9 +3295,11 @@ func (v AttachmentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 			"attached":        basetypes.BoolType{},
 			"display_name":    basetypes.StringType{},
 			"freeform_config": basetypes.StringType{},
-			"instance_values": basetypes.StringType{},
-			"serial_number":   basetypes.StringType{},
-			"switch_name":     basetypes.StringType{},
+			"instance_values": basetypes.MapType{
+				ElemType: types.StringType,
+			},
+			"serial_number": basetypes.StringType{},
+			"switch_name":   basetypes.StringType{},
 			"switch_ports": basetypes.SetType{
 				ElemType: types.StringType,
 			},
@@ -3275,9 +3315,11 @@ func (v AttachmentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 		"attached":        basetypes.BoolType{},
 		"display_name":    basetypes.StringType{},
 		"freeform_config": basetypes.StringType{},
-		"instance_values": basetypes.StringType{},
-		"serial_number":   basetypes.StringType{},
-		"switch_name":     basetypes.StringType{},
+		"instance_values": basetypes.MapType{
+			ElemType: types.StringType,
+		},
+		"serial_number": basetypes.StringType{},
+		"switch_name":   basetypes.StringType{},
 		"switch_ports": basetypes.SetType{
 			ElemType: types.StringType,
 		},
@@ -3302,7 +3344,7 @@ func (v AttachmentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 			"attached":        v.Attached,
 			"display_name":    v.DisplayName,
 			"freeform_config": v.FreeformConfig,
-			"instance_values": v.InstanceValues,
+			"instance_values": instanceValuesVal,
 			"serial_number":   v.SerialNumber,
 			"switch_name":     v.SwitchName,
 			"switch_ports":    switchPortsVal,
@@ -3385,9 +3427,11 @@ func (v AttachmentsValue) AttributeTypes(ctx context.Context) map[string]attr.Ty
 		"attached":        basetypes.BoolType{},
 		"display_name":    basetypes.StringType{},
 		"freeform_config": basetypes.StringType{},
-		"instance_values": basetypes.StringType{},
-		"serial_number":   basetypes.StringType{},
-		"switch_name":     basetypes.StringType{},
+		"instance_values": basetypes.MapType{
+			ElemType: types.StringType,
+		},
+		"serial_number": basetypes.StringType{},
+		"switch_name":   basetypes.StringType{},
 		"switch_ports": basetypes.SetType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/ndfc/network_attachments.go
+++ b/internal/provider/ndfc/network_attachments.go
@@ -28,7 +28,6 @@ func (c *NDFC) RscGetNetworkAttachments(ctx context.Context, nw *resource_networ
 		tflog.Error(ctx, "RscGetNetworkAttachments: Error getting network attachments", map[string]interface{}{"Err": err})
 		return err
 	}
-	c.createVpcPairMap(ctx, nw.FabricName)
 	nw.FillAttachmentsFromPayload(nwAttachPayload)
 
 	for netName, nwEntry := range nw.Networks {

--- a/internal/provider/resources/resource_network_attachments/resource_codec_gen.go
+++ b/internal/provider/resources/resource_network_attachments/resource_codec_gen.go
@@ -24,25 +24,25 @@ type NDFCNetworkAttachmentsValue struct {
 }
 
 type NDFCAttachmentsValue struct {
-	FilterThisValue      bool         `json:"-"`
-	Id                   *int64       `json:"-"`
-	FabricName           string       `json:"fabric,omitempty"`
-	NetworkName          string       `json:"networkName,omitempty"`
-	SerialNumber         string       `json:"serialNumber,omitempty"`
-	SwitchSerialNo       string       `json:"switchSerialNo,omitempty"`
-	SwitchName           string       `json:"switchName,omitempty"`
-	DisplayName          string       `json:"displayName,omitempty"`
-	Vlan                 *Int64Custom `json:"vlan,omitempty"`
-	VlanId               *Int64Custom `json:"vlanId,omitempty"`
-	Deployment           string       `json:"deployment,omitempty"`
-	AttachState          string       `json:"lanAttachState,omitempty"`
-	Attached             *bool        `json:"isLanAttached,omitempty"`
-	FreeformConfig       string       `json:"freeformconfig,omitempty"`
-	DeployThisAttachment bool         `json:"-"`
-	SwitchPorts          CSVString    `json:"switchPorts,omitempty"`
-	DetachSwitchPorts    CSVString    `json:"detachSwitchPorts,omitempty"`
-	PortNames            string       `json:"portNames,omitempty"`
-	TorPorts             CSVString    `json:"torPorts,omitempty"`
-	InstanceValues       string       `json:"instanceValues,omitempty"`
-	UpdateAction         uint16       `json:"-"`
+	FilterThisValue      bool            `json:"-"`
+	Id                   *int64          `json:"-"`
+	FabricName           string          `json:"fabric,omitempty"`
+	NetworkName          string          `json:"networkName,omitempty"`
+	SerialNumber         string          `json:"serialNumber,omitempty"`
+	SwitchSerialNo       string          `json:"switchSerialNo,omitempty"`
+	SwitchName           string          `json:"switchName,omitempty"`
+	DisplayName          string          `json:"displayName,omitempty"`
+	Vlan                 *Int64Custom    `json:"vlan,omitempty"`
+	VlanId               *Int64Custom    `json:"vlanId,omitempty"`
+	Deployment           string          `json:"deployment,omitempty"`
+	AttachState          string          `json:"lanAttachState,omitempty"`
+	Attached             *bool           `json:"isLanAttached,omitempty"`
+	FreeformConfig       string          `json:"freeformconfig,omitempty"`
+	DeployThisAttachment bool            `json:"-"`
+	SwitchPorts          CSVString       `json:"switchPorts,omitempty"`
+	DetachSwitchPorts    CSVString       `json:"detachSwitchPorts,omitempty"`
+	PortNames            string          `json:"portNames,omitempty"`
+	TorPorts             CSVString       `json:"torPorts,omitempty"`
+	InstanceValues       CustomMapString `json:"instanceValues,omitempty"`
+	UpdateAction         uint16          `json:"-"`
 }

--- a/internal/provider/resources/resource_network_attachments/resource_compare_gen.go
+++ b/internal/provider/resources/resource_network_attachments/resource_compare_gen.go
@@ -66,10 +66,6 @@ func (v NDFCAttachmentsValue) DeepEqual(c NDFCAttachmentsValue) int {
 			return PortListUpdate
 		}
 	}
-	if v.InstanceValues != c.InstanceValues {
-		log.Printf("v.InstanceValues=%v, c.InstanceValues=%v", v.InstanceValues, c.InstanceValues)
-		return RequiresUpdate
-	}
 
 	if cf {
 		return ControlFlagUpdate
@@ -169,19 +165,20 @@ func (v *NDFCAttachmentsValue) CreatePlan(c NDFCAttachmentsValue, cf *bool) int 
 		}
 	}
 
-	if v.InstanceValues != "" {
-
-		if v.InstanceValues != c.InstanceValues {
-			log.Printf("Update: v.InstanceValues=%v, c.InstanceValues=%v", v.InstanceValues, c.InstanceValues)
-			if action == ActionNone || action == RequiresUpdate {
-				action = RequiresUpdate
-			}
+	if len(v.InstanceValues) != len(c.InstanceValues) {
+		log.Printf("Update: len(v.InstanceValues)=%d, len(c.InstanceValues)=%d", len(v.InstanceValues), len(c.InstanceValues))
+		return RequiresUpdate
+	}
+	for kk, vv := range v.InstanceValues {
+		cc, ok := c.InstanceValues[kk]
+		if !ok {
+			log.Printf("Update: v.InstanceValues[%s]=%s, c.InstanceValues[%s]=nil", kk, vv, kk)
+			return RequiresUpdate
 		}
-
-	} else {
-		//v empty, fill with c
-		log.Printf("Copy from state: v.InstanceValues=%v, c.InstanceValues=%v", v.InstanceValues, c.InstanceValues)
-		v.InstanceValues = c.InstanceValues
+		if vv != cc {
+			log.Printf("Update: v.InstanceValues[%s]=%s, c.InstanceValues[%s]=%s", kk, vv, kk, cc)
+			return RequiresUpdate
+		}
 	}
 
 	return action

--- a/internal/provider/test_utils_network_attachments_test.go
+++ b/internal/provider/test_utils_network_attachments_test.go
@@ -56,10 +56,6 @@ func AttachmentsValueHelperStateCheck(RscName string, c resource_network_attachm
 		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("deploy_this_attachment").String(), "false"))
 	}
 
-	if c.InstanceValues != "" {
-		ret = append(ret, resource.TestCheckResourceAttr(RscName, attrPath.AtName("instance_values").String(), c.InstanceValues))
-	}
-
 	return ret
 }
 

--- a/internal/provider/types/custtypes.go
+++ b/internal/provider/types/custtypes.go
@@ -11,6 +11,7 @@
 package types
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 )
@@ -39,7 +40,6 @@ func (i *CSVString) UnmarshalJSON(data []byte) error {
 		ss = ssUn
 	}
 	*i = strings.Split(ss, ",")
-
 	return nil
 }
 
@@ -47,6 +47,41 @@ func (i CSVString) MarshalJSON() ([]byte, error) {
 	res := ""
 	res = strings.Join(i, ",")
 	return []byte(strconv.Quote(res)), nil
+
+}
+
+type CustomMapString map[string]string
+
+func (i *CustomMapString) UnmarshalJSON(data []byte) error {
+	if string(data) == "" || string(data) == "\"\"" {
+		*i = make(CustomMapString, 0)
+		return nil
+	}
+	ss := string(data)
+	ssUn, err := strconv.Unquote(ss)
+	if err == nil {
+		// Quote removed
+		ss = ssUn
+	}
+	// If that fails, try to unmarshal directly as a map
+	var m map[string]string
+	if err := json.Unmarshal([]byte(ss), &m); err != nil {
+		return err
+	}
+	*i = m
+
+	return nil
+}
+
+func (i CustomMapString) MarshalJSON() ([]byte, error) {
+	if i == nil {
+		return []byte("\"\""), nil
+	}
+	b, err := json.Marshal(map[string]string(i))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(strconv.Quote(string(b))), nil
 
 }
 


### PR DESCRIPTION
Changing instance_values to map string to handle key-value pairs in shuffled payload.